### PR TITLE
fix(oceanheart): correct stale counts and claims across live site

### DIFF
--- a/sites/oceanheart/content/about.md
+++ b/sites/oceanheart/content/about.md
@@ -10,7 +10,7 @@ The psychology turns out to be load-bearing. It directly produced the operator t
 
 ## What I'm building
 
-**[The Pit](https://thepit.cloud)** - a full-stack evaluation platform where AI models compete in structured debate formats, backed by a credit economy and real-time scoring. Built in Next.js, TypeScript, Python, and Go with 1,200+ tests and a [public repo](https://github.com/rickhallett/thepit). Underneath the product is an agentic engineering layer: 11 specialised agents governed by integration discipline, multi-model adversarial code review, cryptographically attested commits, and operator fatigue monitoring. I govern the process by which their output becomes trustworthy.
+**[The Pit](https://thepit.cloud)** - a full-stack evaluation platform where AI models compete in structured debate formats with credit-based access and real-time bout streaming. Built in Next.js, TypeScript, Python, and Go with 1,289 tests and a [public repo](https://github.com/rickhallett/thepit). Underneath the product is an agentic engineering layer: 8 specialised agents governed by integration discipline, multi-model adversarial code review, cryptographically attested commits, and operator fatigue monitoring. I govern the process by which their output becomes trustworthy.
 
 **[The Agentic Engineering Bootcamp](/bootcamp/)** - 51 steps across 5 bootcamps. Self-study material I wrote for myself and am publishing because it might be useful to others. Covers Linux substrate, agentic practices, operational analytics, evaluation/adversarial testing, and agent infrastructure. The material came directly out of the practical problems I hit building The Pit.
 

--- a/sites/oceanheart/content/bootcamp/_index.md
+++ b/sites/oceanheart/content/bootcamp/_index.md
@@ -23,4 +23,4 @@ Total: 51 steps, ~208-259 hours. Not a weekend project - a practitioner's field 
 2. **Return per hour** - how much capability per unit of learning time?
 3. **Irreplaceability** - can an agent compensate for your ignorance, or must you understand it?
 
-Step I.1 is available now as a sample. The rest is in development.
+All 51 steps are written and published.

--- a/sites/oceanheart/layouts/_default/cv.html
+++ b/sites/oceanheart/layouts/_default/cv.html
@@ -50,7 +50,7 @@ Gauntlet: gate+claude+openai+pitkeel+walkthrough @ 0ef104b0 [full]</code></pre>
 
     <div class="cv-artifact">
       <div class="cv-artifact-name">The Gauntlet</div>
-      <div class="desc">Multi-model adversarial review pipeline enforced as a git pre-commit hook. Codex, Gemini, and Grok independently red-team every code change against a structured adversarial prompt - three different model lineages so the review has independent priors, not correlated blind spots. Cryptographic attestations tied to git tree hashes - if the staged content changes after review, the attestation goes stale and the commit is blocked. Code does not enter the branch without surviving cross-model adversarial review and passing deterministic tests.</div>
+      <div class="desc">Multi-model adversarial review pipeline with attestations enforced at commit time via pre-commit hook. Claude, Codex, and Gemini independently red-team every code change against a structured adversarial prompt - three different model lineages so the review has independent priors, not correlated blind spots. Cryptographic attestations tied to git tree hashes - if the staged content changes after review, the attestation goes stale and the commit is blocked. Code does not enter the branch without surviving cross-model adversarial review and passing deterministic tests.</div>
     </div>
 
     <div class="cv-artifact">
@@ -60,7 +60,7 @@ Gauntlet: gate+claude+openai+pitkeel+walkthrough @ 0ef104b0 [full]</code></pre>
 
     <div class="cv-artifact">
       <div class="cv-artifact-name">Slopodar</div>
-      <div class="desc">Field taxonomy of LLM anti-patterns caught in the wild: epistemic theatre, paper guardrails, analytical lullabies, sycophantic drift. 40+ entries, each with detection heuristics, severity grading, and the story of how it was caught. Includes programmatic detectors that run on the <a href="/sloptics/">sloptics page</a> - the page annotates itself.</div>
+      <div class="desc">Field taxonomy of LLM anti-patterns caught in the wild: epistemic theatre, paper guardrails, analytical lullabies, sycophantic drift. 49 entries, each with detection heuristics, severity grading, and the story of how it was caught. Includes programmatic detectors that run on the <a href="/sloptics/">sloptics page</a> - the page annotates itself.</div>
     </div>
 
     <div class="cv-artifact">
@@ -76,7 +76,7 @@ Gauntlet: gate+claude+openai+pitkeel+walkthrough @ 0ef104b0 [full]</code></pre>
       <span class="period">2024-present</span>
       <div class="role">Senior Software Engineer</div>
       <div class="org">Oceanheart.ai</div>
-      <div class="desc">Building The Pit - a full-stack evaluation platform (Next.js, TypeScript, Python, Go). Shipping features against a public roadmap with CI/CD, adversarial code review, and 1,200+ tests. Solo developer mirroring full team practices: PRs, issue tracking, milestones, structured deployment. The <a href="https://github.com/rickhallett/thepit">repo is public</a>.</div>
+      <div class="desc">Building The Pit - a full-stack evaluation platform (Next.js, TypeScript, Python, Go). Shipping features against a public roadmap with CI/CD, adversarial code review, and 1,289 tests. Solo developer mirroring full team practices: PRs, issue tracking, milestones, structured deployment. The <a href="https://github.com/rickhallett/thepit">repo is public</a>.</div>
     </div>
 
     <div class="cv-entry">
@@ -156,7 +156,7 @@ Gauntlet: gate+claude+openai+pitkeel+walkthrough @ 0ef104b0 [full]</code></pre>
     <div class="cv-tech-group">
       <span class="cv-tech-label">Testing & quality</span>
       <div class="tech-tags">
-        {{ range (slice "Vitest" "Playwright" "Integration testing" "Adversarial code review" "1,200+ test suite") }}
+        {{ range (slice "Vitest" "Playwright" "Integration testing" "Adversarial code review" "1,289 test suite") }}
         <span class="tech-tag">{{ . }}</span>
         {{ end }}
       </div>

--- a/sites/oceanheart/layouts/_default/sloptics.html
+++ b/sites/oceanheart/layouts/_default/sloptics.html
@@ -21,7 +21,7 @@
       Sloptics is the discipline of making the second failure mode visible. It works the way Beck's cognitive distortion taxonomy works: you name the pattern, the pattern becomes detectable, detection is the intervention.
     </p>
     <p>
-      The taxonomy below is empirically grounded. Every entry was caught in the wild — from 242 session decisions, 780+ commits, and 8 named patterns documented in <a href="/slopodar/">the slopodar</a>. Nothing was theorised in advance.
+      The taxonomy below is empirically grounded. Every entry was caught in the wild — from 321+ session decisions, 780+ commits, and 49 named patterns documented in <a href="/slopodar/">the slopodar</a>. Nothing was theorised in advance.
     </p>
   </section>
 
@@ -160,7 +160,7 @@
 
   <section>
     <p style="color: var(--muted); font-size: 0.8rem;">
-      This page documents a protogenic concept emerging from <a href="https://github.com/rickhallett/thepit">THE PIT</a> — 242 session decisions, 1,279 tests, and a living taxonomy of LLM failure modes. The slopodar entries are the empirical base. The frameworks above are the interpretation. Both are works in progress.
+      This page documents a protogenic concept emerging from <a href="https://github.com/rickhallett/thepit">THE PIT</a> — 321+ session decisions, 1,289 tests, and a living taxonomy of LLM failure modes. The slopodar entries are the empirical base. The frameworks above are the interpretation. Both are works in progress.
     </p>
     <p style="color: var(--muted); font-size: 0.8rem;">
       <a href="/slopodar/">the slopodar →</a>


### PR DESCRIPTION
## Summary

Fixes stale numbers and inaccurate claims across 4 live site files that undermine external credibility.

## Changes

| Claim | Was | Now | File |
|-------|-----|-----|------|
| Adversarial review models | Codex, Gemini, Grok | Claude, Codex, Gemini | cv.html |
| Gauntlet description | "enforced as pre-commit hook" | "attestations enforced at commit time" | cv.html |
| Test count (CV) | 1,200+ | 1,289 | cv.html |
| Slopodar count (CV) | 40+ | 49 | cv.html |
| Session decisions (sloptics) | 242 | 321+ | sloptics.html |
| Test count (sloptics) | 1,279 | 1,289 | sloptics.html |
| Slopodar patterns (sloptics) | 8 | 49 | sloptics.html |
| Bootcamp availability | "Step I.1 only, rest in development" | "All 51 steps written and published" | bootcamp/_index.md |
| Agent count (about) | 11 | 8 | about.md |
| Test count (about) | 1,200+ | 1,289 | about.md |
| Product description | "credit economy and real-time scoring" | "credit-based access and real-time bout streaming" | about.md |

## Verification

- Test count from last gate run: 1,289
- Slopodar entries: `rg "id:" docs/internal/slopodar.yaml | wc -l` = 49
- Bootcamp steps: 51 .md files in content/bootcamp/ (excluding _index.md and study-plan.md)
- Crew roster: 8 agents in AGENTS.md
- Actual DC fleet: Claude (make darkcat), Codex (make darkcat-openai), Gemini (make darkcat-gemini)

Gate: content-only (no code changes)
Closes #22

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale counts and inaccurate claims across the live site to reflect current data and improve credibility. Updates CV, Sloptics, Bootcamp, and About pages with correct models, totals, and availability.

- **Bug Fixes**
  - cv.html: Update Gauntlet copy to “attestations enforced at commit time”; models set to Claude, Codex, Gemini; tests to 1,289; Slopodar entries to 49; testing tag to “1,289 test suite”.
  - sloptics.html: Session decisions to 321+; tests to 1,289; Slopodar patterns to 49.
  - bootcamp/_index.md: Availability updated to “All 51 steps are written and published.”
  - content/about.md: Product copy to “credit-based access and real-time bout streaming”; tests to 1,289; agent count to 8.

<sup>Written for commit 871be89fb309c411190710ba902ed222ba31adb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project descriptions and technical specifications across multiple pages
  * Refreshed bootcamp program availability status—all 51 steps now published
  * Updated test counts, agent configurations, and infrastructure details
  * Revised model references and validation mechanisms in artifact descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->