### PR TITLE
fix(docs): correct stale references in root CV/directive files

### DIFF
--- a/master-agentic.md
+++ b/master-agentic.md
@@ -1,0 +1,120 @@
+---
+name: Richard Hallett
+tagline: "I verify LLM output before it ships | React/Python"
+contact: "rickhallett@icloud.com | linkedin.com/in/richardhallett86 | github.com/rickhallett"
+---
+
+## Summary
+
+I build infrastructure that verifies LLM output before it ships: cross-model review gates, commit attestation, drift measurement. 4 years enterprise (React/TypeScript, Python). 15 years as a Cognitive Behavioural Therapist. That's why my tooling tracks human cognitive reserves and enforces ultradian breaks.
+
+---
+
+## Experience
+
+### Founder | Oceanheart.ai
+**Apr 2024 – Present**
+
+**The Pit** is a solo infrastructure project for AI-human collaboration.
+
+- **Gauntlet (verification pipeline):** Attestation-gated commits. Code requires: gate pass, cross-model adversarial review, tree-hashed human attestation. Walkthrough tier requires sudo authentication.
+- **Pitkeel (operator telemetry):** Python daemon tracking session context drift, cognitive reserves, and velocity. Enforces ultradian breaks via sleep daemon. Exists because human fatigue causes errors that no linter catches.
+- **Shorthand governance protocol:** Compressed communication between human and agent, validated across Claude, GPT-5.2, and Gemini via adversarial decode testing.
+- **Build orchestration:** Numbered plan files with topologically sorted execution. Makefile modularization. Deliberate reset midway: deleted product code to rebuild with feedback infrastructure first.
+- **Slopodar:** Failure mode taxonomy with detection heuristics. Covers sycophantic drift, epistemic theatre, context degradation.
+
+Public repo: github.com/rickhallett/thepit
+
+**Prior:** Job application automation (parser generation, match scoring, ATS form filling), client websites (Next.js, Astro), AI-assisted CBT education tools.
+
+### Software Engineer | EDITED
+**Nov 2023 – Mar 2024**
+
+- Developed React/TypeScript features for AI-driven retail analytics SaaS platform
+- Built data visualisation components enabling clients to interpret ML insights
+- Partnered with backend engineers (Python/Django) to optimize API integrations
+
+### Software Engineer | Brandwatch
+**Jun 2021 – Nov 2023**
+
+- Contributed to enterprise data visualisation platform (Monitor project)
+- Built scalable React components while modernising legacy Backbone codebase
+- Mentored junior developers and facilitated knowledge-sharing sessions
+
+### Full Stack Engineer | Telesoft
+**Sep 2020 – Feb 2021**
+
+- Delivered secure features for cybersecurity applications (TypeScript, Angular, Node.js)
+- Built Python utilities for data processing and automation
+
+### Software Developer | School Business Services Ltd
+**Mar 2019 – Mar 2020**
+
+- Created Vue.js frontend features for school financial management software
+- Applied psychology expertise to simplify complex workflows and improve usability
+
+---
+
+## Skills
+
+**Agentic Infrastructure:**
+- Verifying LLM output with cross-model review and cryptographic attestation
+- Measuring operator state: context drift, cognitive reserves, session velocity
+- Compressing human-agent communication to fit context windows
+- Scoping agents via file structure and agent identity files
+- Ordering non-deterministic work via Makefiles and numbered plans
+
+**Production Engineering:**
+- React, TypeScript, Next.js, Python, Node.js
+- PostgreSQL, Drizzle, API design
+- Git hook scripting, Makefile orchestration
+- Vitest, Playwright
+
+**Background:**
+- CBT delivery via voice/video platforms. Informs human-system interaction design.
+- Rapid prototyping with deliberate disposal
+
+---
+
+## Portfolio
+
+**The Pit** (github.com/rickhallett/thepit)
+
+Infrastructure for AI-human collaboration. LLMs drift, hallucinate, and agree when they shouldn't. This tooling catches it at commit time.
+
+- Gauntlet enforces cross-model review before code enters the repo
+- Pitkeel measures what linters can't: operator fatigue, context drift, session velocity
+- Shorthand governance protocol compresses human-agent communication
+- Slopodar documents failure modes with detection heuristics
+
+**Operational Tooling**
+- Job application automation: parser generation, match scoring, ATS form filling
+- Browser automation via Kernel MCP
+
+---
+
+## Psychology Background
+
+15 years as a Cognitive Behavioural Therapist. This informs my systems architecture: Pitkeel tracks cognitive reserves because I understand fatigue-induced errors. The ultradian break enforcement isn't optional. It's borrowed from clinical practice. I've spent 15 years watching people make predictable mistakes under cognitive load. That's why my tooling has "foot gun" detection built in.
+
+---
+
+## Education
+
+**PGDip Cognitive Behavioural Therapy** | Royal Holloway, London (2015)
+
+**PGCert Cognitive Behavioural Therapy** | UCLAN (2013)
+
+**BSc Psychology** | University of the West of England (2008)
+
+Ongoing: Building verification gates, measuring operator drift, testing protocols across model families
+
+---
+
+<!--
+NOTES FOR TAILORING:
+- This variant positions as agentic systems/infrastructure engineer, not frontend dev with AI interest
+- Use when job mentions: agentic, founding engineer, AI-native, multi-agent, Claude/Cursor, product engineer
+- The CBT background is the "why" behind the technical choices. Don't bury it.
+- Portfolio section explains what problems the tools solve, not just what they're called
+-->

