### PR TITLE
fix(docs): clean up internal data files and codebase READMEs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,7 @@ Consent-gated (see Privacy above). SPA page view tracking, Clerk identity sync, 
 LLM cost and token analytics are captured via PostHog `$ai_generation` events emitted by the bout engine after each turn completes. This provides per-model cost tracking, token usage trends, and latency monitoring in the PostHog LLM analytics dashboard. Both platform-funded and BYOK turns are tracked (BYOK with the user's resolved model ID for accurate attribution).
 
 ### Structured Logger
-`lib/logger.ts` — zero-dep structured logging. JSON lines in production (`level`, `msg`, `ts`, `service: 'tspit'`), human-readable in dev. Configurable level via `LOG_LEVEL`. Auto-sanitizes API keys (`sk-ant-*`, `sk_live_*`, `sk_test_*`).
+`lib/logger.ts` - zero-dep structured logging. JSON lines in production (`level`, `msg`, `ts`, `service: 'thepit'`), human-readable in dev. Configurable level via `LOG_LEVEL`. Auto-sanitizes API keys (`sk-ant-*`, `sk_live_*`, `sk_test_*`).
 
 ### Anomaly Detection
 `lib/anomaly.ts` — in-memory sliding window analysis (per serverless instance). Detects burst traffic (>100 req/min/IP), credential probing (>20 auth failures/5min), error rate spikes (>50% per route), and suspicious user-agents. Best-effort logging only; enforcement handled by `lib/rate-limit.ts` and DB constraints.
@@ -145,7 +145,7 @@ LLM cost and token analytics are captured via PostHog `$ai_generation` events em
 Web Vitals reporting via `vitals.vercel-insights.com`.
 
 ## Go CLI Toolchain
-Eight CLI tools and a shared library, organized as a Go workspace under `github.com/rickhallett/thepit/`. Go 1.25.7. Each tool has `make gate` (vet + build + test). These are internal tools built for our own workflow — not yet polished for external use.
+Nine CLI tools and a shared library, organized as a Go workspace under `github.com/rickhallett/thepit/`. Go 1.25.7. Each tool has `make gate` (vet + build + test). These are internal tools built for our own workflow — not yet polished for external use.
 
 ### shared/ (Library)
 Consumed by all tools. Modules: `config/` (.env parsing, env var schema), `db/` (PostgreSQL via `lib/pq`), `license/` (Ed25519 JWT-like token create/verify, 7-day expiry), `format/` (number/time/credit formatting), `theme/` (Tokyo Night palette via `charmbracelet/lipgloss`).

--- a/docs/examples/echo-signal-protocol-bearing-check.md
+++ b/docs/examples/echo-signal-protocol-bearing-check.md
@@ -1,7 +1,9 @@
-# Example: Echo→Signal Protocol — Bearing Check into Bout Dispatch
+# Example: Echo Protocol - Bearing Check into Bout Dispatch
+
+> **HISTORICAL:** This example uses Signal notation, which was killed in SD-321 after adversarial testing showed conventional shorthand achieves equal decode accuracy. The echo/readback protocol [SD-315] remains active; only the Signal notation format is obsolete.
 
 > Portfolio material. Captured 2026-03-08.
-> Demonstrates: echo protocol [SD-315], bearing check governance unit, PLAN.md provenance practice.
+> Demonstrates: readback protocol [SD-315], bearing check governance unit.
 
 ## What this shows
 

--- a/docs/internal/backlog.yaml
+++ b/docs/internal/backlog.yaml
@@ -42,14 +42,14 @@
   title: Check Signal compression claim against compressed natural language control
     (shorthand). Signal may hold up as style guidance with implicit syntax meaning,
     but hasn't faced adversarial pressure on the 4.5:1 compression ratio claim
-  status: open
+  status: closed
   priority: medium
   tags:
   - signal-research
   epic: null
   created: '2026-03-09T09:53:25.454394+00:00'
-  closed: null
-  reason: null
+  closed: '2026-03-12T14:00:00+00:00'
+  reason: 'Signal killed SD-321. Adversarial test completed SD-320: shorthand >= signal with 14% smaller size.'
 - id: BL-007
   title: 'Blog publish scheduler: script to flip draft=false on posts by date. Hugo
     renders future-dated draft=false pages only with buildFuture=true. Need either
@@ -114,14 +114,14 @@
   reason: 'Parked: complexity vs marginal gain. See docs/field-notes/2026-03-10-slopmop-pipe-filter-exploration.md'
 - id: BL-010
   title: Evaluate debian:bookworm-slim or wolfi as midget base image
-  status: open
+  status: closed
   priority: medium
   tags:
   - infra
   epic: null
   created: '2026-03-10T11:55:31.653612+00:00'
-  closed: null
-  reason: null
+  closed: '2026-03-12T14:00:00+00:00'
+  reason: 'Decided: using debian:bookworm-slim. Evaluation complete.'
 - id: BL-011
   title: capture and pipe used tokens for midgets back for observation
   status: open

--- a/docs/orchestration-layer-starting-template.md
+++ b/docs/orchestration-layer-starting-template.md
@@ -1,3 +1,6 @@
+<!-- HISTORICAL: Orphaned template from the pilot study (tspit). Retained for reference.
+     Current orchestration patterns live in AGENTS.md. -->
+
 ```markdown
 ## Workflow Orchestration
 

--- a/ops/level4/README.md
+++ b/ops/level4/README.md
@@ -1,11 +1,13 @@
 # Level 4 Thin Contract Integration
 
-This folder integrates `tspit` with the external `darkfactorio` Level-4 gate using a thin data contract.
+> **HISTORICAL:** This integration was built during the pilot study (tspit). References to `tspit` below are accurate for that context. The current repo is `thepit`.
+
+This folder integrates the application with the external `darkfactorio` Level-4 gate using a thin data contract.
 
 ## Why this exists
 
-- Keep `tspit` release runtime stable.
-- Avoid embedding darkfactory policy logic directly in `tspit`.
+- Keep the release runtime stable.
+- Avoid embedding darkfactory policy logic directly in the application.
 - Emit one deterministic NDJSON record per real run.
 - Evaluate runs with external, versioned `dfgatev01` criteria.
 

--- a/pitctl/README.md
+++ b/pitctl/README.md
@@ -178,49 +178,6 @@ pitctl license verify                     # verify license at ~/.pit/license.jwt
 
 Keys are written to `keys/` directory. The signing key should be set as `LICENSE_SIGNING_KEY` in `.env`.
 
-#### `alerts` — Health checks
-
-```bash
-pitctl alerts                             # run all health checks (DB, API, free pool, error rate)
-pitctl alerts --json                      # output as JSON
-pitctl alerts --quiet                     # exit code only (for cron/CI)
-pitctl alerts --webhook <slack-url>       # send alerts to Slack
-```
-
-Checks database connectivity, API health endpoint, free bout pool exhaustion, and recent error rate.
-
-#### `metrics` — Platform metrics
-
-```bash
-pitctl metrics                            # last 24h metrics (default)
-pitctl metrics --period 7d                # last 7 days
-pitctl metrics --period 30d               # last 30 days
-pitctl metrics --json                     # output as JSON
-```
-
-Shows bout completion rates, user growth, credit economy stats, agent creation rates, and engagement metrics for the specified period.
-
-#### `report` — Summary report
-
-```bash
-pitctl report                             # daily summary report
-pitctl report --period weekly             # weekly summary
-pitctl report --webhook <slack-url>       # send to Slack
-```
-
-Generates a formatted summary report with key metrics. Optionally posts to Slack.
-
-#### `watch` — Continuous monitoring
-
-```bash
-pitctl watch                              # check every 5m (default)
-pitctl watch --interval 30s               # custom interval
-pitctl watch --json                       # output as JSON
-pitctl watch --webhook <slack-url>        # send alerts to Slack
-```
-
-Runs `alerts` checks in a continuous loop until interrupted (Ctrl+C).
-
 #### `version`
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes stale references, duplications, and missing historical context markers across internal data files and codebase READMEs.

Closes #27

## Changes

- **pitctl/README.md** - removed duplicate command sections: `alerts`, `metrics`, `report`, and `watch` each appeared twice (lines 181-222 were duplicates of lines 110-148)
- **ops/level4/README.md** - added historical banner marking this as a pilot study (tspit) artifact; fixed 2 inline `tspit` refs
- **docs/internal/backlog.yaml** - closed BL-005 (Signal compression research, killed SD-321 after adversarial test) and BL-010 (debian base image evaluation, decided)
- **docs/architecture.md** - fixed CLI tool count "Eight" -> "Nine" (missing pitlinear), fixed logger service name `tspit` -> `thepit`
- **docs/examples/echo-signal-protocol-bearing-check.md** - added historical banner: Signal notation obsolete per SD-321, readback protocol still active
- **docs/orchestration-layer-starting-template.md** - added historical comment: orphaned pilot study template, current patterns in AGENTS.md

## Testing

Docs-only change. Verified duplicate removal via line count comparison. All changes are factual corrections or historical context markers.

Gate: N/A (docs only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up internal docs by removing duplicate sections, fixing stale references, and adding historical notes. Keeps READMEs, examples, and backlog aligned with current decisions and the `thepit` repo.

- **Bug Fixes**
  - Removed duplicate command sections in `pitctl/README.md` (alerts, metrics, report, watch).
  - Corrected docs: logger service to `thepit` and CLI tool count to nine.
  - Added historical banners/notes to pilot-era files and the Signal notation example; clarified readback protocol remains active and pointed orchestration readers to `AGENTS.md`.
  - Updated backlog: closed BL-005 (drop Signal per SD-321) and BL-010 (choose `debian:bookworm-slim`).

<sup>Written for commit dfd8b35eebaef7cc312d29f69c27ee032da67f1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

