### PR TITLE
fix(docs): restore SD-323/SD-324 chain integrity and fix index

### DIFF
--- a/docs/decisions/SD-323-debian-slim.md
+++ b/docs/decisions/SD-323-debian-slim.md
@@ -1,7 +1,7 @@
 # SD-323 - debian-slim base image
 
 **Date:** 2026-03-10
-**Status:** ACTIVE
+**Status:** COMPLETE
 **Author:** Operator + Claude Code
 
 ---

--- a/docs/decisions/SD-324-c2-intercontainer.md
+++ b/docs/decisions/SD-324-c2-intercontainer.md
@@ -1,7 +1,7 @@
 # SD-324 - C2: Inter-container communication
 
 **Date:** 2026-03-10
-**Status:** ACTIVE
+**Status:** COMPLETE
 **Depends on:** C1 (done - 550bcd2)
 
 ---

--- a/docs/internal/session-decisions-index.yaml
+++ b/docs/internal/session-decisions-index.yaml
@@ -1,14 +1,14 @@
 # session-decisions-index.yaml
 # Manually curated for noopit (thepit-v2) boot sequence.
-# Full chain: docs/internal/session-decisions.md (312+ entries from SD-001, append-only per SD-266)
+# Full chain: docs/internal/session-decisions.md (SD-001 to SD-324, append-only per SD-266)
 #
 # This is the BOOT file. Read this for orientation, not the full log.
 # The full log is for provenance and archaeology.
-# Only last 10 SDs shown here - read full file for deeper history.
+# Recent SDs shown here - read full file for deeper history.
 
-generated: "2026-03-10T14:30:00.000Z"
-total_decisions: 322
-range: "SD-001 to SD-322"
+generated: "2026-03-12T16:00:00.000Z"
+total_decisions: 324
+range: "SD-001 to SD-324"
 note: "Chain carries forward from tspit (pilot study). noopit is thepit-v2 - diverged at SD-278."
 
 # Standing orders that carry forward (always active)
@@ -25,6 +25,10 @@ standing_orders:
     label: "agentic-estimation-reducer"
     summary: "All estimates assume agentic execution speed. Operator's time is scarce; agent time is abundant."
     status: "PERMANENT"
+  - id: SD-278
+    label: "stage-magnum"
+    summary: "Pilot study over."
+    status: "PERMANENT LOCKED"
   - id: SD-286
     label: "slopodar-boot"
     summary: "Slopodar is mandatory reading for all agents on load. 49 entries."
@@ -34,7 +38,7 @@ standing_orders:
     summary: "SD number collisions resolved by forward-ref, not rewrite (SD-266)."
     status: "STANDING ORDER"
 
-# Last 10 SDs - orientation for cold boot
+# Recent SDs - orientation for cold boot
 recent:
   - id: SD-308
     label: "thepit-v2-created"
@@ -96,3 +100,11 @@ recent:
     label: "midget-castle"
     summary: "First build trajectory for midgets. Three phases: (A) agent in container - gate, tmux, OCR, Chromium, agent framework; (B) governance adaptation - SPEC.md, Makefile rewrite, containerised gauntlet, EVAL.md; (C) multi-agent coordination - job server, inter-container comms, orchestration, governance crew as physical agents. Gate first. Plan file: PLAN.md (root)."
     status: "ACTIVE"
+  - id: SD-323
+    label: "debian-slim"
+    summary: "Switch midget container base from ubuntu:24.04 to debian:bookworm-slim. Smaller image, reduced attack surface. Migration finding: xterm fonts required xfonts-base + fonts-dejavu-core. All 29 tests pass."
+    status: "COMPLETE"
+  - id: SD-324
+    label: "c2-intercontainer"
+    summary: "Inter-container communication via Docker named volumes. Two midgets share volume at /opt/jobs. File-based job protocol from C1 is the transport. Proven by convergence check. New target: make interop."
+    status: "COMPLETE"

--- a/docs/internal/session-decisions.md
+++ b/docs/internal/session-decisions.md
@@ -638,3 +638,15 @@ The Operator extended this acknowledgment to all crew members, noting the closes
 | SD-321 | [signal-killed] **Operator verbatim:** "Signal has no signal. Kill it." Signal notation abandoned as a governance compression mechanism. Adversarial test [SD-320] showed shorthand achieves equal or better compression with equal decode accuracy (16/16 vs 15/16). The := -> | & ! operators add no measurable value over bullets and dashes. Data: `data/signal-test/`, design: `docs/weaver/signal-vs-shorthand-adversarial-test.md`, script: `bin/signal-test`. | Operator | **PERMANENT** |
 
 | SD-322 | [midget-castle] **First build trajectory for midgets.** Three phases: (A) get an agent operating inside the container - gate, terminal protocol, OCR, Chromium, agent framework; (B) adapt governance for midgets - SPEC.md, rewrite Makefile targets, containerised gauntlet, EVAL.md; (C) multi-agent coordination - job server, inter-container comms, orchestration, governance crew as physical agents. Gate (A1) comes first because everything builds on verification. Plan file: `PLAN.md` (root, d1). | Operator (direction) / Weaver (sequencing) | **ACTIVE** |
