### PR TITLE
fix(docs): correct structural inaccuracies in AGENTS.md and README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,11 +214,10 @@ A repeatable governance unit. Calibrate instruments before changing heading.
 
 **Checks:**
 
-- **spec drift:** search SPEC.md against implementation, note divergence
-- **eval validity:** read EVAL.md - criteria still reachable? amendments needed?
-- **plan accuracy:** read PLAN.md - completed table current? dependencies still valid?
 - **gate health:** run the gate - all tests pass? no regressions?
 - **backlog sync:** read backlog.yaml - items still relevant? priorities correct?
+- **issue sync:** check open GitHub issues against milestones - priorities current?
+- **doc accuracy:** spot-check AGENTS.md filesystem map and conventions against reality
 
 **Output:** findings per check - note drift, fix if small, backlog if large.
 
@@ -230,11 +229,11 @@ Cost is roughly 15 agent-minutes. Drift cost is always higher than check cost. C
 
 How work flows through the system at the Operator's level. Each phase boundary triggers a bearing check.
 
-1. **BEARING CHECK** - spec inline? plan current? eval valid? gate green? Fix drift or note findings.
-2. **SCOPE** - identify next phase from PLAN.md, decompose into PRs (1 PR = 1 concern), write spec/plan to docs/decisions/.
+1. **BEARING CHECK** - gate green? backlog current? issues aligned? Fix drift or note findings.
+2. **SCOPE** - identify next milestone from GitHub issues, decompose into PRs (1 PR = 1 concern), write decisions to docs/decisions/.
 3. **DISPATCH** - prime context (plan file + deps) to agent. Agent implements, gate verifies. Use polecats (fresh context, no interactive steering).
 4. **REVIEW** - Weaver reviews PR (reviewer != author). Darkcat adversarial review. Findings resolved before merge.
-5. **MERGE + POST-VERIFY** - run gate on merge target; failure means investigate immediately. Stain diff against watchdog taxonomy. Update PLAN.md completed table.
+5. **MERGE + POST-VERIFY** - run gate on merge target; failure means investigate immediately. Stain diff against watchdog taxonomy. Close issue if scope complete.
 6. **ADVANCE or LOOP** - phase complete? bearing check then next phase. Phase incomplete? next PR in same phase.
 
 **Cadence:** bearing check -> scope -> (dispatch -> review -> merge)* -> advance
@@ -424,7 +423,7 @@ Full verbose model: `docs/internal/layer-model.md`
 
 ## Slopodar - Anti-Pattern Taxonomy (Compressed)
 
-Full taxonomy: `docs/internal/slopodar.yaml` (21 entries, mandatory reading [SD-286]).
+Full taxonomy: `docs/internal/slopodar.yaml` (49 entries, mandatory reading [SD-286]).
 These are the named patterns caught in the wild. If you recognise them in your output, stop.
 
 **Prose patterns** (detectable by discerning reader):
@@ -625,14 +624,11 @@ You cannot reliably self-detect slop because the same token-prediction mechanism
 / (repo root)
 ├── AGENTS.md                       -- THIS FILE (auto-loaded, canonical)
 ├── CLAUDE.md                       -- Symlink -> AGENTS.md (harness compat)
-├── SPEC.md                         -- Product spec, 12 tables, API contracts
-├── EVAL.md                         -- Success/failure criteria, confounds
 ├── Makefile                        -- 26 polecat tasks (deterministic build)
