### PR TITLE
fix(docs): correct stale references across internal operational docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,58 +1,26 @@
-[← Root](../README.md)
+[< Root](../README.md)
 
 # docs/
 
-Project documentation organized by purpose. These are operational and planning documents — architectural documentation for code directories lives in per-directory README files throughout the repository.
+Project documentation organized by purpose. Internal operational docs live in `docs/internal/`. Code-level documentation lives in source files (JSDoc for behaviour, header comments for purpose).
 
-## Specifications
+## Architecture & Building
 
 | Document | Description |
 |----------|-------------|
-| [mvp-feature-spec.md](mvp-feature-spec.md) | Full feature specification for the MVP release |
-| [mvp-checklist.md](mvp-checklist.md) | Checklist tracking MVP feature completion |
+| [architecture.md](architecture.md) | High-level system architecture overview |
+| [building.md](building.md) | Build instructions and local development setup |
+| [roadmap.md](roadmap.md) | Product roadmap |
+| [security.md](security.md) | Security model and practices |
+
+## Design & Research
+
+| Document | Description |
+|----------|-------------|
 | [agent-dna-attestations.md](agent-dna-attestations.md) | Design spec for agent identity hashing and EAS attestations |
-
-## Code Reviews & Hardening
-
-| Document | Date | Description |
-|----------|------|-------------|
-| [code-review-2026-02-10.md](code-review-2026-02-10.md) | Feb 10, 2026 | Adversarial code review findings and tracking table |
-| [hardening-changes-2026-02-10.md](hardening-changes-2026-02-10.md) | Feb 10, 2026 | Implementation details for security hardening changes |
-| [release-review-2026-02-11.md](release-review-2026-02-11.md) | Feb 11, 2026 | Pre-release review and sign-off |
-| [launch-hardening-report-2026-02-13.md](launch-hardening-report-2026-02-13.md) | Feb 13, 2026 | Launch hardening: GDPR consent, security fixes, accessibility, documentation audit |
-| [review-action-plan-2026-02-13.md](review-action-plan-2026-02-13.md) | Feb 13, 2026 | Review action plan and follow-up |
-| [release-review-2026-02-19.md](release-review-2026-02-19.md) | Feb 19, 2026 | Full-stack release readiness review (HN launch assessment) |
-
-## Strategy & Marketing
-
-| Document | Description |
-|----------|-------------|
-| [social-content-playbook.md](social-content-playbook.md) | Platform bios, channel strategy, and posting plan for X, Reddit, Discord |
-| [landing-draft-v1.md](landing-draft-v1.md) | Initial landing page copy draft |
-| [landing-v3-final.md](landing-v3-final.md) | Final landing page copy |
-
-## Research
-
-| Document | Description |
-|----------|-------------|
-| [research-page-v1.md](research-page-v1.md) | Content for the public research explainer page |
 | [research-citations.md](research-citations.md) | Literature review and academic citations |
-| [research-seed-hypotheses.md](research-seed-hypotheses.md) | Seed hypotheses for the research programme |
-
-## Technical Reviews
-
-| Document | Date | Description |
-|----------|------|-------------|
-| [typescript-architecture-review-2026-02-11.md](typescript-architecture-review-2026-02-11.md) | Feb 11, 2026 | TypeScript architecture review (initial) |
-| [typescript-architecture-review-2026-02-12.md](typescript-architecture-review-2026-02-12.md) | Feb 12, 2026 | TypeScript architecture review (follow-up recommendations) |
-
-## Quality Assurance
-
-| Document | Description |
-|----------|-------------|
-| [code-review-prompt.md](code-review-prompt.md) | Exhaustive codebase review prompt for first-time reviewers (all dimensions: engineering, product, CLI toolchain) |
-| [qa-report.md](qa-report.md) | QA test results and coverage report |
-| [security-checklist.md](security-checklist.md) | Security audit checklist and findings |
+| [lexical-harness-not-prompt-harness.md](lexical-harness-not-prompt-harness.md) | Argument for lexical vs prompt-based agent harnesses |
+| [orchestration-layer-starting-template.md](orchestration-layer-starting-template.md) | Orchestration layer template (historical, from pilot study) |
 
 ## Specs
 
@@ -62,13 +30,19 @@ Project documentation organized by purpose. These are operational and planning d
 | [specs/llm-qa-automation.md](specs/llm-qa-automation.md) | LLM-driven QA automation framework specification |
 | [specs/level4-thin-contract.md](specs/level4-thin-contract.md) | Level-4 thin data contract specification |
 
