### PR TITLE
Fix homepage research link 404

### DIFF
--- a/sites/oceanheart/layouts/index.html
+++ b/sites/oceanheart/layouts/index.html
@@ -10,7 +10,7 @@
   <div class="hero-links">
     <a href="/blog/">writing</a>
     <span>/</span>
-    <a href="/research/">research</a>
+    <span class="inactive-link">research</span>
     <span>/</span>
     <a href="/about/">about</a>
   </div>

--- a/sites/oceanheart/static/css/terminal.css
+++ b/sites/oceanheart/static/css/terminal.css
@@ -214,6 +214,12 @@ nav .container {
   color: var(--muted);
 }
 
+.hero-links .inactive-link {
+  color: var(--cyan);
+  opacity: 0.35;
+  cursor: default;
+}
+
 /* Section headers */
 .section-header {
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary

The /research/ link on the oceanheart.ai homepage returns a 404 because the research section index has `draft: true` in its frontmatter. Hugo does not render draft pages in production.

## Fix

Replace the `<a href="/research/">` with a `<span class="inactive-link">` that retains the link styling but at 35% opacity and no click behavior. The research link will be reactivated when the content is published.

## What was tested

- Hugo build green on main
- CSS change is additive (new class only)
- HTML change is a single element swap

**Complexity:** low | **Risk:** low

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deactivate the homepage “research” link to prevent 404s while the section remains draft. It now renders as a non-clickable label with the `inactive-link` style at 35% opacity and will be re-enabled when content is published.

<sup>Written for commit e27dc01d34a3da0591c1be412f813c406eedf23e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

