### PR TITLE
chore(docs): fix stale references in remaining docs (P6 audit)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,7 @@ startup_timeout_sec = 30
 
 [smoke_targets.sentry]
 region_url = "https://us.sentry.io"
+# NOTE: organization_slug is from a prior employer (Brandwatch). Update if Sentry is configured for thepit.
 organization_slug = "brandwatch-77a365983"
 project_slug = "thepit"
 project_id = "4510870484746240"

--- a/docs/building.md
+++ b/docs/building.md
@@ -33,7 +33,7 @@ The disciplined response: **acknowledge, isolate, defer.** Capture the knowledge
 
 This applies beyond dependencies. It applies to any category of finding where the fix generates more findings of the same category. The test is: does fixing this now move the product forward, or does it move the goalposts?
 
-*This principle was learned during the type safety triage (PRs [#319](https://github.com/rickhallett/thepit/pull/319)–[#327](https://github.com/rickhallett/thepit/pull/327)), where 8 fixes across 9 PRs generated 6 rounds of automated review findings. The acknowledge-isolate-defer pattern was applied to pre-existing CI failures ([#330](https://github.com/rickhallett/thepit/issues/330)) and the remaining dependency vulnerabilities — the decision recorded in the issue, not re-debated on each red build.*
+*This principle was learned during the type safety triage (PRs [#319](https://github.com/rickhallett/thepit-pilot/pull/319)-[#327](https://github.com/rickhallett/thepit-pilot/pull/327)), where 8 fixes across 9 PRs generated 6 rounds of automated review findings. The acknowledge-isolate-defer pattern was applied to pre-existing CI failures ([#330](https://github.com/rickhallett/thepit-pilot/issues/330)) and the remaining dependency vulnerabilities - the decision recorded in the issue, not re-debated on each red build.*
 
 ## The human in the loop
 
@@ -56,7 +56,7 @@ We have not seen it proven at the level of enduring product that interfaces with
 If you contribute to this codebase:
 
 - **Run the local gate before you declare anything done.** The gate is not a suggestion. It is the minimum bar.
-- **Fix before merge if you can. Fix after merge if you must.** The first preserves atomicity. The second preserves forward progress. *(Derived from PRs [#325](https://github.com/rickhallett/thepit/pull/325)–[#328](https://github.com/rickhallett/thepit/pull/328); codified in [Weaver agent instructions](https://github.com/rickhallett/thepit/pull/328).)*
+- **Fix before merge if you can. Fix after merge if you must.** The first preserves atomicity. The second preserves forward progress. *(Derived from PRs [#325](https://github.com/rickhallett/thepit-pilot/pull/325)-[#328](https://github.com/rickhallett/thepit-pilot/pull/328); codified in [Weaver agent instructions](https://github.com/rickhallett/thepit-pilot/pull/328).)*
 - **Name what you find.** If a pattern has a name, the next person who encounters it will recognise it faster. If it doesn't have a name yet, give it one and document where you found it.
-- **Don't optimise for everything simultaneously.** A longer list of truths does not mean they can all be caught and actioned every time. Truths often exist in creative tension. The skill is knowing which one to prioritise right now, and recording why, so the next person can make a different choice with full context rather than no context. *(See [#330](https://github.com/rickhallett/thepit/issues/330) for a worked example of this trade-off.)*
+- **Don't optimise for everything simultaneously.** A longer list of truths does not mean they can all be caught and actioned every time. Truths often exist in creative tension. The skill is knowing which one to prioritise right now, and recording why, so the next person can make a different choice with full context rather than no context. *(See [#330](https://github.com/rickhallett/thepit-pilot/issues/330) for a worked example of this trade-off.)*
 - **Trust is the product.** The code is the output. The tests are the evidence. The verification discipline is the craft. The trust is what remains.

--- a/docs/orchestration-layer-starting-template.md
+++ b/docs/orchestration-layer-starting-template.md
@@ -1,6 +1,9 @@
 <!-- HISTORICAL: Orphaned template from the pilot study (tspit). Retained for reference.
      Current orchestration patterns live in AGENTS.md. -->
 
+> **Note:** References to `tasks/todo.md` and `tasks/lessons.md` below are from the pilot study.
+> The `tasks/` directory does not exist in this repo. Current task tracking uses `docs/internal/backlog.yaml`.
+
 ```markdown
 ## Workflow Orchestration
 

--- a/sites/oceanheart/content/decisions/sd-031.md
+++ b/sites/oceanheart/content/decisions/sd-031.md
@@ -1,0 +1,5 @@
++++
+title = "SD-031"
+id = "SD-031"
+type = "decisions"
++++

--- a/sites/oceanheart/content/decisions/sd-032.md
+++ b/sites/oceanheart/content/decisions/sd-032.md
@@ -1,0 +1,5 @@
++++
+title = "SD-032"
+id = "SD-032"
+type = "decisions"
++++

--- a/sites/oceanheart/content/decisions/sd-033.md
+++ b/sites/oceanheart/content/decisions/sd-033.md
@@ -1,0 +1,5 @@
++++
+title = "SD-033"
+id = "SD-033"
+type = "decisions"
++++

--- a/sites/oceanheart/content/decisions/sd-034.md
+++ b/sites/oceanheart/content/decisions/sd-034.md
@@ -1,0 +1,5 @@
++++
+title = "SD-034"
+id = "SD-034"
+type = "decisions"
++++

--- a/sites/oceanheart/content/decisions/sd-035.md
+++ b/sites/oceanheart/content/decisions/sd-035.md
@@ -1,0 +1,5 @@
++++
+title = "SD-035"
+id = "SD-035"
+type = "decisions"
++++

--- a/sites/oceanheart/content/decisions/sd-036.md
+++ b/sites/oceanheart/content/decisions/sd-036.md
@@ -1,0 +1,5 @@
++++
+title = "SD-036"
+id = "SD-036"
+type = "decisions"
++++


### PR DESCRIPTION
## Summary

Fix stale references in miscellaneous docs not covered by P1-P5 audit fix plans.

- **5 GitHub links** in `docs/building.md` repointed from `thepit` to `thepit-pilot` (PRs #319-#328, issue #330 belong to the pilot repo)
- **Historical annotation** added to `docs/orchestration-layer-starting-template.md` for stale `tasks/` directory references (body preserved per SD-266)
- **Staleness comment** added to `config.toml` Sentry org slug (Brandwatch, prior employer) - value unchanged, Operator decides replacement
- **6 Hugo SD stubs** created (`sd-031.md` through `sd-036.md`) filling the gap in `sites/oceanheart/content/decisions/`
- **Hugo wake branch links** (10 across 5 files) verified accessible via `gh api` - no changes needed (Option A)

## Technical decisions

- Em-dashes in the link range text (`#319-#327`) replaced with single dashes per SD-319. Pre-existing em-dashes in body prose not touched (outside scope, historical content).
- SD stubs follow the exact format of adjacent stubs (sd-030.md, sd-037.md): TOML frontmatter with title, id, type fields only.
- config.toml value left unchanged with annotation comment - Operator judgment call on replacement.

## What was tested

- Gate: `pnpm run test:ci` (lint + typecheck + 1289 tests passed)
- `grep` verification: no remaining `thepit/pull/` or `thepit/issues/` links in building.md (all now `thepit-pilot/`)
- SD stub existence: all 6 files confirmed present
- Em-dash/emoji check: diff clean

## Scope boundary

Does not touch: AGENTS.md (P1), session-decisions.md (P2), boot-sequence/dead-reckoning/gauntlet (P3), agent files (P4), justfile/README (P5), Hugo `public/` generated output.

## Fix plan

`docs/internal/janitor/audit/fix-plans/P6-remaining-docs.md`

Closes #52

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up stale references across remaining docs (P6 audit). Repointed links to `thepit-pilot`, added historical context, created missing SD stubs, and annotated a stale Sentry slug.

- **Bug Fixes**
  - Repointed 5 GitHub links in `docs/building.md` from `thepit` to `thepit-pilot`; replaced em-dash ranges with single dashes per SD-319.
  - Added a historical note in `docs/orchestration-layer-starting-template.md` for old `tasks/` references; pointed to `docs/internal/backlog.yaml`.
  - Annotated the Sentry `organization_slug` in `config.toml` as stale (Brandwatch); value unchanged for operator follow-up.
  - Added 6 missing Hugo SD stubs (`sd-031`–`sd-036`) with minimal TOML frontmatter.
  - Verified 10 Hugo wake-branch links via `gh api`; no changes needed.

<sup>Written for commit b0524279125795b2f31dd80f2dace87d5b60dedb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