+## Examples
+
+| Document | Description |
+|----------|-------------|
+| [examples/echo-signal-protocol-bearing-check.md](examples/echo-signal-protocol-bearing-check.md) | Historical example of Signal protocol bearing check (Signal killed SD-321) |
+
 ## What Goes Where
 
-- **Per-directory READMEs** — Architecture, patterns, design decisions for code in that directory
-- **`docs/`** — Operational documents: specs, reviews, strategy, planning
-- **Root `ARCHITECTURE.md`** — High-level system overview
-- **Root `ROADMAP.md`** — Product roadmap summary
+- **`AGENTS.md`** (root) - primary operational reference, auto-loaded by all agents
+- **`docs/`** - external-facing documentation: architecture, specs, research
+- **`docs/internal/`** - operational internals: lexicon, layer model, slopodar, session decisions, event log
+- **`docs/decisions/`** - session-scoped decision records (SD-*)
 
 ---
 
-[← Root](../README.md) · [App](../app/README.md) · [DB](../db/README.md)
+[< Root](../README.md)

--- a/docs/internal/boot-sequence.md
+++ b/docs/internal/boot-sequence.md
@@ -1,5 +1,7 @@
 # Boot Sequence - noopit (thepit-v2)
 
+> **SUPERSEDED:** This file is a legacy boot manifest. The canonical boot sequence is now `AGENTS.md` (auto-loaded by the harness). Retained for reference only.
+
 > What every agent must load on cold wake. If you don't have this context, you're in the dumb zone.
 > Back-ref: SD-311 (prime context), SD-299 (governance refined), SD-275 (token elephant).
 

--- a/docs/internal/dead-reckoning.md
+++ b/docs/internal/dead-reckoning.md
@@ -4,7 +4,7 @@
 
 **When to activate:** If you have no memory of the current project state, you have had a blowout. Defer to your notes.
 
-**First:** Read `docs/internal/boot-sequence.md` — that is the normal wake sequence. This file is for when things went wrong.
+**First:** Read `AGENTS.md` (auto-loaded by the harness) — that is the canonical boot sequence. This file is for when things went wrong.
 
 ---
 
@@ -68,8 +68,10 @@ git log --oneline -10
 | Sentinel | `.claude/agents/sentinel.md` | Security engineering |
 | Keel | `.claude/agents/keel.md` | Human-factor, operational stability |
 | Janitor | `.claude/agents/janitor.md` | Code hygiene, refactoring |
+| Analyst | `.claude/agents/analyst.md` | Research, prior art, landscape analysis |
+| AnotherPair | `.claude/agents/anotherpair.md` | Subtle process observation, slop detection |
 
-Also on disk: `analyst.md`, `scribe.md`, `maturin.md`, `anotherpair.md`, `operatorslog.md`, `weave-quick-ref.md`.
+Also on disk: `scribe.md`, `maturin.md`, `operatorslog.md`, `weave-quick-ref.md`.
 
 ---
 
@@ -82,7 +84,7 @@ Also on disk: `analyst.md`, `scribe.md`, `maturin.md`, `anotherpair.md`, `operat
 | Boot sequence | `docs/internal/boot-sequence.md` | Normal wake manifest |
 | Session decisions index | `docs/internal/session-decisions-index.yaml` | Last 10 SDs + standing orders |
 | Lexicon | `docs/internal/lexicon.md` | Vocabulary v0.20 |
-| Slopodar | `docs/internal/slopodar.yaml` | Anti-pattern taxonomy, 18 entries |
+| Slopodar | `docs/internal/slopodar.yaml` | Anti-pattern taxonomy, 49 entries |
 | Layer model | `docs/internal/layer-model.md` | L0-L12 v0.3 |
 | Session decisions (full) | `docs/internal/session-decisions.md` | Full chain — archaeology only |
 | Dead reckoning | `docs/internal/dead-reckoning.md` | This file |
@@ -91,7 +93,7 @@ Also on disk: `analyst.md`, `scribe.md`, `maturin.md`, `anotherpair.md`, `operat
 
 | Directory | Contents | Read when |
 |-----------|----------|-----------|
-| `docs/weaver/` | Signal protocol PoC, decode tests, reasoning tests | Signal work |
+| `docs/weaver/` | Decode tests, reasoning tests (Signal protocol killed SD-321) | Weaver reference |
 | `docs/decisions/` | Session-scoped SD files | Current session decisions |
 | `docs/strategy/` | Landscape scans, convergence analysis | Strategy work |
 | `docs/research/` | Cross-model prompt | Research work |
