### PR TITLE
fix(pitkeel): check shutdown exit code with retry on failure

### DIFF
--- a/pitkeel-py/daemon.py
+++ b/pitkeel-py/daemon.py
@@ -111,12 +111,32 @@ def _shutdown(dry_run: bool = False) -> None:
         _wall("PITKEEL: [DRY RUN] Would execute: shutdown now")
         return
 
-    # Literal OS shutdown — visceral by design [E1 spec, M1]
-    try:
-        subprocess.run(["shutdown", "now"], timeout=10)
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        sys.stderr.write("PITKEEL: shutdown command failed\n")
-        sys.exit(1)
+    # Literal OS shutdown - visceral by design [E1 spec, M1]
+    # Check exit code and retry once on failure before giving up.
+    for attempt in range(2):
+        try:
+            result = subprocess.run(["shutdown", "now"], timeout=10)
+            if result.returncode == 0:
+                return
+            sys.stderr.write(
+                f"PITKEEL: shutdown command failed (exit {result.returncode})"
+                f"{', retrying...' if attempt == 0 else ''}\n"
+            )
+            if attempt == 0:
+                _wall("PITKEEL: shutdown failed, retrying in 5 seconds...")
+                time.sleep(5)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            sys.stderr.write(
+                f"PITKEEL: shutdown command error: {exc}"
+                f"{', retrying...' if attempt == 0 else ''}\n"
+            )
+            if attempt == 0:
+                _wall("PITKEEL: shutdown failed, retrying in 5 seconds...")
+                time.sleep(5)
+
+    sys.stderr.write("PITKEEL: shutdown failed after 2 attempts, exiting with error\n")
+    _wall("PITKEEL: SHUTDOWN FAILED - manual intervention required")
+    sys.exit(2)
 
 
 def _check_reserves(

--- a/pitkeel-py/daemon.py
+++ b/pitkeel-py/daemon.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -35,6 +36,17 @@ from git_io import read_reserves_tsv, repo_root
 CHECK_INTERVAL = 15 * 60  # 15 minutes in seconds
 COUNTDOWN_SECONDS = 60
 GRACE_PERIOD = timedelta(minutes=10)  # T-10min warning before shutdown
+
+# Resolve shutdown binary at import time to avoid PATH hijack (S607).
+# Prefer well-known absolute paths; fall back to shutil.which.
+_SHUTDOWN_CANDIDATES = ("/usr/sbin/shutdown", "/sbin/shutdown", "/usr/bin/shutdown")
+_SHUTDOWN_BIN: str | None = None
+for _candidate in _SHUTDOWN_CANDIDATES:
+    if os.path.isfile(_candidate) and os.access(_candidate, os.X_OK):
+        _SHUTDOWN_BIN = _candidate
+        break
+if _SHUTDOWN_BIN is None:
+    _SHUTDOWN_BIN = shutil.which("shutdown")
 
 PID_FILE = os.path.join(os.path.expanduser("~"), ".pitkeel-sleep-daemon.pid")
 
@@ -113,9 +125,14 @@ def _shutdown(dry_run: bool = False) -> None:
 
     # Literal OS shutdown - visceral by design [E1 spec, M1]
     # Check exit code and retry once on failure before giving up.
+    if _SHUTDOWN_BIN is None:
+        sys.stderr.write("PITKEEL: shutdown binary not found on this system\n")
+        _wall("PITKEEL: SHUTDOWN FAILED - binary not found")
+        sys.exit(2)
+
     for attempt in range(2):
         try:
-            result = subprocess.run(["shutdown", "now"], timeout=10)
+            result = subprocess.run([_SHUTDOWN_BIN, "now"], timeout=10)
             if result.returncode == 0:
                 return
             sys.stderr.write(

--- a/pitkeel-py/test_daemon.py
+++ b/pitkeel-py/test_daemon.py
@@ -1,0 +1,133 @@
+# test_daemon.py - Integration tests for daemon shutdown failure handling.
+#
+# Tests the _shutdown function's exit-code checking and retry logic.
+# Uses subprocess mocking to simulate shutdown command failures without
+# requiring actual OS shutdown permissions.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _shutdown failure path tests
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_exits_nonzero_when_command_fails_twice(monkeypatch):
+    """When shutdown returns non-zero on both attempts, _shutdown exits with code 2."""
+    failed_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=1)
+
+    with (
+        patch("daemon.subprocess.run", return_value=failed_result) as mock_run,
+        patch("daemon._wall"),
+        patch("daemon._notify"),
+        patch("daemon.time.sleep"),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            from daemon import _shutdown
+
+            _shutdown(dry_run=False)
+
+        assert exc_info.value.code == 2
+        assert mock_run.call_count == 2
+
+
+def test_shutdown_retries_once_then_succeeds(monkeypatch):
+    """When shutdown fails first attempt but succeeds on retry, no exit."""
+    fail_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=1)
+    ok_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=0)
+
+    with (
+        patch(
+            "daemon.subprocess.run", side_effect=[fail_result, ok_result]
+        ) as mock_run,
+        patch("daemon._wall"),
+        patch("daemon._notify"),
+        patch("daemon.time.sleep"),
+    ):
+        from daemon import _shutdown
+
+        # Should return normally (no SystemExit) on second success
+        _shutdown(dry_run=False)
+
+        assert mock_run.call_count == 2
+
+
+def test_shutdown_succeeds_first_try_no_retry():
+    """When shutdown succeeds on first attempt, no retry occurs."""
+    ok_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=0)
+
+    with (
+        patch("daemon.subprocess.run", return_value=ok_result) as mock_run,
+        patch("daemon._wall"),
+        patch("daemon._notify"),
+        patch("daemon.time.sleep"),
+    ):
+        from daemon import _shutdown
+
+        _shutdown(dry_run=False)
+
+        assert mock_run.call_count == 1
+
+
+def test_shutdown_file_not_found_retries_then_exits():
+    """When shutdown binary is missing, retries once then exits with code 2."""
+    with (
+        patch(
+            "daemon.subprocess.run", side_effect=FileNotFoundError("shutdown")
+        ) as mock_run,
+        patch("daemon._wall"),
+        patch("daemon._notify"),
+        patch("daemon.time.sleep"),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            from daemon import _shutdown
+
+            _shutdown(dry_run=False)
+
+        assert exc_info.value.code == 2
+        assert mock_run.call_count == 2
+
+
+def test_shutdown_timeout_retries_then_exits():
+    """When shutdown command times out, retries once then exits with code 2."""
+    with (
+        patch(
+            "daemon.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("shutdown", 10),
+        ) as mock_run,
+        patch("daemon._wall"),
+        patch("daemon._notify"),
+        patch("daemon.time.sleep"),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            from daemon import _shutdown
+
+            _shutdown(dry_run=False)
+
+        assert exc_info.value.code == 2
+        assert mock_run.call_count == 2
+
+
+def test_shutdown_dry_run_skips_actual_command():
+    """Dry-run mode writes a message but does not call shutdown."""
+    with (
+        patch("daemon.subprocess.run") as mock_run,
+        patch("daemon._wall"),
+        patch("daemon._notify"),
+        patch("daemon.time.sleep"),
+    ):
+        from daemon import _shutdown
+
+        _shutdown(dry_run=True)
+
+        # subprocess.run should NOT be called with ["shutdown", "now"]
+        for c in mock_run.call_args_list:
+            assert c[0][0] != ["shutdown", "now"], (
+                "dry-run should not call actual shutdown"
+            )

--- a/pitkeel-py/test_daemon.py
+++ b/pitkeel-py/test_daemon.py
@@ -7,8 +7,7 @@
 from __future__ import annotations
 
 import subprocess
-import sys
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -18,11 +17,12 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def test_shutdown_exits_nonzero_when_command_fails_twice(monkeypatch):
+def test_shutdown_exits_nonzero_when_command_fails_twice():
     """When shutdown returns non-zero on both attempts, _shutdown exits with code 2."""
     failed_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=1)
 
     with (
+        patch("daemon._SHUTDOWN_BIN", "/usr/sbin/shutdown"),
         patch("daemon.subprocess.run", return_value=failed_result) as mock_run,
         patch("daemon._wall"),
         patch("daemon._notify"),
@@ -37,12 +37,13 @@ def test_shutdown_exits_nonzero_when_command_fails_twice(monkeypatch):
         assert mock_run.call_count == 2
 
 
-def test_shutdown_retries_once_then_succeeds(monkeypatch):
+def test_shutdown_retries_once_then_succeeds():
     """When shutdown fails first attempt but succeeds on retry, no exit."""
     fail_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=1)
     ok_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=0)
 
     with (
+        patch("daemon._SHUTDOWN_BIN", "/usr/sbin/shutdown"),
         patch(
             "daemon.subprocess.run", side_effect=[fail_result, ok_result]
         ) as mock_run,
@@ -63,6 +64,7 @@ def test_shutdown_succeeds_first_try_no_retry():
     ok_result = subprocess.CompletedProcess(args=["shutdown", "now"], returncode=0)
 
     with (
+        patch("daemon._SHUTDOWN_BIN", "/usr/sbin/shutdown"),
         patch("daemon.subprocess.run", return_value=ok_result) as mock_run,
         patch("daemon._wall"),
         patch("daemon._notify"),
@@ -78,6 +80,7 @@ def test_shutdown_succeeds_first_try_no_retry():
 def test_shutdown_file_not_found_retries_then_exits():
     """When shutdown binary is missing, retries once then exits with code 2."""
     with (
+        patch("daemon._SHUTDOWN_BIN", "/usr/sbin/shutdown"),
         patch(
             "daemon.subprocess.run", side_effect=FileNotFoundError("shutdown")
         ) as mock_run,
@@ -97,6 +100,7 @@ def test_shutdown_file_not_found_retries_then_exits():
 def test_shutdown_timeout_retries_then_exits():
     """When shutdown command times out, retries once then exits with code 2."""
     with (
+        patch("daemon._SHUTDOWN_BIN", "/usr/sbin/shutdown"),
         patch(
             "daemon.subprocess.run",
             side_effect=subprocess.TimeoutExpired("shutdown", 10),
@@ -126,8 +130,5 @@ def test_shutdown_dry_run_skips_actual_command():
 
         _shutdown(dry_run=True)
 
-        # subprocess.run should NOT be called with ["shutdown", "now"]
-        for c in mock_run.call_args_list:
-            assert c[0][0] != ["shutdown", "now"], (
-                "dry-run should not call actual shutdown"
-            )
+        # subprocess.run should NOT be called at all in dry-run mode
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

Fix the pitkeel sleep daemon to verify the OS shutdown command actually succeeded before exiting. Previously, `subprocess.run(["shutdown", "now"])` was called without checking the return code - a non-zero exit (e.g. permission denied) would silently fall through, the daemon would exit normally, and the operator protection system would stop enforcing.

## The bug

```python
# Before: exit code unchecked
subprocess.run(["shutdown", "now"], timeout=10)
# If shutdown returns 1 (permission denied), execution continues
# and the daemon exits its main loop normally
```

## The fix

- Check `result.returncode` after `subprocess.run`
- On non-zero exit or exception: log error, wait 5s, retry once
- If both attempts fail: broadcast via `wall`, exit with code 2
- Exit code 2 (distinct from 1) signals "shutdown was attempted but failed"

## Testing

6 new integration tests covering all paths:

| Test | Scenario |
|------|----------|
| `test_shutdown_exits_nonzero_when_command_fails_twice` | Both attempts return non-zero, exits 2 |
| `test_shutdown_retries_once_then_succeeds` | First fail, second success, no exit |
| `test_shutdown_succeeds_first_try_no_retry` | Success on first try, no retry |
| `test_shutdown_file_not_found_retries_then_exits` | Binary missing, retries, exits 2 |
| `test_shutdown_timeout_retries_then_exits` | Command timeout, retries, exits 2 |
| `test_shutdown_dry_run_skips_actual_command` | Dry-run never calls shutdown |

All tests use `unittest.mock.patch` to avoid actual OS shutdown calls.

```
60 passed (54 existing + 6 new)
```

Closes #9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the pitkeel sleep daemon verifies OS shutdown success, retries once on failure, and resolves `shutdown` via an absolute path for safety. Fulfills #9 by checking command results and signaling a distinct failure state.

- **Bug Fixes**
  - Resolve `shutdown` at import time from known absolute paths; fall back to `shutil.which`. If not found, `wall` notify and exit 2.
  - Run shutdown and proceed only on exit code 0. On non-zero or exception, `wall` notify, wait 5s, retry once.
  - After two failures, `wall` critical message and exit with code 2.
  - Keep dry-run behavior; never calls `shutdown`.
  - Add 6 integration tests for success, retry, missing binary, timeout, and dry-run; tighten assertions and remove unused fixtures.

<sup>Written for commit a80e8fb1976f5597de74e27497c8e7cb8a00b5c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability with proactive resolution of the shutdown executable and an automatic retry sequence (up to 2 attempts) before final failure.
  * Enhanced error handling, user notifications, and dry-run behavior for shutdown operations, including clearer failure exit behavior.

* **Tests**
  * Added comprehensive integration tests covering shutdown failures, retries, timeouts, missing executable, and dry-run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->