### PR TITLE
chore(config): add missing RESEARCH_API_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,8 @@ REMIX_REWARD_SOURCE_OWNER_MICRO=0
 # Research
 # Required in production for PII anonymization. When unset, research exports use a fixed fallback salt (not safe for production).
 RESEARCH_ANONYMIZE_SALT=
+# API key for research data endpoints
+RESEARCH_API_KEY=
 
 # App URLs
 NEXT_PUBLIC_APP_URL=http://localhost:3000


### PR DESCRIPTION
## Summary

The .env.example file was already committed and comprehensive. This adds the one missing server-side env var (`RESEARCH_API_KEY`) that exists in `lib/env.ts` but was not listed in .env.example.

## Context

Issue #8 asked for `.env.example` to be created. It already existed and was tracked in git with all required/optional vars documented. The README quick start already references it (`cp .env.example .env`). This PR closes the gap by adding the single missing variable.

## What was verified

- Compared all keys in `lib/env.ts` Zod schema against `.env.example` keys
- `RESEARCH_API_KEY` was the only server-side var missing
- `NODE_ENV` is intentionally omitted (Next.js sets it)

Closes #8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing `RESEARCH_API_KEY` to `.env.example` to match `lib/env.ts` and allow configuring research data endpoints. Completes the env list requested in issue #8.

<sup>Written for commit 1461ebb9fbf001f7be7b17acd8fadf411d4cc2d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