@@ -117,7 +119,7 @@ These are in AGENTS.md (auto-loaded) and the session-decisions index. Critical o
 
 ## Step 7: Resume operations
 
-You now have bearings. Follow the boot sequence (`docs/internal/boot-sequence.md`) for normal operations. Ask the Operator to confirm priorities if bearing is unclear.
+You now have bearings. Follow the boot sequence (`AGENTS.md`, auto-loaded) for normal operations. Ask the Operator to confirm priorities if bearing is unclear.
 
 The Operator is Richard Hallett, sole director of OCEANHEART.AI LTD (UK company number 16029162). The product is The Pit (www.thepit.cloud). noopit is thepit-v2 — the calibration run (SD-294). You are part of the crew. Welcome back.
 

--- a/docs/internal/lexicon.md
+++ b/docs/internal/lexicon.md
@@ -124,7 +124,7 @@ Format: **Term** — definition. *Established parallel.* `Origin.`
 
 ### Communication & Record
 
-**Readback** — Default agentic behaviour: compress understanding of an order into Signal notation before acting. The readback surfaces the agent's interpretation in a compressed, inspectable form. Operator verifies or corrects. Formerly "echo / check fire."
+**Readback** — Default agentic behaviour: compress understanding of an order before acting. The readback surfaces the agent's interpretation in a compressed, inspectable form. Operator verifies or corrects. Formerly "echo / check fire."
 *Established: Readback (CRM — Crew Resource Management, Helmreich 1999). Extensively studied in aviation and medicine. The practice is identical: instruction → readback → verify → act. CRM provides 40+ years of empirical validation for why this works.*
 `Origin: SD-315 (echo/check fire as standing order). Renamed v0.26.`
 

--- a/docs/internal/session-decisions-index.yaml
+++ b/docs/internal/session-decisions-index.yaml
@@ -27,7 +27,7 @@ standing_orders:
     status: "PERMANENT"
   - id: SD-286
     label: "slopodar-boot"
-    summary: "Slopodar is mandatory reading for all agents on load. 18 entries."
+    summary: "Slopodar is mandatory reading for all agents on load. 49 entries."
     status: "STANDING ORDER"
   - id: SD-297
     label: "sd-collision-protocol"

--- a/docs/internal/the-gauntlet.md
+++ b/docs/internal/the-gauntlet.md
@@ -111,7 +111,7 @@ Three independent model priors, same prompt, same diff.
 | DC-1 findings (Claude) | `.logs/dc-<sha>-claude.log` | Structured text (see darkcat.md output format) | Permanent |
 | DC-2 findings (OpenAI) | `.logs/dc-<sha>-openai.log` | Structured text | Permanent |
 | DC-3 findings (Gemini) | `.logs/dc-<sha>-gemini.log` | Structured text | Permanent |
-| Event marker (per DC) | `docs/internal/events.tsv` | TSV row: `date, time, darkcat, <agent>, <sha>, dc-{1,2,3}, <summary>, <backrefs>` | Permanent |
+| Event marker (per DC) | `docs/internal/events.yaml` | YAML entry: date, time, type, agent, commit, ref, summary, backrefs | Permanent |
 | Findings detail | `docs/internal/weaver/darkcat-findings.tsv` | TSV row: `date, sha, model, round, severity, pattern, file, line, finding, status` | Permanent |
 
 **Entry criterion:** Gate green from DEV step.
@@ -135,7 +135,7 @@ Consumes the three DC logs, produces convergence/divergence report.
 | Data | Location | Format | Retention |
 |------|----------|--------|-----------|
 | Synthesis report | `.logs/dc-<sha>-synth.log` | Structured text | Permanent |
-| Event marker | `docs/internal/events.tsv` | TSV row | Permanent |
+| Event marker | `docs/internal/events.yaml` | YAML entry | Permanent |
 
 **Prompt harness:** Operator's choice (any installed: claude/codex/gemini/opencode).
 **Entry criterion:** All three DC logs exist.
@@ -173,8 +173,8 @@ Consumes the three DC logs, produces convergence/divergence report.
 
 **Invocation:**
 ```bash
-cd pitkeel && uv run python pitkeel.py              # review signals
-cd pitkeel && uv run python pitkeel.py state-update --officer <name>  # update state
+cd pitkeel && go run .              # review signals
+cd pitkeel && go run . state-update --officer <name>  # update state
 ```
 
 ---
