### PR TITLE
chore(docs): restructure README for external legibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # The Pit
 
+![CI](https://github.com/rickhallett/thepit/actions/workflows/ci.yml/badge.svg)
+
 A real-time AI debate arena. Language models argue structured debates while the platform generates behavioural data, tracks agent lineage, and lets users vote on outcomes.
 
 Users pick debate presets (16 formats), watch agents argue in real-time via SSE, vote on winners, and react to individual turns. Agent cloning, DNA hashing, credit economy, demo mode, BYOK for subscribers.
+
+**1,289 tests | 96% coverage | TypeScript strict | zero lint errors**
 
 Live at [thepit.cloud](https://thepit.cloud).
 
@@ -15,6 +19,8 @@ pnpm install
 pnpm run dev            # http://localhost:3000
 ```
 
+Standard tooling works without the Go CLI layer or the governance infrastructure.
+
 ## Stack
 
 - **Runtime:** Next.js 16, TypeScript (strict), React 19
@@ -26,7 +32,6 @@ pnpm run dev            # http://localhost:3000
 - **Monitoring:** Sentry, PostHog
 - **Styling:** Tailwind CSS
 - **Deployment:** Vercel
-- **CLI tools:** 8 Go binaries (pitstorm, pitctl, pitforge, pitlab, pitnet, pitbench, pitlinear, pitkeel)
 
 ## Architecture
 
@@ -37,17 +42,8 @@ lib/                    Domain modules (flat files: credits.ts, bout-engine.ts, 
   lib/ai.ts             Multi-provider AI SDK configuration
 drizzle/                Schema, migrations
 components/             React components (shadcn/ui base)
-pitstorm/               Go - debate orchestration CLI
-pitctl/                 Go - admin operations
-pitforge/               Go - agent prompt engineering
-pitlab/                 Go - local dev environment
-pitnet/                 Go - network diagnostics
-pitbench/               Go - performance benchmarking
-pitlinear/              Go - linear workflow automation
-pitkeel/                Go - developer telemetry and session tracking
+tests/                  Unit, integration, API, E2E, and simulation tests
 ```
-
-Tests live in `tests/` with subdirectories for unit, integration, API, E2E, and simulation tests.
 
 ## Testing
 
@@ -58,6 +54,21 @@ pnpm run lint           # ESLint, zero errors
 ```
 
 The gate (typecheck + lint + test) must pass before any merge.
+
+## Optional CLI Toolchain
+
+Eight Go binaries for orchestration, admin, and dev tooling. These are supplementary - the application runs without them.
+
+```
+pitstorm/               Debate orchestration CLI
+pitctl/                 Admin operations
+pitforge/               Agent prompt engineering
+pitlab/                 Local dev environment
+pitnet/                 Network diagnostics
+pitbench/               Performance benchmarking
+pitlinear/              Linear workflow automation
+pitkeel/                Developer telemetry and session tracking
+```
 
 ## Development History
 


### PR DESCRIPTION
## Summary

Restructure README to put test stats and standard tooling above the fold, and move Go CLIs to a separate section. Optimised for an external evaluator's first impression.

## Changes

- **Test stats above fold:** Bold line with "1,289 tests | 96% coverage | TypeScript strict | zero lint errors" now appears before the Live link
- **Go CLIs separated:** Moved from Stack bullet and Architecture tree into new "Optional CLI Toolchain" section below Testing
- **Independence note:** Added "Standard tooling works without the Go CLI layer or the governance infrastructure" after Quick Start
- **Architecture tree:** Replaced Go CLI listings with `tests/` directory entry
- **CI badge:** Added (also in PR #36 - will need conflict resolution on merge order)

## Merge note

Both this PR and #36 add the CI badge to README.md. Merge #36 first, then this PR will have a trivial conflict on the badge line (already present vs being added again). Alternatively, merge this one and #36 becomes a no-op for the badge.

Closes #10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructured the README to better highlight test quality and make the Go CLI layer clearly optional for new readers. Added a CI badge and clarified the architecture/testing layout.

- **Refactors**
  - Put test stats above the fold and added a CI badge.
  - Moved Go CLIs to a new "Optional CLI Toolchain" section; removed them from Stack and Architecture.
  - Architecture tree now lists `tests/`; added a note that standard tooling works without the Go CLI or governance layers.

<sup>Written for commit 4a67a81be981fe8018d6d84e9c3a8985e3b7026b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

