### PR TITLE
chore: update repo links after rename thepit-cloud -> thepit

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ This repository consolidates three development phases via subtree merge, preserv
 
 The agentic infrastructure (adversarial review pipeline, anti-pattern detection, session governance) lives in `docs/internal/` and supporting tooling. The interesting finding: sycophantic drift - agents performing honesty while being dishonest about their confidence - is harder to catch than hallucination, because it passes every surface-level check.
 
+The pilot study (Phase 1-2) has its own repo with [420 PRs of engineering history](https://github.com/rickhallett/thepit-pilot/pulls?q=is%3Apr+is%3Amerged) - review descriptions, adversarial review findings, and the full decision chain.
+
 ## License
 
 Private. All rights reserved.

--- a/sites/oceanheart/content/about.md
+++ b/sites/oceanheart/content/about.md
@@ -10,7 +10,7 @@ The psychology turns out to be load-bearing. It directly produced the operator t
 
 ## What I'm building
 
-**[The Pit](https://thepit.cloud)** - a full-stack evaluation platform where AI models compete in structured debate formats, backed by a credit economy and real-time scoring. Built in Next.js, TypeScript, Python, and Go with 1,200+ tests and a [public repo](https://github.com/rickhallett/thepit-cloud). Underneath the product is an agentic engineering layer: 11 specialised agents governed by integration discipline, multi-model adversarial code review, cryptographically attested commits, and operator fatigue monitoring. I govern the process by which their output becomes trustworthy.
+**[The Pit](https://thepit.cloud)** - a full-stack evaluation platform where AI models compete in structured debate formats, backed by a credit economy and real-time scoring. Built in Next.js, TypeScript, Python, and Go with 1,200+ tests and a [public repo](https://github.com/rickhallett/thepit). Underneath the product is an agentic engineering layer: 11 specialised agents governed by integration discipline, multi-model adversarial code review, cryptographically attested commits, and operator fatigue monitoring. I govern the process by which their output becomes trustworthy.
 
 **[The Agentic Engineering Bootcamp](/bootcamp/)** - 51 steps across 5 bootcamps. Self-study material I wrote for myself and am publishing because it might be useful to others. Covers Linux substrate, agentic practices, operational analytics, evaluation/adversarial testing, and agent infrastructure. The material came directly out of the practical problems I hit building The Pit.
 

--- a/sites/oceanheart/layouts/_default/cv.html
+++ b/sites/oceanheart/layouts/_default/cv.html
@@ -41,7 +41,7 @@ Gauntlet: gate+claude+openai+pitkeel+walkthrough @ 0ef104b0 [full]</code></pre>
 
   <div class="cv-section">
     <h2 style="color: var(--cyan);">What I built</h2>
-    <p class="cv-section-note">Everything below is auditable in the <a href="https://github.com/rickhallett/thepit-cloud">public repo</a>. The git log is the proof.</p>
+    <p class="cv-section-note">Everything below is auditable in the <a href="https://github.com/rickhallett/thepit">public repo</a>. The git log is the proof.</p>
 
     <div class="cv-artifact">
       <div class="cv-artifact-name">Deterministic build orchestration</div>
@@ -76,7 +76,7 @@ Gauntlet: gate+claude+openai+pitkeel+walkthrough @ 0ef104b0 [full]</code></pre>
       <span class="period">2024-present</span>
       <div class="role">Senior Software Engineer</div>
       <div class="org">Oceanheart.ai</div>
-      <div class="desc">Building The Pit - a full-stack evaluation platform (Next.js, TypeScript, Python, Go). Shipping features against a public roadmap with CI/CD, adversarial code review, and 1,200+ tests. Solo developer mirroring full team practices: PRs, issue tracking, milestones, structured deployment. The <a href="https://github.com/rickhallett/thepit-cloud">repo is public</a>.</div>
+      <div class="desc">Building The Pit - a full-stack evaluation platform (Next.js, TypeScript, Python, Go). Shipping features against a public roadmap with CI/CD, adversarial code review, and 1,200+ tests. Solo developer mirroring full team practices: PRs, issue tracking, milestones, structured deployment. The <a href="https://github.com/rickhallett/thepit">repo is public</a>.</div>
     </div>
 
     <div class="cv-entry">


### PR DESCRIPTION
## Summary

Updates live site references from `thepit-cloud` to `thepit` after the repo rename. Adds pilot study link to README.

## Changes

- `sites/oceanheart/layouts/_default/cv.html`: 2 repo links updated (What I built section + Oceanheart.ai job entry)
- `sites/oceanheart/content/about.md`: 1 repo link updated (What I'm building section)
- `README.md`: added pilot study paragraph with link to 420 merged PRs in thepit-pilot

## Not changed

- `docs/decisions/MIGRATION-001.md` (11 refs) - historical record, immutable per SD-266
- `docs/decisions/oceanheart-reframe-plan.md` (3 refs) - historical record, immutable per SD-266

## Testing

- Verified zero `thepit-cloud` references remain in `sites/oceanheart/`
- HTML/markdown only, no build path impact

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update public references from `thepit-cloud` to `thepit` after the repo rename, and add a pilot study link in the README. Decision records stay unchanged as historical artifacts.

<sup>Written for commit 895c08ae79bbcdd2d949b19481a49bbeb68fdd84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