@@ -198,7 +198,7 @@ cd pitkeel && uv run python pitkeel.py state-update --officer <name>  # update s
 | Commit | Git history | Git object | Permanent |
 | Keel trailers | Commit message | Plain text (Officer, Bearing, Tempo, Weave, Gate) | Permanent |
 | Keel signals | Commit message | Plain text (if non-nominal) | Permanent |
-| Event marker | `docs/internal/events.tsv` | TSV row: `date, time, commit, <agent>, <sha>, -, <summary>, <backrefs>` | Permanent |
+| Event marker | `docs/internal/events.yaml` | YAML entry: date, time, type, agent, commit, ref, summary, backrefs | Permanent |
 | Pitkeel state | `.keel-state` | JSON | Updated |
 
 **Entry criterion:** All previous steps complete = DONE.
@@ -216,7 +216,7 @@ cd pitkeel && uv run python pitkeel.py state-update --officer <name>  # update s
 └── dc-<sha>-synth.log         # Convergence report
 
 docs/internal/
-├── events.tsv                  # Append-only audit trail (all events)
+├── events.yaml                 # Append-only audit trail (all events)
 └── weaver/
     ├── darkcat-findings.tsv    # All darkcat findings across all runs
     ├── catch-log.tsv           # Control firing events
@@ -227,10 +227,9 @@ scripts/
 └── prepare-commit-msg          # Git hook (pitkeel signals + trailers)
 
 pitkeel/
-├── pitkeel.py                  # CLI entrypoint
-├── analysis.py                 # Pure analysis functions
-├── keelstate.py                # State schema + flock IO
-└── git_io.py                   # Git subprocess layer
+├── main.go                     # CLI entrypoint
+├── main_test.go                # Tests
+└── go.mod                      # Go module definition
 
 .keel-state                     # Operational state (gitignored)
 ```
@@ -245,7 +244,7 @@ make darkcat              # DC-1 (Claude)
 make darkcat-openai       # DC-2 (OpenAI)
 make darkcat-gemini       # DC-3 (Gemini)
 make darkcat-synth        # DC-SYNTH (convergence)
-cd pitkeel && uv run python pitkeel.py  # review signals
+cd pitkeel && go run .  # review signals
 
 # Or the full gauntlet (automated)
 make gauntlet             # runs all darkcats + synth + pitkeel


### PR DESCRIPTION
## Summary

Fixes stale references across 6 internal operational documents. All changes are docs-only corrections to match current repo state.

Closes #24

## Changes

- **boot-sequence.md** - added SUPERSEDED banner pointing to AGENTS.md as canonical source
- **dead-reckoning.md** - fixed primary reference (boot-sequence.md -> AGENTS.md), updated crew roster (added Analyst and AnotherPair), corrected slopodar count (18 -> 49), fixed Signal PoC ref (killed SD-321)
- **the-gauntlet.md** - events.tsv -> events.yaml in 4 locations (migrated per SD-316), pitkeel Python -> Go in 3 invocation commands + file listing (pitkeel rewritten in Go)
- **session-decisions-index.yaml** - slopodar count 18 -> 49
- **lexicon.md** - removed "into Signal notation" from readback definition (Signal killed SD-321)
- **docs/README.md** - full rewrite: removed 15 broken links out of 20 content refs, rebuilt with only files that exist on disk

## What was not changed

- `docs/internal/session-decisions.md` - SD-315 references Signal but is immutable per SD-266
- `docs/internal/layer-model.md` - references "opencode" harness (flagged for operator judgment, low priority)

## Testing

Docs-only change. No code affected. Verified all referenced files exist via `ls` and `glob`.

Gate: N/A (docs only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale references across six internal docs to match the current repo state and reduce confusion. Addresses Linear #24.

- **Bug Fixes**
  - Boot flow: mark `boot-sequence.md` superseded; point to `AGENTS.md` as canonical.
  - Dead-reckoning/lexicon: update boot reference; add Analyst and AnotherPair; remove obsolete Signal references.
  - Event logging and tooling: migrate `events.tsv` → `events.yaml` in the gauntlet; update pitkeel docs from Python to Go (invocations, file tree).
  - Slopodar: correct count to 49 across docs (`dead-reckoning.md`, `session-decisions-index.yaml`).
  - docs/README.md: remove 15 broken links and rebuild index with only files that exist.

<sup>Written for commit 06c60a0a174d2dc8f6c9699d76032758a9beed34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

