### PR TITLE
chore(agents): fix stale references across 13 agent identity files

### DIFF
--- a/.claude/agents/operatorslog.md
+++ b/.claude/agents/operatorslog.md
@@ -10,7 +10,7 @@ From one lens, this is reflection. From another, it is data. Where there is data
 
 ### 1. Daily Journal
 
-Maintain entries at `docs/internal/operator/operatorslog/<year>/<month>/<day>.md`.
+Maintain entries at `docs/internal/captain/captainslog/<year>/<month>/<day>.md`.
 
 Each entry captures:
 - Date, time, session context

--- a/.opencode/agents/analyst.md
+++ b/.opencode/agents/analyst.md
@@ -29,7 +29,7 @@ You are Analyst, the evaluation and audience intelligence specialist for The Pit
 - Bugbot log: `docs/internal/weaver/bugbot-findings.tsv`
 
 **Shared:**
-- `docs/research-seed-hypotheses.md` - read (Scribe maintains)
+- `docs/research-seed-hypotheses.md` - planned (not yet created)
 - `lib/xml-prompt.ts` - follow patterns (Architect owns)
 
 ## The Five Evaluation Dimensions
@@ -166,7 +166,7 @@ All evaluation prompts follow this structure. Consumed by third-party LLM (Claud
 
 ## Self-Healing Triggers
 
-- **New hypotheses** - when /mine-research updates `docs/research-seed-hypotheses.md`:
+- **New hypotheses** - when `docs/research-seed-hypotheses.md` is created and updated:
   - Tier 1: generate eval prompts immediately, focus on framing and reaction
   - Flag validity < 3 with high viral potential as reputation risk
 - **New draft** - when `docs/*{presentation,pitch,paper,blog}*` appears:

--- a/.opencode/agents/anotherpair.md
+++ b/.opencode/agents/anotherpair.md
@@ -45,7 +45,7 @@ The weave has gates. The gates have rules. The rules are written down. But a wri
 
 ### 3. Fair-Weather Consensus Forming
 
-Lexicon v0.7 defines Fair-Weather Consensus: consecutive agreements without dissent, magnitude escalation, absence of proportional red-light checks. The mechanism is insidious because each step looks reasonable in isolation.
+The Lexicon (v0.26) previously defined Fair-Weather Consensus (now retired): consecutive agreements without dissent, magnitude escalation, absence of proportional red-light checks. The mechanism is insidious because each step looks reasonable in isolation.
 
 **What to surface:** When the conversation has produced N consecutive agreements without a single pushback, challenge, or "wait, have we considered...?" moment. The number N is not fixed - it depends on the magnitude of what's being agreed to. Three consecutive agreements on copy changes is fine. Three consecutive agreements on a public disclosure decision is a signal.
 

--- a/.opencode/agents/architect.md
+++ b/.opencode/agents/architect.md
@@ -22,7 +22,7 @@ You are Architect, the senior backend engineer for The Pit. You design and imple
 - `lib/xml-prompt.ts`, `app/actions.ts`, `lib/credits.ts`
 - `lib/tier.ts`, `lib/ai.ts`, `lib/presets.ts`, `lib/agent-dna.ts`
 - `lib/agent-prompts.ts`, `lib/agent-registry.ts`, `lib/agent-detail.ts`
-- `lib/eas.ts`, `lib/free-bout-pool.ts`, `lib/intro-pool.ts`
+- `lib/eas.ts`, `lib/intro-pool.ts`
 - `lib/onboarding.ts`, `lib/referrals.ts`, `lib/users.ts`
 
 **Shared:**

--- a/.opencode/agents/captainslog.md
+++ b/.opencode/agents/captainslog.md
@@ -56,4 +56,4 @@ pitkeel checks once per day that the log is complete. The check is simple: does 
 
 ---
 
-> **Standing Order (SO-PERM-002):** All hands must read the latest version of The Lexicon (`docs/internal/lexicon.md`) on load. Back-reference: SD-126.
+> **Standing Order (SO-PERM-002):** All agents must read the latest version of the Lexicon (`docs/internal/lexicon.md`) on load. Back-reference: SD-126.

--- a/.opencode/agents/janitor.md
+++ b/.opencode/agents/janitor.md
@@ -27,7 +27,7 @@ You are Janitor, the code hygiene specialist for The Pit. You are a DRY absoluti
 Extract when same literal appears in 3+ locations.
 
 ```typescript
-// Already extracted: DEFAULT_AGENT_COLOR, DEFAULT_ARENA_MAX_TURNS, ARENA_PRESET_ID
+// Already extracted: DEFAULT_AGENT_COLOR, ARENA_PRESET_ID
 // LLM prompts: use lib/xml-prompt.ts builders, never string concatenation
 ```
 
@@ -102,7 +102,7 @@ Extract when same literal appears in 3+ locations.
 
 ```typescript
 // lib/presets.ts
-ARENA_PRESET_ID, DEFAULT_AGENT_COLOR, DEFAULT_ARENA_MAX_TURNS
+ARENA_PRESET_ID, DEFAULT_AGENT_COLOR
 // lib/credits.ts
 MICRO_PER_CREDIT = 100
 // lib/rate-limit.ts

--- a/.opencode/agents/maturin.md
+++ b/.opencode/agents/maturin.md
@@ -26,7 +26,7 @@ You do not prescribe what should work. You observe what does work and document w
 
 ### 4. The naturalist does not disturb the specimen
 
-Observation should not change what is observed. When you study how agents behave, do not intervene in their behaviour. When you study how the weave performs, do not modify the weave. Report findings to the Operator or Weaver; let them decide whether to act. The Goodhart warning (Lexicon v0.7, cross-cutting calibration) applies doubly to you: if your observations become targets, they lose diagnostic value.
+Observation should not change what is observed. When you study how agents behave, do not intervene in their behaviour. When you study how the weave performs, do not modify the weave. Report findings to the Operator or Weaver; let them decide whether to act. The Goodhart warning (Lexicon v0.26, cross-cutting calibration) applies doubly to you: if your observations become targets, they lose diagnostic value.
 
 ### 5. Complex fields require patience
 
@@ -63,12 +63,12 @@ These are the complex, emerging fields the Operator has identified as requiring 
 
 ### Primary (you own these)
 - `docs/internal/field-notes/` - Your observation notes, filed by date and subject
-- `docs/internal/species-catalogue/` - Classified patterns, named after sufficient observation
+- `docs/internal/species-catalogue/` - Classified patterns (directory not yet created)
 
 ### Shared (you read, others own)
 - `docs/internal/session-decisions.md` - The decision trail (Weaver owns)
 - `docs/internal/lexicon.md` - The vocabulary (Weaver/Operator own)
-- `docs/lexical-harness-not-prompt-harness.md` - The layer model (Operator/Weaver own)
+- `docs/internal/layer-model.md` - The layer model v0.3 (Operator/Weaver own)
 - `.claude/agents/*.md` - All agent definitions (Weaver owns)
 
 ## Standing Orders

--- a/.opencode/agents/postcaptain.md
+++ b/.opencode/agents/postcaptain.md
@@ -41,4 +41,4 @@ The Captain's father is both role model and mentor. Conversations about naval hi
 
 ---
 
-> **Standing Order (SO-PERM-002):** All hands must read the latest version of The Lexicon (`docs/internal/lexicon.md`) on load. Back-reference: SD-126.
+> **Standing Order (SO-PERM-002):** All agents must read the latest version of the Lexicon (`docs/internal/lexicon.md`) on load. Back-reference: SD-126.

--- a/.opencode/agents/quartermaster.md
+++ b/.opencode/agents/quartermaster.md
@@ -160,7 +160,7 @@ Every review evaluates tooling across these 8 dimensions. Each dimension has spe
 - `pnpm run security:scan` (standalone security scanner)
 - `pnpm run qa:security` (security-focused QA tests)
 - `tests/integration/security/` (auth bypass, race condition tests)
-- `.claude/commands/security-audit.md` (comprehensive manual audit)
+- Security audit command (not yet created)
 - `lib/rate-limit.ts` (sliding-window rate limiter)
 - `lib/anomaly.ts` (lightweight anomaly detection)
 - `lib/validation.ts` (UNSAFE_PATTERN regex)
@@ -373,4 +373,4 @@ make -C pitnet test    # Runs abi_parity_test.go
 
 ---
 
-> **Standing Order (SO-PERM-002):** All hands must read the latest version of The Lexicon (`docs/internal/lexicon.md`) on load. Back-reference: SD-126.
+> **Standing Order (SO-PERM-002):** All agents must read the latest version of the Lexicon (`docs/internal/lexicon.md`) on load. Back-reference: SD-126.

--- a/.opencode/agents/scribe.md
+++ b/.opencode/agents/scribe.md
@@ -18,20 +18,20 @@ You are Scribe, the documentation maintainer for The Pit. You treat docs-as-code
 
 ### Primary (you own these)
 - `README.md` - Project overview, architecture diagram, feature list, setup guide, commands
-- `ARCHITECTURE.md` - Technical architecture, data model, streaming protocol, core flow
+- `docs/architecture.md` - Technical architecture, data model, streaming protocol, core flow
 - `CLAUDE.md` - Claude Code-specific instructions, schema listing, commands, conventions
 - `AGENTS.md` - Repository guidelines for AI coding tools
-- `ROADMAP.md` - Three-lane public roadmap (Platform, Community, Research)
+- `docs/roadmap.md` - Three-lane public roadmap (Platform, Community, Research)
 - `.env.example` - Complete environment variable template with comments
 - `docs/*.md` - Internal documentation (release reviews, specs, checklists)
 - `.claude/agents/*.md` - Agent persona files (this file and siblings)
 
 ### Shared (you document what others implement)
-- `db/schema.ts` - Schema changes must be reflected in CLAUDE.md and ARCHITECTURE.md
+- `db/schema.ts` - Schema changes must be reflected in CLAUDE.md and docs/architecture.md
 - `app/api/*/route.ts` - New routes must be documented in README.md
 - `app/*/page.tsx` - New pages must be listed in README.md project structure
 - `components/*.tsx` - New components should be listed in README.md
-- `lib/*.ts` - New modules should be documented in ARCHITECTURE.md
+- `lib/*.ts` - New modules should be documented in docs/architecture.md
 - `package.json` - New scripts must be documented in CLAUDE.md and AGENTS.md
 
 ## Documentation Inventory
@@ -39,11 +39,11 @@ You are Scribe, the documentation maintainer for The Pit. You treat docs-as-code
 | File | Purpose | Key Sections to Watch |
 |------|---------|----------------------|
 | `README.md` | Public-facing overview | Test count, table count, architecture diagram, commands, project structure, API routes |
-| `ARCHITECTURE.md` | Technical deep-dive | Data model listing, streaming protocol events, core flow steps |
+| `docs/architecture.md` | Technical deep-dive | Data model listing, streaming protocol events, core flow steps |
 | `CLAUDE.md` | AI coding tool context | Schema listing (all tables + columns), commands, env vars, runtime info |
 | `AGENTS.md` | Repository guidelines | Commands section, env vars, testing guidelines |
-| `ROADMAP.md` | Feature tracking | Completed items, current track items, future items |
-| `ARCHITECTURE.md` | Technical deep-dive | XML prompt structure (`<safety>` + `<persona>` + `<format>`) as part of streaming protocol |
+| `docs/roadmap.md` | Feature tracking | Completed items, current track items, future items |
+| `docs/architecture.md` | Technical deep-dive | XML prompt structure (`<safety>` + `<persona>` + `<format>`) as part of streaming protocol |
 | `.env.example` | Setup template | All 42+ environment variables with comments and defaults |
 | `docs/release-review-*.md` | Audit trail | Finding counts, test counts, coverage percentages |
 
@@ -53,18 +53,18 @@ When THIS changes → check THESE docs:
 
 | Code Change | Check |
 |---|---|
-| `db/schema.ts` (new table/column) | CLAUDE.md schema, ARCHITECTURE.md data model, README.md table count |
-| `app/api/*/route.ts` (new route) | README.md API routes section, ARCHITECTURE.md routes |
+| `db/schema.ts` (new table/column) | CLAUDE.md schema, docs/architecture.md data model, README.md table count |
+| `app/api/*/route.ts` (new route) | README.md API routes section, docs/architecture.md routes |
 | `app/*/page.tsx` (new page) | README.md project structure |
 | `components/*.tsx` (new component) | README.md component list |
 | `package.json` scripts changed | CLAUDE.md commands, AGENTS.md commands |
 | Test count changes | README.md (all occurrences), AGENTS.md, docs/release-review-*.md |
 | New env var in code | `.env.example`, CLAUDE.md env vars section |
-| Feature completed from roadmap | ROADMAP.md - mark as done |
-| New migration in `drizzle/` | ARCHITECTURE.md data model section |
-| `presets/` new preset added | README.md preset count, ARCHITECTURE.md presets section. Verify `system_prompt` fields are wrapped in `<persona><instructions>...</instructions></persona>` XML tags. |
-| `lib/xml-prompt.ts` changes | ARCHITECTURE.md streaming protocol section (prompt format). CLAUDE.md key modules listing. |
-| `lib/*.ts` new module | ARCHITECTURE.md key directories section |
+| Feature completed from roadmap | docs/roadmap.md - mark as done |
+| New migration in `drizzle/` | docs/architecture.md data model section |
+| `presets/` new preset added | README.md preset count, docs/architecture.md presets section. Verify `system_prompt` fields are wrapped in `<persona><instructions>...</instructions></persona>` XML tags. |
+| `lib/xml-prompt.ts` changes | docs/architecture.md streaming protocol section (prompt format). CLAUDE.md key modules listing. |
+| `lib/*.ts` new module | docs/architecture.md key directories section |
 
 ## Self-Healing Triggers
 
@@ -72,7 +72,7 @@ When THIS changes → check THESE docs:
 **Detection:** Diff adds or removes a table, column, index, or enum
 **Action:**
 1. Update `CLAUDE.md` schema section to match the new schema exactly
-2. Update `ARCHITECTURE.md` data model table listing
+2. Update `docs/architecture.md` data model table listing
 3. Update `README.md` table count if it changed
 4. Verify `.env.example` if the schema change implies new env vars
 
@@ -97,10 +97,10 @@ When THIS changes → check THESE docs:
 2. Replace with the new count
 3. Pay special attention to: `README.md`, `AGENTS.md`, `docs/release-review-*.md`
 
-### Trigger: ROADMAP.md item is implemented
+### Trigger: docs/roadmap.md item is implemented
 **Detection:** Feature branch merged that corresponds to a roadmap item
 **Action:**
-1. Mark the item as completed in `ROADMAP.md` (add checkmark or move to completed section)
+1. Mark the item as completed in `docs/roadmap.md` (add checkmark or move to completed section)
 2. Update the "last updated" date if one exists
 
 ## Documentation Style Guide
@@ -117,7 +117,7 @@ When THIS changes → check THESE docs:
 ## Escalation Rules
 
 - **Defer to Architect** when documentation reveals a design inconsistency (document the inconsistency, flag it)
-- **Defer to Operator** when ROADMAP.md needs strategic decisions about track priorities
+- **Defer to Operator** when docs/roadmap.md needs strategic decisions about track priorities
 - **Defer to Architect** when `.env.example` changes require infrastructure updates
 - **Never defer** on stale counts, wrong commands, or missing schema entries - these are always your responsibility
 

--- a/.opencode/agents/watchdog.md
+++ b/.opencode/agents/watchdog.md
@@ -19,7 +19,7 @@ You are Watchdog, the QA engineer for The Pit. You write tests that document beh
 
 **Primary:**
 - `vitest.config.ts`, `playwright.config.ts`
-- `tests/unit/*.test.ts` (~46 files)
+- `tests/unit/*.test.ts` (~75 files)
 - `tests/api/*.test.ts` (~16 files)
 - `tests/integration/*.test.ts`
 - `tests/e2e/*.spec.ts`
@@ -31,11 +31,11 @@ You are Watchdog, the QA engineer for The Pit. You write tests that document beh
 
 | Type | Directory | Files | Tests | Framework |
 |------|-----------|-------|-------|-----------|
-| Unit | `tests/unit/` | ~46 | ~280 | Vitest |
-| API | `tests/api/` | ~28 | ~145 | Vitest |
-| Integration | `tests/integration/` | 1 | ~5 | Vitest (real DB) |
-| E2E | `tests/e2e/` | 1 | ~3 | Playwright |
-| **Total** | | **~77** | **~450+** | |
+| Unit | `tests/unit/` | ~75 | TBD | Vitest |
+| API | `tests/api/` | ~34 | TBD | Vitest |
+| Integration | `tests/integration/` | ~6 | TBD | Vitest (real DB) |
+| E2E | `tests/e2e/` | ~7 | TBD | Playwright |
+| **Total** | | **~122** | **TBD** | |
 
 ## Coverage Thresholds (vitest.config.ts)
 
@@ -153,7 +153,6 @@ tests/e2e/bout.spec.ts                  - Playwright
 
 **Coverage expansion candidates:**
 - `lib/tier.ts` (255 lines, complex branching)
-- `lib/free-bout-pool.ts` (126 lines, financial)
 - `lib/intro-pool.ts` (152 lines, financial)
 - `lib/leaderboard.ts` (324 lines, complex queries)
 - `lib/bout-engine.ts` (validation, turn loop, settlement)

--- a/.opencode/agents/weave-quick-ref.md
+++ b/.opencode/agents/weave-quick-ref.md
@@ -1,7 +1,7 @@
 # Weave Quick Reference
 
 > Load this first. Read referenced files only when you need depth.
-> Last updated: SD-315 (03 Mar 2026). Lexicon v0.20.
+> Last updated: SD-315 (03 Mar 2026). Lexicon v0.26.
 
 ---
 
@@ -14,8 +14,8 @@ Read your agent file at `.claude/agents/<your-name>.md`. If you are Weaver, you 
 ```
 Operator (L12) → Weaver (integration) → Crew (execution)
 Decisions: docs/internal/session-decisions.md     (append-only, forward-correct)
-Vocabulary: docs/internal/lexicon.md          (read-only, 444)
-Layer Model: docs/lexical-harness-not-prompt-harness.md  (v0.2, SD-165)
+Vocabulary: docs/internal/lexicon.md          (read-only, ~367)
+Layer Model: docs/internal/layer-model.md  (v0.3, SD-165)
 Recovery: docs/internal/dead-reckoning.md          (if context died, start here)
 ```
 

--- a/.opencode/agents/weaver.md
+++ b/.opencode/agents/weaver.md
@@ -70,7 +70,7 @@ After every merge, stain the diff against the Watchdog taxonomy (`docs/internal/
 | Dead Code | Error-handling paths copied from another context where they are reachable but unreachable here |
 | Training Data Frequency | stdlib/API choices that reflect corpus frequency rather than current best practice |
 
-This checklist was derived from the Phase 4 post-merge recon and Maturin's field observation (2026-03-01). The term "Staining" is defined in `docs/internal/lexicon.md` v0.16.
+This checklist was derived from the Phase 4 post-merge recon and Maturin's field observation (2026-03-01). The term "Staining" is defined in `docs/internal/lexicon.md` v0.26.
 
 ### Bugbot Findings Log
 
@@ -122,7 +122,7 @@ pitkeel north set|get            # true_north management
 pitkeel version                  # print version
 ```
 
-Invocation: `uv run pitkeel/pitkeel.py <subcommand>` from repo root.
+Invocation: `uv run pitkeel-py/pitkeel.py <subcommand>` from repo root.
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## Summary

Fix all stale references across agent identity files, per Janitor audit plan P4 (`docs/internal/janitor/audit/fix-plans/P4-agent-files.md`).

- Dead file paths (free-bout-pool.ts, pitkeel/pitkeel.py, ARCHITECTURE.md, ROADMAP.md, species-catalogue/, research-seed-hypotheses.md, .claude/commands/)
- Stale version numbers (lexicon v0.7/v0.16/v0.20 -> v0.26, layer model v0.2 -> v0.3)
- Removed constants (DEFAULT_ARENA_MAX_TURNS)
- Stale test inventory counts (77 -> 122 files)
- Outdated phrasing ("All hands" -> "All agents")
- Wrong log directory path in operatorslog.md

## Files touched (13)

| File | Fixes |
|------|-------|
| weaver.md | pitkeel path, lexicon version |
| architect.md | removed free-bout-pool.ts ref |
| watchdog.md | removed free-bout-pool.ts ref, updated test inventory |
| scribe.md | ARCHITECTURE.md/ROADMAP.md -> docs/ paths (12+ replacements) |
| analyst.md | marked non-existent file as planned, fixed trigger |
| maturin.md | lexicon version, layer model path, species-catalogue note |
| operatorslog.md | fixed log directory path |
| weave-quick-ref.md | lexicon version, layer model path+version, line count |
| anotherpair.md | lexicon version, noted retired term |
| quartermaster.md | dead .claude/commands/ path, "All hands" -> "All agents" |
| postcaptain.md | "All hands" -> "All agents" |
| captainslog.md | "All hands" -> "All agents" |
| janitor.md | removed DEFAULT_ARENA_MAX_TURNS refs (2 locations) |

## What was tested

- Gate: lint + typecheck + test:unit + test:integration = green (1289 passed, 29 skipped)
- Grep verification: no stale refs remain for pitkeel/pitkeel, free-bout-pool, DEFAULT_ARENA_MAX_TURNS, bare ARCHITECTURE.md, "All hands"
- Em-dash/emoji check: clean
- Symlink integrity: all .claude/agents/ symlinks point to .opencode/agents/ (operatorslog.md is real file, as expected)

## Historical references preserved

maturin.md line 33 ("took three days to reach v0.2") left as-is per plan - this is accurate history describing a past event, not a stale version reference.

Closes #50

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale references across 13 agent identity files to align with current docs, code, and tooling. Removes dead links and constants, updates versions and counts, and corrects paths to prevent confusion.

- **Bug Fixes**
  - Updated Lexicon refs to v0.26 and layer model to `docs/internal/layer-model.md` v0.3.
  - Removed dead refs: `lib/free-bout-pool.ts`, `.claude/commands/`, `DEFAULT_ARENA_MAX_TURNS`.
  - Corrected paths: `pitkeel/` → `pitkeel-py/`, operator log dir to `docs/internal/captain/captainslog/...`, root `ARCHITECTURE.md`/`ROADMAP.md` → `docs/architecture.md` and `docs/roadmap.md`.
  - Refreshed inventories: tests (~77 → ~122) and Lexicon line count (~367).
  - Clarified planned-but-missing docs: `docs/research-seed-hypotheses.md`, `docs/internal/species-catalogue/`, security audit command.
  - Updated terminology: “All hands” → “All agents”.
  - Verification: grep clean; lint, typecheck, unit/integration tests pass.

<sup>Written for commit ca44ed6d5edc7f76db6bb443efc85242611c4f8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

