### PR TITLE
fix(ci): correct branch trigger, pipeline name, and add CI badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 concurrency:
@@ -118,7 +118,7 @@ jobs:
           pnpm run level4:emit -- \
             --window "$WINDOW_ID" \
             --run "$RUN_ID" \
-            --pipeline "tspit-ci-integration" \
+            --pipeline "thepit-ci-integration" \
             --class medium_integration \
             --qa qa/results/latest.json \
             --decision approved \
@@ -177,7 +177,7 @@ jobs:
         run: pnpm run security:scan
         continue-on-error: true  # scan targets live endpoints; may fail in CI without running server
 
-  # Single required check — aggregates all job results.
+  # Single required check - aggregates all job results.
   # Passes when: all code jobs passed, OR all were skipped (docs-only).
   # Fails when: any code job that ran has failed.
   ci-gate:
@@ -197,11 +197,11 @@ jobs:
           echo "  go-gate:     ${{ needs.go-gate.result }}"
           echo "  security:    ${{ needs.security.result }}"
 
-          # Fail if any job failed (not skipped, not cancelled — failed)
+          # Fail if any job failed (not skipped, not cancelled - failed)
           RESULTS="${{ needs.lint.result }} ${{ needs.typecheck.result }} ${{ needs.test-unit.result }} ${{ needs.integration.result }} ${{ needs.go-gate.result }} ${{ needs.security.result }}"
           for result in $RESULTS; do
             if [ "$result" = "failure" ]; then
-              echo "::error::CI gate failed — one or more jobs reported failure"
+              echo "::error::CI gate failed - one or more jobs reported failure"
               exit 1
             fi
           done

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Pit
 
+![CI](https://github.com/rickhallett/thepit/actions/workflows/ci.yml/badge.svg)
+
 A real-time AI debate arena. Language models argue structured debates while the platform generates behavioural data, tracks agent lineage, and lets users vote on outcomes.
 
 Users pick debate presets (16 formats), watch agents argue in real-time via SSE, vote on winners, and react to individual turns. Agent cloning, DNA hashing, credit economy, demo mode, BYOK for subscribers.


### PR DESCRIPTION
## Summary

Fix the GitHub Actions CI workflow to trigger on the correct default branch and update stale references from the repo migration.

## Changes

- **Branch trigger:** `master` -> `main` on push trigger (line 5). The default branch is `main`; CI was never triggering on push to main.
- **Pipeline name:** `tspit-ci-integration` -> `thepit-ci-integration` in the Level4 eval record emission. Stale reference from the pilot study repo.
- **CI badge:** Added `![CI]` badge to README.md, directly under the title.
- **Em-dash cleanup:** 3 em-dashes replaced with single dashes per SD-319.

## What was not changed

- `go-gate` job does not include `pitkeel/` or `pitlinear/` - neither has a Makefile with a `gate` target. Adding Makefiles to those dirs is a separate concern.
- Go version `1.25.7` not verified against what is actually installed - left as-is.

## Testing

- YAML syntax verified (no structural changes to workflow logic)
- This is infra/config - no application code changed, no gate run needed

Closes #6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI to trigger on `main` (was `master`), updates the Level4 pipeline name to `thepit-ci-integration`, and adds a CI status badge to the README. Also normalizes workflow comments (em-dash to single dash) per SD-319.

<sup>Written for commit 5f790ea5cef399bf8844abcdd4a3a8c5f7aa1c46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