--- a/master.md
+++ b/master.md
@@ -1,0 +1,93 @@
+---
+name: Richard Hallett
+tagline: "Human-Centred Software Engineer | React • Python • Go • AI"
+contact: "rickhallett@icloud.com | linkedin.com/in/richardhallett86 | github.com/rickhallett"
+---
+
+## Summary
+
+Software Engineer with 4 years of enterprise experience (6 years total), specialising in React/TypeScript and Python. Unique background as a Cognitive Behavioural Therapist (15 years), bringing advanced communication, problem-solving, and human-centred design expertise. Recently focused on AI-psychology convergence through entrepreneurial prototyping, strengthening adaptability and technical breadth.
+
+---
+
+## Experience
+
+### Founder | Oceanheart.ai
+**Apr 2024 – Present**
+
+- Owned end-to-end design and delivery of two client websites (Next.js, Astro, Turso/Neon) with custom Decap CMS, bespoke members portal featuring video streaming and automated video-to-text transcription
+- Prototyping AI-powered wellbeing tools at the intersection of psychotherapy and technology
+- Rapidly built full-stack prototypes with React, TypeScript, and Python, deploying proof-of-concepts for testing
+- Designed and implemented LLM agent workflows, integrating external APIs and structured prompts to support user interaction
+- Scoped product lifecycles from idea → prototype → user feedback, gaining exposure to end-to-end development
+- Applied CBT expertise to ensure human-centred design and ethical considerations in AI-driven tools
+
+### Software Engineer | EDITED
+**Nov 2023 – Mar 2024**
+
+- Developed React/TypeScript features for AI-driven retail analytics SaaS platform
+- Built data visualisation components enabling clients to interpret ML insights
+- Partnered with backend engineers (Python/Django) to optimize API integrations
+
+### Software Engineer | Brandwatch
+**Jun 2021 – Nov 2023**
+
+- Contributed to enterprise data visualisation platform (Monitor project)
+- Built scalable React components while modernising legacy Backbone codebase
+- Mentored junior developers and facilitated knowledge-sharing sessions
+
+### Full Stack Engineer | Telesoft
+**Sep 2020 – Feb 2021**
+
+- Delivered secure features for cybersecurity applications (TypeScript, Angular, Node.js)
+- Built Python utilities for data processing and automation
+
+### Software Developer | School Business Services Ltd
+**Mar 2019 – Mar 2020**
+
+- Created Vue.js frontend features for school financial management software
+- Applied psychology expertise to simplify complex workflows and improve usability
+
+---
+
+## Skills
+
+**Frontend:** Next.js 15-16, React, TypeScript, Vue, Tailwind CSS, shadcn/ui
+
+**Backend & Data:** Python, Node.js, Go, SQL, API design, Docker
+
+**CLI & Tooling:** Go CLI tools for agentic workflows, Rust experimentation
+
+**AI/ML:** LLM integration, agent workflows, prompt engineering
+
+**Testing & Workflow:** Vitest, Playwright, Git, Agile methodologies
+
+**Telehealth:** 1000s of hours delivering CBT via voice/video platforms
+
+---
+
+## Psychology Background
+
+15 years as a Cognitive Behavioural Therapist. Expertise in communication, human behaviour, and structured problem-solving, directly leveraged in software roles to improve usability, collaboration, and human-centred design.
+
+---
+
+## Education
+
+**PGDip Cognitive Behavioural Therapy** | Royal Holloway, London (2015)
+
+**PGCert Cognitive Behavioural Therapy** | UCLAN (2013)
+
+**BSc Psychology** | University of the West of England (2008)
+
+Ongoing self-directed training in modern web development, system design, and AI/ML
+
+---
+
+<!--
+NOTES FOR TAILORING:
+- Keep master comprehensive; create versions/ for specific applications
+- Reorder bullets within sections based on job relevance
+- Adjust summary positioning per role type
+- Psychology angle is the genuine differentiator - don't bury it
+-->


### PR DESCRIPTION
## Summary

Fixes stale references in root-level CV and directive markdown files. Adds previously untracked files to version control.

Closes #26

## Changes

- **master-agentic.md** (new to git):
  - Replaced Signal notation refs with "shorthand governance protocol" (Signal killed SD-321)
  - Fixed thepit-v2 -> thepit repo URLs (repos merged)
  - Removed DOMAIN.md convention ref (convention removed in PR #28)
  - Jest/Vitest/Cypress -> Vitest/Playwright (current test stack)
- **master.md** (new to git):
  - Jest/Cypress -> Vitest/Playwright
  - Added Go to tagline

## Not committed (gitignored)

`cv.todo.md`, `market.todo.md`, `so.todo.md` are matched by `*.todo.*` in `.gitignore`. Fixes applied locally (thepit-v2 -> thepit URLs, DIRECTIVE-MARKET-PROOF.md -> market.todo.md, Jest -> Vitest) but not committable by design.

## Testing

Docs-only change. Verified via `rg` that no Signal, Jest, Cypress, or thepit-v2 refs remain in committed files.

Gate: N/A (docs only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale references in the root CV/directive docs and adds the missing `master-agentic.md` and `master.md` to version control. Closes #26.

- **Bug Fixes**
  - master-agentic.md: Replaced Signal notation with “shorthand governance protocol”; updated `thepit-v2` → `thepit` URLs; removed `DOMAIN.md` convention; updated test stack to `Vitest`/`Playwright`.
  - master.md: Updated test stack to `Vitest`/`Playwright`; added Go to the tagline.
  - Note: `.todo` files remain ignored by `*.todo.*`; similar fixes applied locally but not committed.

<sup>Written for commit b0762be2c78836de0a1c0d96be3a140ed658cb85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive professional profile documentation including experience, skills, expertise areas, education background, and career portfolio information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->