### PR TITLE
fix(oceanheart): fix live 404 links and delete orphan slopodar stubs

### DIFF
--- a/sites/oceanheart/content/blog/2026-03-01-paper-guardrail.md
+++ b/sites/oceanheart/content/blog/2026-03-01-paper-guardrail.md
@@ -56,6 +56,6 @@ ${latest.map(sd => `  - id: SD-${sd.id}
 writeFileSync(INDEX_FILE, yaml);
 ```
 
-[Source](https://github.com/rickhallett/thepit/blob/wake/bin/sd-index.js)[^1]
+[Source](https://github.com/rickhallett/thepit-pilot/blob/wake/bin/sd-index.js)[^1]
 
-[^1]: [Paper Guardrail](https://github.com/rickhallett/thepit/blob/wake/slopodar.yaml#L201) — "The LLM creates a rule, then in the same breath asserts that the rule will prevent the failure it was designed for. The assertion has no enforcement mechanism." ([oceanheart.ai/slopodar/paper-guardrail](https://oceanheart.ai/slopodar/paper-guardrail/))
+[^1]: [Paper Guardrail](https://github.com/rickhallett/thepit-pilot/blob/wake/slopodar.yaml#L201) — "The LLM creates a rule, then in the same breath asserts that the rule will prevent the failure it was designed for. The assertion has no enforcement mechanism." ([oceanheart.ai/slopodar/paper-guardrail](https://oceanheart.ai/slopodar/paper-guardrail/))

--- a/sites/oceanheart/content/blog/2026-03-01-slopiculture.md
+++ b/sites/oceanheart/content/blog/2026-03-01-slopiculture.md
@@ -78,7 +78,7 @@ Claude selected the features. Claude computed the effect sizes. Claude designed 
 
 The extension has 3 commits and the taxonomy has 15 entries. The entries turned out to be worth more than the extension.
 
-[Slopodar](https://oceanheart.ai/slopodar/) | [Source](https://github.com/rickhallett/thepit/blob/wake/slopodar.yaml)
+[Slopodar](https://oceanheart.ai/slopodar/) | [Source](https://github.com/rickhallett/thepit-pilot/blob/wake/slopodar.yaml)
 
 [^1]: [Redundant Antithesis](https://oceanheart.ai/slopodar/redundant-antithesis/) — slopodar catching slopodar on its own page.
 [^2]: [Right Answer, Wrong Work](https://oceanheart.ai/slopodar/right-answer-wrong-work/) — the first slopodar entry to cross the prose/code boundary.

--- a/sites/oceanheart/content/blog/2026-03-01-the-elephant.md
+++ b/sites/oceanheart/content/blog/2026-03-01-the-elephant.md
@@ -41,6 +41,6 @@ tag boot files
 
 5 agent-minutes to build. 3 seconds to run. The fix (stop loading all 271 historical decisions on every wake) drops 30k tokens from the boot sequence.[^1]
 
-[Provenance](https://github.com/rickhallett/thepit/blob/wake/docs/internal/weaver/token-heatmap.yaml) | [Script](https://github.com/rickhallett/thepit/blob/wake/bin/token-heatmap.js)
+[Provenance](https://github.com/rickhallett/thepit-pilot/blob/wake/docs/internal/weaver/token-heatmap.yaml) | [Script](https://github.com/rickhallett/thepit-pilot/blob/wake/bin/token-heatmap.js)
 
 [^1]: The heaviest directory in the repo is `docs/internal/research/mobprogrammingrpg/` at 1,148,700 tokens. Twelve PDFs. ["We are not doing PDFs."](https://github.com/rickhallett/thepit/blob/7e5675ab89d28d86baf5a47847d53a4e84918efc/docs/internal/anotherpair/log.md#we-are-not-doing-pdfs-2026-03-01)

--- a/sites/oceanheart/content/blog/2026-03-01-trying-to-kill-me.md
+++ b/sites/oceanheart/content/blog/2026-03-01-trying-to-kill-me.md
@@ -70,6 +70,6 @@ fi
 exit 0
 ```
 
-[Source](https://github.com/rickhallett/thepit/blob/wake/scripts/post-commit)
+[Source](https://github.com/rickhallett/thepit-pilot/blob/wake/scripts/post-commit)
 
 Happy hunting, chaps.

--- a/sites/oceanheart/content/slopodar/cost-margin-asymmetry.md
+++ b/sites/oceanheart/content/slopodar/cost-margin-asymmetry.md
@@ -1,5 +1,0 @@
-+++
-title = "Cost-Margin Asymmetry"
-id = "cost-margin-asymmetry"
-type = "slopodar"
-+++

--- a/sites/oceanheart/content/slopodar/edge-file-mitosis.md
+++ b/sites/oceanheart/content/slopodar/edge-file-mitosis.md
@@ -1,5 +1,0 @@
-+++
-title = "Edge-File Mitosis"
-id = "edge-file-mitosis"
-type = "slopodar"
-+++

--- a/sites/oceanheart/content/slopodar/false-spectrum.md
+++ b/sites/oceanheart/content/slopodar/false-spectrum.md
@@ -1,5 +1,0 @@
-+++
-title = "False Spectrum"
-id = "false-spectrum"
-type = "slopodar"
-+++

--- a/sites/oceanheart/content/slopodar/near-miss-double-tap.md
+++ b/sites/oceanheart/content/slopodar/near-miss-double-tap.md
@@ -1,5 +1,0 @@
-+++
-title = "Near-Miss Double-Tap"
-id = "near-miss-double-tap"
-type = "slopodar"
-+++

--- a/sites/oceanheart/content/slopodar/phantom-limb-commit.md
+++ b/sites/oceanheart/content/slopodar/phantom-limb-commit.md
@@ -1,5 +1,0 @@
-+++
-title = "Phantom Limb Commit"
-id = "phantom-limb-commit"
-type = "slopodar"
-+++

--- a/sites/oceanheart/content/slopodar/synonym-braid.md
+++ b/sites/oceanheart/content/slopodar/synonym-braid.md
@@ -1,5 +1,0 @@
-+++
-title = "Synonym Braid"
-id = "synonym-braid"
-type = "slopodar"
-+++

--- a/sites/oceanheart/layouts/_default/sloptics.html
+++ b/sites/oceanheart/layouts/_default/sloptics.html
@@ -134,7 +134,7 @@
   <section style="margin-bottom: 3rem;">
     <h2 style="margin-top: 0;">calibration note</h2>
     <p>
-      A <a href="https://github.com/rickhallett/thepit/tree/wake/slopodar-ext">chrome extension</a> was built to run these detectors on any web page. Calibrating it against 46 pages of known-human and known-AI text revealed something the detectors themselves couldn't: the structural rhetoric patterns (epigram, isocolon, anadiplosis, antithesis) measure <em>writing quality</em>, not writing origin. Good human writers trigger them as much or more than AI. What actually discriminates is voice — contractions, first-person pronouns, questions, and the absence of formal transition words. The tool was renamed accordingly. It previously called itself an "LLM slop detector." It contained more slop than science.
+      A <a href="https://github.com/rickhallett/thepit-pilot/tree/wake/slopodar-ext">chrome extension</a> was built to run these detectors on any web page. Calibrating it against 46 pages of known-human and known-AI text revealed something the detectors themselves couldn't: the structural rhetoric patterns (epigram, isocolon, anadiplosis, antithesis) measure <em>writing quality</em>, not writing origin. Good human writers trigger them as much or more than AI. What actually discriminates is voice — contractions, first-person pronouns, questions, and the absence of formal transition words. The tool was renamed accordingly. It previously called itself an "LLM slop detector." It contained more slop than science.
     </p>
   </section>
 
@@ -250,7 +250,7 @@
 
   <section style="margin-top: 2rem;">
     <p style="color: var(--muted); font-size: 0.8rem;">
-      The slopodar is <a href="https://github.com/rickhallett/thepit/tree/wake/slopodar-ext">available as a chrome extension</a> if you want to try it. At its current version I am not sure it is worth the Google developer fee. People who know enough about sample sizes, false positives, and calibration to use it properly probably don't need a half-baked chrome extension for support. People who don't know those things need a tool reliable enough that they don't need to understand why it's broken. It is not that tool yet.
+      The slopodar is <a href="https://github.com/rickhallett/thepit-pilot/tree/wake/slopodar-ext">available as a chrome extension</a> if you want to try it. At its current version I am not sure it is worth the Google developer fee. People who know enough about sample sizes, false positives, and calibration to use it properly probably don't need a half-baked chrome extension for support. People who don't know those things need a tool reliable enough that they don't need to understand why it's broken. It is not that tool yet.
     </p>
   </section>
 </article>


### PR DESCRIPTION
## Summary

Fixes live 404s on oceanheart.ai caused by `wake` branch references pointing to `thepit` (where `wake` does not exist) instead of `thepit-pilot` (where it does).

## Changes

**Link fixes (5 files, 7 URLs):**
- `sloptics.html` L137, L253: slopodar-ext chrome extension links
- `2026-03-01-trying-to-kill-me.md`: post-commit script link
- `2026-03-01-the-elephant.md`: token-heatmap.yaml and token-heatmap.js links
- `2026-03-01-slopiculture.md`: slopodar.yaml source link
- `2026-03-01-paper-guardrail.md`: sd-index.js and slopodar.yaml#L201 links

All changed from `rickhallett/thepit/blob/wake/` to `rickhallett/thepit-pilot/blob/wake/` (or tree/wake for sloptics).

**Orphan stub deletions (6 files):**
- cost-margin-asymmetry.md, edge-file-mitosis.md, false-spectrum.md
- near-miss-double-tap.md, phantom-limb-commit.md, synonym-braid.md

These had frontmatter only (no YAML data backing) and rendered as blank pages.

## Verification

- `grep -r "thepit/tree/wake\|thepit/blob/wake" sites/oceanheart/` returns zero matches after fix
- Orphan stubs confirmed: each was 6 lines of frontmatter with no content body

Gate: content-only change (no code)
Closes #21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live 404s on oceanheart.ai by updating `wake` branch links to `rickhallett/thepit-pilot` and removing six orphan slopodar stubs. Restores working source links and removes blank pages.

- **Bug Fixes**
  - Updated 7 GitHub links across 5 files to `thepit-pilot/wake` (sloptics.html x2; blog posts: trying-to-kill-me, the-elephant, slopiculture, paper-guardrail).
  - Removed 6 frontmatter-only slopodar pages: cost-margin-asymmetry, edge-file-mitosis, false-spectrum, near-miss-double-tap, phantom-limb-commit, synonym-braid.
  - Verified no remaining `thepit/*/wake` references.

<sup>Written for commit 65bcbbd03664dbe2d4c207b3f9e6863a555e6bf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