-├── .claude/agents/*.md             -- Agent identity files (auto-loaded per agent)
-├── .opencode/agents/*.md           -- Symlinks -> .claude/agents/ (prevent drift)
-├── lib/                            -- Source code
-│   ├── {bouts,credits,auth,engagement,stripe,sharing,agents,common}/
-│   │   └── DOMAIN.md              -- Architectural boundaries per domain
+├── .claude/agents/*.md             -- Symlinks -> .opencode/agents/ (harness compat)
+├── .opencode/agents/*.md           -- Agent identity files (canonical copies)
+├── lib/                            -- Source code (flat files, no subdirectories)
+├── tests/                          -- Unit, integration, API tests
 ├── docs/                           -- D1-D3 documentation
 │   ├── decisions/SD-*.md           -- Session-scoped decisions
 │   ├── weaver/                     -- Signal PoC, decode tests, reasoning tests
@@ -643,8 +639,8 @@ You cannot reliably self-detect slop because the same token-prediction mechanism
 │   └── internal/                   -- Operational (verbose versions, full chain)
 │       ├── lexicon.md              -- Full verbose lexicon v0.20
 │       ├── layer-model.md          -- Full verbose layer model v0.3
-│       ├── slopodar.yaml           -- Full anti-pattern taxonomy (18 entries)
-│       ├── session-decisions.md    -- FULL chain SD-001–SD-314 (archaeology only)
+│       ├── slopodar.yaml           -- Full anti-pattern taxonomy (49 entries)
+│       ├── session-decisions.md    -- Chain SD-031-SD-036 (this repo; pilot chain in thepit-pilot)
 │       ├── session-decisions-index.yaml  -- Last 10 SDs + standing orders
 │       ├── boot-sequence.md        -- Legacy boot manifest (superseded by this file)
 │       ├── dead-reckoning.md       -- Blowout recovery protocol
@@ -737,10 +733,9 @@ From commit 0:
 
 ## Conventions
 
-- TypeScript, Next.js 15, Tailwind, Drizzle ORM, Neon Postgres (prod: `snowy-river-644*****`, branch `noopit-dev` for local dev)
-- Co-located tests: `*.test.ts` beside the module they test
-- One domain = one directory = one agent context boundary [SD-304]
-- DOMAIN.md for architectural boundaries, JSDoc for behaviour, header comment for purpose
+- TypeScript, Next.js 16, Tailwind, Drizzle ORM, Neon Postgres (prod: `snowy-river-644*****`, branch `noopit-dev` for local dev)
+- Tests in `tests/` directory (unit, integration, API subdirs)
+- JSDoc for behaviour, header comment for purpose
 - YAML for structured data [SD-258]
 - `uv` for all Python, no exceptions [SD-310]
 - 2 spaces indentation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pnpm run dev            # http://localhost:3000
 ## Stack
 
 - **Runtime:** Next.js 16, TypeScript (strict), React 19
-- **Database:** Neon Postgres, Drizzle ORM (12 tables, 241-line schema)
+- **Database:** Neon Postgres, Drizzle ORM (22 tables)
 - **Auth:** Clerk (SSO, role-based access)
 - **Payments:** Stripe (subscriptions, credit purchases, webhooks)
 - **AI:** Vercel AI SDK (multi-provider: OpenAI, Anthropic, Google, xAI)
@@ -32,7 +32,7 @@ pnpm run dev            # http://localhost:3000
 
 ```
 app/                    Next.js 16 app router (30+ routes)
-lib/                    Domain modules (bouts, credits, auth, agents, sharing, engagement, stripe)
+lib/                    Domain modules (flat files: credits.ts, bout-engine.ts, auth, agents, etc.)
   lib/api-utils.ts      Standardised API response/error handling
   lib/ai.ts             Multi-provider AI SDK configuration
 drizzle/                Schema, migrations
@@ -47,7 +47,7 @@ pitlinear/              Go - linear workflow automation
 pitkeel/                Go - developer telemetry and session tracking
 ```
 
-Each domain in `lib/` has a `DOMAIN.md` describing its boundaries and contracts. Tests are co-located: `module.test.ts` beside `module.ts`.
+Tests live in `tests/` with subdirectories for unit, integration, API, E2E, and simulation tests.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Fixes issue #20. AGENTS.md and README.md contained stale claims inherited from the pilot study repo that no longer match the actual filesystem.

## What changed

**AGENTS.md (11 edits):**
- Removed SPEC.md, EVAL.md references from filesystem map (files do not exist)
- Removed PLAN.md references from bearing check and macro workflow sections
- Fixed symlink direction: `.claude/agents/` symlinks TO `.opencode/agents/`, not reverse
- Fixed `lib/` description: flat files, no subdirectories, no DOMAIN.md
- Added `tests/` to filesystem map
- Fixed slopodar entry count: 49 entries, not 21/18
- Fixed session-decisions range: SD-031-SD-036 (this repo), not SD-001-SD-314 (pilot)
- Fixed Next.js version: 16 (actual), not 15 (stale)
- Replaced co-located tests convention with `tests/` directory convention
- Removed DOMAIN.md convention (files do not exist)
- Rewrote bearing check and macro workflow to reference GitHub issues instead of nonexistent plan files

**README.md (3 edits):**
- Fixed DB table count: 22 tables, not "12 tables, 241-line schema"
- Fixed `lib/` description: flat files, not subdirectory structure
- Fixed tests description: `tests/` directory, not co-located

## Verification

Every claim was verified against the actual filesystem before editing:
- `ls SPEC.md EVAL.md PLAN.md` - all missing
- `ls lib/` - flat files confirmed
- `file .opencode/agents/weaver.md` vs `file .claude/agents/weaver.md` - symlink direction confirmed
- `cat package.json | grep next` - 16.1.6 confirmed
- `rg "id:" docs/internal/slopodar.yaml | wc -l` - 49 entries confirmed
- `rg "^### SD-" docs/internal/session-decisions.md` - SD-031 through SD-036 confirmed

Gate: docs-only change (no code changes)
Closes #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects outdated details in AGENTS.md and README.md to match the current repo. Removes nonexistent docs, fixes symlink direction, updates `Next.js` and data counts, and aligns testing/docs conventions.

- **Bug Fixes**
  - Removed references to `SPEC.md`, `EVAL.md`, `PLAN.md`.
  - Fixed symlink direction: `.claude/agents/` -> `.opencode/agents/`.
  - Updated filesystem map: flat `lib/`; added `tests/`; removed `DOMAIN.md`/co-located tests.
  - Corrected versions/counts: `Next.js` 16; slopodar 49; session decisions SD-031–SD-036; DB tables 22.
  - Rewrote bearing check and workflow to use GitHub issues and milestones.

<sup>Written for commit b56a2b7ccfc9260f88f295a6d79cddab388ea021. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance and workflow processes in project documentation.
  * Expanded anti-pattern taxonomy entries for better guidance.
  * Updated project architecture documentation with new stack components.

* **Chores**
  * Reorganized tests into dedicated directory structure with unit, integration, and API tests.
  * Expanded database schema to 22 tables.
  * Updated TypeScript version to 16 and related tooling configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->