+
+---
+
+## 2026-03-10 - Session (Container Infrastructure)
+
+### Decisions Made
+
+| ID | Decision | Made By | Status |
+|----|----------|---------|--------|
+| SD-323 | [debian-slim] **Switch midget container base from ubuntu:24.04 to debian:bookworm-slim.** Ubuntu 24.04 is ~200MB uncompressed; Debian Bookworm Slim is ~75MB. Minimum surface, minimum assumption. Risk analysis confirmed all required packages (xvfb, fluxbox, xdotool, scrot, xclip, wmctrl, x11-utils, xterm, tmux, tesseract-ocr, python3, wget) exist with identical names. google-chrome-stable .deb resolves against Bookworm repos. Wolfi rejected (no dpkg, no X11 toolchain). Migration finding: xterm bitmap fonts unreadable by tesseract on Slim without recommends - fixed by adding xfonts-base + fonts-dejavu-core and launching xterm in XFT mode. All 29 tests pass. Decision file: `docs/decisions/SD-323-debian-slim.md`. | Operator + Claude Code | **COMPLETE** |
+
+| SD-324 | [c2-intercontainer] **Inter-container communication via Docker named volumes.** Depends on C1 (550bcd2). Two midgets share a named volume at /opt/jobs. Midget-A writes an artifact, Midget-B reads it - proven by convergence check (output match). File-based job protocol from C1 is the transport. No TCP, no message bus. Test: `test-c2.sh` runs on host, orchestrates two containers with `docker run`. New target: `make interop` (distinct from `make gate` - single-container vs multi-container verification). Decision file: `docs/decisions/SD-324-c2-intercontainer.md`. | Operator + Claude Code | **COMPLETE** |


### PR DESCRIPTION
## Summary

Closes #44

SD-323 (debian-slim) and SD-324 (c2-intercontainer) were created as standalone decision files on 2026-03-10 but never appended to the canonical chain or properly reflected in the index. This PR closes that chain integrity gap per SD-266.

## Changes

- **session-decisions.md**: Append SD-323 and SD-324 in table format matching the surrounding 2026-03-10 session entries. New session header "Container Infrastructure" added (the existing 2026-03-10 session covers a different topic).
- **session-decisions-index.yaml**: Fix header comment (stale "312+"), update total_decisions 322->324, update range to SD-324, remove hardcoded "last 10 SDs" claim, add SD-278 (stage-magnum) to standing_orders (was missing vs AGENTS.md), add SD-323/SD-324 to recent section in correct ID order.
- **SD-323-debian-slim.md**: Status ACTIVE -> COMPLETE (implementation was completed per commit history).
- **SD-324-c2-intercontainer.md**: Status ACTIVE -> COMPLETE (implementation was completed per commit history).

## What was tested

- Full gate: typecheck (pass) + lint (0 errors, 26 pre-existing warnings) + test:ci (1289 passed, 29 skipped)
- 7 acceptance criteria verified: chain ends at SD-324, index counts match, ordering correct, no em-dashes in new content, SD-323/SD-324 in both chain and index, standalone files say COMPLETE

## Technical decisions

- Used table format for chain entries (matching the format used by surrounding SD-319 through SD-322 in the same era)
- New content uses `-` not em-dashes per SD-319 (existing immutable entries retain their em-dashes per SD-266)
- Content extracted from the actual standalone decision files, not from the plan template summaries

## Collision note

Per SD-297, a prior session refers to SD-323 as "no-stash" (in PR #43's worktree). The actual SD-323 on disk is "debian-slim". The no-stash policy will become SD-325 when PR #43 merges. This PR does not create SD-325.

Gate: typecheck + lint + test:ci = green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore chain integrity by appending SD-323 and SD-324 to the canonical log and syncing the index. The chain now runs SD-001–SD-324, and both decisions are marked COMPLETE.

- **Bug Fixes**
  - Append SD-323 (debian-slim) and SD-324 (c2-intercontainer) to `docs/internal/session-decisions.md` under a new 2026-03-10 "Container Infrastructure" session.
  - Update `docs/internal/session-decisions-index.yaml`: correct header and counts (now SD-001 to SD-324), add missing `SD-278` to standing_orders, and list SD-323/SD-324 in recent.
  - Set `docs/decisions/SD-323-debian-slim.md` and `docs/decisions/SD-324-c2-intercontainer.md` status to COMPLETE.

<sup>Written for commit faacce5aee5760cd41485c7a73488ab511647309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architectural decision records marking container infrastructure decisions as complete.
  * Added documentation for container optimization strategy using lightweight base images.
  * Documented inter-container communication approach via named volumes.
  * Updated decision tracking index to reflect latest architectural decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->