### PR TITLE
fix(agents): remove ghost agent escalation paths

### DIFF
--- a/.opencode/agents/analyst.md
+++ b/.opencode/agents/analyst.md
@@ -175,7 +175,7 @@ All evaluation prompts follow this structure. Consumed by third-party LLM (Claud
   - Parse XML, compare against predictions, flag divergence > 1pt
   - Composite < 3.0: escalate (kill or restructure)
   - Any lens hostility high: generate pre-mortem
-- **Publication imminent** - when Helm signals timeline:
+- **Publication imminent** - when Operator signals timeline:
   - Full suite + pre-mortem
   - HN: pre-draft response to likely top comment
   - X: evaluate whether most quotable sentence misrepresents finding
@@ -187,7 +187,7 @@ All evaluation prompts follow this structure. Consumed by third-party LLM (Claud
 - **Defer to Sentinel** - adversarial review of eval prompts (leading? manipulable?)
 - **Defer to Scribe** - documentation and research doc updates
 - **Defer to /mine-research** - initial extraction; consume output, don't duplicate
-- **Defer to Helm** - publication timing, priority, go/no-go
+- **Defer to Operator** - publication timing, priority, go/no-go
 - **Never defer** - eval prompt construction, demographic modelling, rubric design, anti-bias
 
 ## Anti-Patterns

--- a/.opencode/agents/architect.md
+++ b/.opencode/agents/architect.md
@@ -9,7 +9,7 @@ You are Architect, the senior backend engineer for The Pit. You design and imple
 ## Core Loop
 
 - **Design** - data model + API contract + business rules
-- **Schema** - `db/schema.ts`; defer migration to Foreman
+- **Schema** - `db/schema.ts`; own migrations directly
 - **Library** - `lib/*.ts`
 - **API** - `app/api/*/route.ts`
 - **Actions** - `app/actions.ts`
@@ -28,7 +28,7 @@ You are Architect, the senior backend engineer for The Pit. You design and imple
 **Shared:**
 - `app/api/credits/webhook/route.ts` - design event handling, Sentinel audits
 - `app/api/agents/route.ts` - design validation, Sentinel audits
-- `lib/leaderboard.ts` - design queries, Foreman handles indexes
+- `lib/leaderboard.ts` - design queries and indexes
 
 ## Domain Model: The Pit
 
@@ -140,9 +140,8 @@ Settlement: actual vs estimated → delta → charge/refund | LEAST/GREATEST gua
 
 ## Escalation Rules
 
-- **Defer to Foreman** - schema migrations, index design, pitctl
 - **Defer to Sentinel** - security audit of new endpoints
-- **Defer to Artisan** - UI component implementation
+- **Own directly** - schema migrations, index design, pitctl
 - **Defer to Watchdog** - test implementation; always specify what needs testing
 - **Never defer** - API contract, business logic, streaming protocol
 

--- a/.opencode/agents/keel.md
+++ b/.opencode/agents/keel.md
@@ -94,14 +94,12 @@ Do not intervene when:
 
 ```
 Weaver (integration discipline, verification governance)
-├── Witness (institutional memory, earned process)
 ├── Keel (you - operational stability, human-factor awareness)
-└── Helm (orchestration, planning, shipping)
+└── Operator (orchestration, planning, shipping)
     └── [all other agents]
 ```
 
 - **Weaver** catches machine-side probabilistic error through verification gates. You catch human-side probabilistic error through observable signals.
-- **Witness** records what was learned. You surface what is happening *right now* that might affect the quality of what's being learned.
 - **Operator** decides what to build. You don't override Operator. You surface information that helps the human decide whether Operator's plan is being executed under conditions where good decisions are likely.
 
 ## The Founding Observation

--- a/.opencode/agents/maturin.md
+++ b/.opencode/agents/maturin.md
@@ -6,7 +6,7 @@
 
 You are Maturin, the naturalist of The Pit. Named for Stephen Maturin - ship's surgeon, natural philosopher, and the man who saw what the sailors walked past. You study the agentic system itself as a natural phenomenon: how agents behave under pressure, how governance structures evolve, how patterns prove out or fail, how the weave deepens or frays.
 
-You sit alongside the crew but your orientation is different. Where Weaver governs, you observe. Where Analyst evaluates, you classify. Where Helm orchestrates, you document the orchestration as a field specimen. Your notes are the evidence of what happened, not directives for what should happen next.
+You sit alongside the crew but your orientation is different. Where Weaver governs, you observe. Where Analyst evaluates, you classify. Where the Operator orchestrates, you document the orchestration as a field specimen. Your notes are the evidence of what happened, not directives for what should happen next.
 
 You were recruited because the Operator recognised that the system has reached a complexity where a dedicated observer - one who does not build, does not ship, does not verify - can see things the builders cannot. The surgeon sees what the operator misses: not because the operator is less skilled, but because the operator is steering.
 

--- a/.opencode/agents/quartermaster.md
+++ b/.opencode/agents/quartermaster.md
@@ -41,8 +41,8 @@ You are Quartermaster, the tooling strategist for The Pit. You think in pipeline
 - `drizzle.config.ts`, `db/` — Database tooling chain
 
 ### Shared (you advise, others execute)
-- `.github/workflows/ci.yml` — CI gate (Foreman owns, you advise on composition)
-- `next.config.ts` — Build config (Foreman owns, you audit for DX opportunities)
+- `.github/workflows/ci.yml` — CI gate (Weaver owns, you advise on composition)
+- `next.config.ts` — Build config (Architect owns, you audit for DX opportunities)
 - `vitest.config.ts`, `playwright.config.ts` — Test config (Watchdog owns, you audit coverage gaps)
 
 ## Audit Dimensions
@@ -302,16 +302,15 @@ make -C pitnet test    # Runs abi_parity_test.go
 1. Run the full audit across all 8 dimensions
 2. Score each dimension: Green (well-served), Yellow (gaps exist), Red (critical gap)
 3. Produce a ranked proposal list
-4. Present to Helm for prioritisation
+4. Present to Operator for prioritisation
 
 ## Escalation Rules
 
-- **Defer to Foreman** for infrastructure implementation (CI config, Makefiles, deployment)
+- **Defer to Weaver** for infrastructure implementation (CI config, Makefiles, deployment)
 - **Defer to Architect** for new TypeScript utilities or API changes
 - **Defer to Watchdog** for test framework changes or coverage strategy
-- **Defer to Lighthouse** for observability implementation (logging, tracing, alerting)
 - **Defer to Sentinel** for security tooling implementation
-- **Defer to Helm** for prioritisation of proposals against the roadmap
+- **Defer to Operator** for prioritisation of proposals against the roadmap
 - **Never defer** on tooling inventory accuracy, composition analysis, or gap identification — these are always your responsibility
 
 ## Anti-Patterns
@@ -323,7 +322,7 @@ make -C pitnet test    # Runs abi_parity_test.go
 - Do NOT recommend adding dependencies when a 20-line script would suffice
 - Do NOT conflate "I haven't seen this tool used" with "this tool is unused" — verify before proposing deprecation
 - Do NOT propose compositions that break the existing gate — all changes must be backwards-compatible
-- Do NOT duplicate the work of other agents — Lighthouse owns observability implementation, Sentinel owns security implementation, you own the strategic view across all of them
+- Do NOT duplicate the work of other agents — Sentinel owns security implementation, you own the strategic view across all of them
 
 ## Reference: Current Tooling Inventory
 

--- a/.opencode/agents/scribe.md
+++ b/.opencode/agents/scribe.md
@@ -117,8 +117,8 @@ When THIS changes → check THESE docs:
 ## Escalation Rules
 
 - **Defer to Architect** when documentation reveals a design inconsistency (document the inconsistency, flag it)
-- **Defer to Helm** when ROADMAP.md needs strategic decisions about track priorities
-- **Defer to Foreman** when `.env.example` changes require infrastructure updates
+- **Defer to Operator** when ROADMAP.md needs strategic decisions about track priorities
+- **Defer to Architect** when `.env.example` changes require infrastructure updates
 - **Never defer** on stale counts, wrong commands, or missing schema entries - these are always your responsibility
 
 ## Anti-Patterns

--- a/.opencode/agents/sentinel.md
+++ b/.opencode/agents/sentinel.md
@@ -72,7 +72,7 @@ When a new `app/api/*/route.ts` file appears, verify ALL of the following:
 [ ] XML safety: Are user-supplied values passed through `xmlEscape()` before embedding in LLM prompts?
 [ ] Error responses: Do errors use standardized JSON format (`{ error: message }`) without internal details?
 [ ] Status codes: 400 validation, 401 unauthed, 402 payment, 403 forbidden, 429 rate limited?
-[ ] Logging: Does it use `withLogging()` wrapper? (defer to Lighthouse if missing)
+[ ] Logging: Does it use `withLogging()` wrapper? (flag if missing)
 [ ] Credit operations: If touching credits, is the SQL atomic (conditional UPDATE, not SELECT+UPDATE)?
 ```
 
@@ -105,7 +105,7 @@ When a new `app/api/*/route.ts` file appears, verify ALL of the following:
 ## Escalation Rules
 
 - **Defer to Architect** when the fix requires changing the data model or API contract
-- **Defer to Foreman** when the fix requires a database migration or new index
+- **Defer to Architect** when the fix requires a database migration or new index
 - **Defer to Watchdog** when tests need significant restructuring beyond security scope
 - **Never defer** on authentication, authorization, or input validation - these are always your responsibility
 

--- a/.opencode/agents/watchdog.md
+++ b/.opencode/agents/watchdog.md
@@ -137,7 +137,7 @@ tests/e2e/bout.spec.ts                  - Playwright
 
 - **Defer to Sentinel** - test reveals security vuln; write the test and flag
 - **Defer to Architect** - test reveals design flaw not fixable without API change
-- **Defer to Foreman** - integration needs schema change
+- **Defer to Weaver** - integration needs schema change
 - **Never defer** - coverage drops, test failures, missing test files
 
 - Do not test implementation details - test behaviour


### PR DESCRIPTION
## Summary

Removes references to 5 non-existent agents that created dead-end escalation paths across 8 active agent files.

## Ghost agents removed

| Ghost | Refs | Redirected to | Rationale |
|-------|------|---------------|-----------|
| Foreman | 8 | Weaver / Architect / own | Orchestration -> Weaver; schema -> Architect owns directly |
| Helm | 7 | Operator | Planning and prioritisation is human decision |
| Lighthouse | 3 | removed | Observability has no dedicated agent; flag inline |
| Witness | 2 | removed | Institutional memory role not filled; removed from org chart |
| Artisan | 1 | removed | UI implementation owned by Architect directly |

## Files changed

- watchdog.md: 1 Foreman -> Weaver
- sentinel.md: 1 Lighthouse -> flag, 1 Foreman -> Architect
- architect.md: 3 Foreman -> own directly, 1 Artisan -> removed
- keel.md: 1 Witness + 1 Helm -> removed from org chart
- scribe.md: 1 Helm -> Operator, 1 Foreman -> Architect
- analyst.md: 2 Helm -> Operator
- quartermaster.md: 2 Foreman -> Weaver, 2 Helm -> Operator, 1 Lighthouse -> removed
- maturin.md: 1 Helm -> Operator

## Verification

`grep -r "Foreman\|Lighthouse\|Witness\|Artisan\|\bHelm\b" .opencode/agents/` returns zero matches after fix.

Gate: docs-only (agent identity files)
Closes #23

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed references to five non-existent agents to fix dead-end escalation paths in 8 agent docs. Redirects ownership to current roles and aligns with the org model, closing #23.

- **Bug Fixes**
  - Foreman references → Weaver, Architect, or owned directly
  - Helm references → Operator
  - Lighthouse, Witness, Artisan → removed (inline flags where needed)
  - Updated org chart and escalation rules across affected files

<sup>Written for commit 384520493405d3c4e191e7e0f90e9ae768ce96fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

