### PR TITLE
chore: fix broken justfile targets and stale README counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The gate (typecheck + lint + test) must pass before any merge.
 
 ## Optional CLI Toolchain
 
-Eight Go binaries for orchestration, admin, and dev tooling. These are supplementary - the application runs without them.
+Nine Go binaries for orchestration, admin, and dev tooling. These are supplementary - the application runs without them.
 
 ```
 pitstorm/               Debate orchestration CLI
@@ -66,6 +66,7 @@ pitforge/               Agent prompt engineering
 pitlab/                 Local dev environment
 pitnet/                 Network diagnostics
 pitbench/               Performance benchmarking
+piteval/                Evaluation tooling
 pitlinear/              Linear workflow automation
 pitkeel/                Developer telemetry and session tracking
 ```
@@ -78,7 +79,7 @@ This repository consolidates three development phases via subtree merge, preserv
 
 **Phase 2 - Governance Evolution** (Mar 2026): Operational controls for multi-agent development. Session decision chain (321 decisions), verification pipeline, pitkeel rewrite in Python.
 
-**Phase 3 - Validation** (Mar 2026): Cross-model adversarial review, slop failure modes taxonomy (43 entries), container-based agent isolation, and a 12-chapter systems engineering bootcamp.
+**Phase 3 - Validation** (Mar 2026): Cross-model adversarial review, slop failure modes taxonomy (49 entries), container-based agent isolation, and a 12-chapter systems engineering bootcamp.
 
 The agentic infrastructure (adversarial review pipeline, anti-pattern detection, session governance) lives in `docs/internal/` and supporting tooling. The interesting finding: sycophantic drift - agents performing honesty while being dishonest about their confidence - is harder to catch than hallucination, because it passes every surface-level check.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Custom JSON event stream (via `createUIMessageStream`):
 Client parsing happens in `lib/use-bout.ts` with `parseJsonEventStream`.
 
 ## Data Model (Drizzle)
-20 tables (see `db/schema.ts`):
+22 tables (see `db/schema.ts`):
 - `bouts` — status, transcript, owner, topic, response length, share line, updatedAt
 - `agents` — system prompt, tier, DNA hashes, lineage, archived flag, attestation fields
 - `credits` + `credit_transactions` — credit balance + append-only ledger
@@ -169,13 +169,13 @@ Release traffic simulator with evaluate-vote engine. Commands: `run` (execute tr
 AI model cost and performance analysis. Free: `models` (pricing comparison table). Premium: `estimate` (hypothetical bout cost), `cost` (exact token cost), `margin` (platform margin verification).
 
 ## QA Framework
-Custom test automation framework in `qa/`. Parses user stories from `docs/qa-report.md` and orchestrates execution.
+Custom test automation framework in `qa/`. Parses user stories from `docs/archive/qa-report.md` and orchestrates execution.
 
 - **Runner** (`qa/runner.ts`): CLI orchestrator — parses args, checks connectivity, filters by category/tier/ID, executes tests, writes results
 - **Parser** (`qa/parser.ts`): extracts test IDs, categories, descriptions, and status flags (`qa:x`, `func:x`, `broken:x`) from markdown
-- **Writer** (`qa/writer.ts`): updates `docs/qa-report.md` with results, generates JSON for CI
+- **Writer** (`qa/writer.ts`): updates `docs/archive/qa-report.md` with results, generates JSON for CI
 - **Registry** (`qa/registry.ts`): test self-registration with `setup?`/`run`/`teardown?` lifecycle
-- **Tiers** (`qa/tiers.ts`): maps tests to automation tiers — `api` (~93), `browser` (~125), `partial` (~21), `human` (6)
+- **Tiers** (`qa/tiers.ts`): maps tests to automation tiers - `api` (~93), `browser` (~125), `partial` (~21), `human` (7)
 - **69 security tests implemented** across auth bypass, injection, IDOR, credit edge cases, race conditions, payment webhooks, subscriptions, and rate limiting
 - **CLI:** `pnpm run qa`, `pnpm run qa:dry`, `pnpm run qa:setup`, `pnpm run qa:teardown`, `pnpm run qa:single <ID>`
 

--- a/justfile
+++ b/justfile
@@ -67,36 +67,36 @@ gate: setup
 # C2: inter-container communication test.
 
 interop: setup
-    @echo ">> Inter-container communication (C2)"
-    bash tests/test-c2.sh
+    #!/usr/bin/env bash
+    echo "ERROR: tests/test-c2.sh does not exist. This target needs implementation." && exit 1
 
 # ── Swarm ────────────────────────────────────────────────────
 #
 # C3: multi-container orchestration test.
 
 swarm n="3": setup
-    @echo ">> Multi-container orchestration (C3) - N={{ n }}"
-    N={{ n }} bash tests/test-c3.sh
+    #!/usr/bin/env bash
+    echo "ERROR: tests/test-c3.sh does not exist. This target needs implementation." && exit 1
 
 # ── Crew ─────────────────────────────────────────────────────
 #
 # C4: governance crew as physical agents.
 
 crew-test: setup
-    @echo ">> Governance crew plumbing (C4 - deterministic)"
-    bash tests/test-c4.sh
+    #!/usr/bin/env bash
+    echo "ERROR: tests/test-c4.sh does not exist. This target needs implementation." && exit 1
 
 steering: setup
-    @echo ">> Mid-flight steering tests (deterministic)"
-    bash tests/test-steer.sh
+    #!/usr/bin/env bash
+    echo "ERROR: tests/test-steer.sh does not exist. This target needs implementation." && exit 1
 
 steering-live: setup
-    @echo ">> Live steering tests (costs API tokens, requires ANTHROPIC_API_KEY)"
-    bash tests/test-steer-live.sh
+    #!/usr/bin/env bash
+    echo "ERROR: tests/test-steer-live.sh does not exist. This target needs implementation." && exit 1
 
 crew: setup
     @echo ">> Live crew orchestration (cross-model, costs API calls)"
-    bash orchestrate.sh
+    bash midgets/orchestrate.sh
 
 # ── Polecat Wrapper ──────────────────────────────────────────
 #
@@ -335,7 +335,7 @@ gauntlet-pitkeel:
     #!/usr/bin/env bash
     set -euo pipefail
     echo ">> Pitkeel signals"
-    if (cd pitkeel && uv run python pitkeel.py); then
+    if (cd pitkeel-py && uv run python pitkeel.py); then
         {{ pitcommit }} attest pitkeel --tree {{ tree_full }} --verdict pass
     else
         {{ pitcommit }} attest pitkeel --tree {{ tree_full }} --verdict fail

--- a/lib/README.md
+++ b/lib/README.md
@@ -11,7 +11,7 @@
 | File | Purpose |
 |------|---------|
 | `ai.ts` | Anthropic provider setup. Exports `FREE_MODEL_ID`, `PREMIUM_MODEL_OPTIONS`, `getModel()`. Three tiers: free (Haiku), premium (Sonnet/Opus), BYOK (user key). |
-| `xml-prompt.ts` | XML prompt builder for all LLM-facing prompts. Safety boundaries (`<safety>`), system/user/share message builders, `xmlEscape()`, legacy `wrapPersona()` for backwards compatibility. ~300 lines. |
+| `xml-prompt.ts` | XML prompt builder for all LLM-facing prompts. Safety boundaries (`<safety>`), system/user/share message builders, `xmlEscape()`, legacy `wrapPersona()` for backwards compatibility. ~364 lines. |
 | `presets.ts` | Loads 11 free + 11 premium presets from JSON, normalizes snake_case to camelCase. Exports `ALL_PRESETS`, `PRESET_BY_ID` (O(1) Map), `getPresetById()`. Core `Preset` and `Agent` types. |
 | `response-lengths.ts` | Three length options (short/standard/long) with `maxOutputTokens` caps. |
 | `response-formats.ts` | Four format options (plain/spaced/markdown/json) with system prompt instructions. |
@@ -20,7 +20,7 @@
 
 | File | Purpose |
 |------|---------|
-| `bout-engine.ts` | Core bout execution engine (~640 lines). Two phases: `validateBoutRequest()` (parse, auth, tier, credits, idempotency) and `executeBout()` (turn loop, transcript, share line, DB persist, credit settlement). Emits `TurnEvent` union for SSE. |
+| `bout-engine.ts` | Core bout execution engine (~1,225 lines). Two phases: `validateBoutRequest()` (parse, auth, tier, credits, idempotency) and `executeBout()` (turn loop, transcript, share line, DB persist, credit settlement). Emits `TurnEvent` union for SSE. |
 | `bout-lineup.ts` | Arena lineup reconstruction from bout JSONB data. `buildArenaPresetFromLineup()` for replay pages and bout engine. |
 | `recent-bouts.ts` | Paginated listing of recently completed bouts for the `/recent` public feed. LEFT JOIN aggregation for reaction counts. |
 | `refusal-detection.ts` | Lightweight refusal detection for agent bout responses. Normalizes Unicode quotes and matches against scoped marker phrases. Logs refusal events for data collection. |

--- a/presets/README.md
+++ b/presets/README.md
@@ -20,7 +20,8 @@ JSON preset definitions for The Pit's debate scenarios. Each preset defines a ca
 | `mansion.json` | Free | Murder mystery mansion |
 | `summit.json` | Free | Diplomatic summit |
 | `flatshare.json` | Free | Flatmate conflicts |
-| `special-guest-hal.json` | Free (dormant) | HAL 9000 guest appearance — exists on disk but is not imported by `lib/presets.ts` at runtime |
+| `rea-baseline.json` | Research | RE-A: Village Baseline - research experiment testing belief persistence in agents with shared environmental assumptions |
+| `special-guest-hal.json` | Free (dormant) | HAL 9000 guest appearance - exists on disk but is not imported by `lib/presets.ts` at runtime |
 | `presets-top5.json` | Premium | Top 5 premium pack (5 presets) |
 | `presets-remaining6.json` | Premium | Remaining 6 premium pack (6 presets) |
 

--- a/qa/README.md
+++ b/qa/README.md
@@ -4,7 +4,7 @@ Automated QA testing for The Pit, enabling LLM-driven test execution.
 
 ## Overview
 
-This framework parses user stories from `docs/qa-report.md` and provides infrastructure for automated testing using:
+This framework parses user stories from `docs/archive/qa-report.md` and provides infrastructure for automated testing using:
 
 - **Playwright MCP** for browser-based UI testing
 - **API calls** (fetch/curl) for endpoint testing
@@ -122,14 +122,14 @@ qa/
 ├── scripts/
 │   ├── setup-accounts.ts   # Creates test accounts in Clerk + DB
 │   └── teardown-accounts.ts # Removes test accounts
-├── tests/                  # Test implementations (to be added)
+├── tests/                  # Test implementations (credits, payments, rate-limiting, security)
 ├── utils/                  # Shared utilities (to be added)
 └── results/                # Test run artifacts
 ```
 
 ## Test Report Format
 
-Tests are defined in `docs/qa-report.md` using this format:
+Tests are defined in `docs/archive/qa-report.md` using this format:
 
 ```markdown
 - [ ] `[qa:_][func:_][broken:_]` **NAV-001**: As a user, I can see the logo
@@ -150,7 +150,7 @@ Each test is classified by automation feasibility:
 | `api` | HTTP/curl/database tests | 30 |
 | `browser` | Playwright UI tests | 125 |
 | `partial` | Needs specific setup | 21 |
-| `human` | Cannot automate | 6 |
+| `human` | Cannot automate | 7 |
 
 Human-required tests (payment flows, OAuth) are skipped automatically.
 
@@ -187,7 +187,7 @@ registerTest(NAV_001)
 ## Results
 
 After running tests:
-- `docs/qa-report.md` is updated with test results
+- `docs/archive/qa-report.md` is updated with test results
 - Console shows pass/fail summary
 - `qa/results/` contains run artifacts
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,15 +2,15 @@
 
 # tests/
 
-111 test files across 4 directories. Unit and API tests run via Vitest; E2E tests run via Playwright. Coverage thresholds are enforced at 85% on 11 critical lib modules. CI is enforced via GitHub Actions (`.github/workflows/ci.yml` for the gate, `.github/workflows/e2e.yml` for Playwright on Vercel preview deploys).
+119 test files across 4 directories. Unit and API tests run via Vitest; E2E tests run via Playwright. Coverage thresholds are enforced at 85% on 11 critical lib modules. CI is enforced via GitHub Actions (`.github/workflows/ci.yml` for the gate, `.github/workflows/e2e.yml` for Playwright on Vercel preview deploys).
 
 ## Directory Structure
 
 ```
 tests/
-├── unit/               69 test files — pure function tests, mocked DB/external deps
-├── api/                32 test files — API route handler tests with mocked deps
-├── integration/         3 test files — real DB + security integration tests
+├── unit/               75 test files — pure function tests, mocked DB/external deps
+├── api/                34 test files — API route handler tests with mocked deps
+├── integration/         6 test files — real DB + security integration tests
 │   ├── db.test.ts                    — real DB operations via TEST_DATABASE_URL
 │   └── security/                     — auth bypass and race condition tests
 └── e2e/                 7 test files — Playwright browser tests
@@ -28,12 +28,12 @@ pnpm run test:ci            # Full gate: lint + typecheck + unit + integration
 
 ## Test Coverage by Domain
 
-### Unit Tests (69 files in `tests/unit/`)
+### Unit Tests (75 files in `tests/unit/`)
 
 | Domain | Files | What's Tested |
 |--------|-------|---------------|
 | Agent system | `agent-dna.test.ts`, `agent-dna-edge.test.ts`, `agent-prompts.test.ts`, `agent-registry.test.ts`, `agent-detail.test.ts`, `agent-detail-edge.test.ts`, `agent-lineage.test.ts`, `agent-mapper.test.ts`, `agent-links.test.ts` | Manifest hashing, prompt generation, registry resolution, lineage chain walking, row mapping, URL encoding |
-| Credits & economy | `credits.test.ts`, `credits-settle.test.ts`, `credit-catalog.test.ts`, `intro-pool.test.ts`, `free-bout-pool.test.ts` | Cost computation, preauthorization, settlement (refund/charge/exact), pool mechanics |
+| Credits & economy | `credits.test.ts`, `credits-settle.test.ts`, `credit-catalog.test.ts`, `intro-pool.test.ts` | Cost computation, preauthorization, settlement (refund/charge/exact), pool mechanics |
 | Users & auth | `users.test.ts`, `users-edge.test.ts`, `admin.test.ts`, `admin-auth.test.ts`, `referrals.test.ts`, `onboarding.test.ts` | User sync, profile refresh, email masking, admin checks, token auth, referral bonuses |
 | Server actions | `actions.test.ts`, `actions-happy.test.ts` | All 8 server actions: auth guards, validation, Stripe flow, redirects |
 | Tier system | `tier.test.ts`, `tier-helpers.test.ts` | Tier resolution, bout/model/agent access checks, daily limits |
@@ -46,7 +46,7 @@ pnpm run test:ci            # Full gate: lint + typecheck + unit + integration
 | Infrastructure | `async-context.test.ts`, `env.test.ts`, `ip.test.ts`, `logger.test.ts`, `context-budget.test.ts` | AsyncLocalStorage context, env validation, IP resolution, structured logging, context budget tracking |
 | Utilities | `hash.test.ts`, `form-utils.test.ts`, `rate-limit.test.ts`, `response-formats.test.ts`, `response-lengths.test.ts`, `presets.test.ts`, `winner-votes-lib.test.ts`, `reactions-lib.test.ts`, `api-utils.test.ts`, `errors.test.ts`, `validation.test.ts` | Hashing, form data, rate limiting, response config, preset integrity, API utils, error handling, input validation |
 
-### API Tests (32 files in `tests/api/`)
+### API Tests (34 files in `tests/api/`)
 
 | Domain | Files | Scenarios |
 |--------|-------|-----------|
@@ -62,11 +62,14 @@ pnpm run test:ci            # Full gate: lint + typecheck + unit + integration
 | Billing | `webhook-subscription.test.ts`, `webhook-edge-cases.test.ts` | Subscription lifecycle, idempotency, edge cases |
 | Security | `security-topic-length.test.ts`, `security-contact-validation.test.ts`, `security-admin-auth.test.ts` | Input bounds, validation, admin auth |
 
-### Integration Tests (3 files)
+### Integration Tests (6 files)
 
 | File | Description |
 |------|-------------|
 | `db.test.ts` | Real DB operations: credit ledger, intro pool, referral credits. Requires `TEST_DATABASE_URL`; skipped when absent. Full cleanup in `afterAll`. |
+| `bout-engine-credits.integration.test.ts` | Bout engine credit flow integration: preauthorization, settlement, refund paths with real DB. |
+| `reactions-validation.integration.test.ts` | Reaction validation integration: deduplication and constraint enforcement. |
+| `winner-vote.integration.test.ts` | Winner vote integration: one-vote-per-user enforcement and tally accuracy. |
 | `security/auth-bypass.test.ts` | Authorization bypass testing: endpoint protection, token validation, timing-safe comparisons. |
 | `security/race-conditions.test.ts` | Concurrent request handling: reaction deduplication, credit race conditions. |
 
@@ -123,11 +126,11 @@ Common mock helpers (`setupSelect()`, `setupInsert()`, `setupUpdate()`) are defi
 
 - `vi.resetModules()` in `beforeEach` when dynamic imports are used
 - `catchRedirect`/`expectRedirect` helpers for testing server action redirects
-- No shared test utility module — mocks are copy-pasted per file
+- Shared test utilities exist in `tests/integration/security/utils.ts`. Unit and API test mocks are copy-pasted per file
 
 ## Design Decisions & Trade-offs
 
-- **No shared test utilities** — Mock setup helpers are duplicated across ~101 test files. This maximizes isolation (no hidden shared state) but increases maintenance cost when DB mock patterns change. Extracting a `tests/helpers/` module with shared mock factories would reduce duplication. This is the most impactful improvement opportunity in the test layer.
+- **Minimal shared test utilities** — Integration security tests share `tests/integration/security/utils.ts`. Unit and API mock setup helpers are duplicated across test files. This maximizes isolation (no hidden shared state) but increases maintenance cost when DB mock patterns change. Extracting a `tests/helpers/` module with shared mock factories would reduce duplication.
 - **CI enforced via GitHub Actions** — `.github/workflows/ci.yml` runs the full gate (lint + typecheck + unit + integration) on every push and PR. `.github/workflows/e2e.yml` runs Playwright against Vercel preview deployments on `deployment_status` events.
 - **Coverage targets are selective** — 11 critical lib modules have enforced 85% coverage (agent-dna, agent-prompts, agent-registry, credits, free-bout-pool, rate-limit, referrals, response-formats, response-lengths, tier, validation). Other modules have no minimum. This focuses coverage enforcement on the highest-risk code without creating busywork for UI-adjacent modules.
 - **Seven E2E tests** — Playwright specs cover the core bout flow, citation validation, mobile responsiveness, hydration checks, OG images, pagination, and the unleashed feature. E2E tests are paused during high-iteration phases and not part of `test:ci`.


### PR DESCRIPTION
## Summary

Fixes broken paths in the justfile and updates stale counts/references across README and documentation files. Janitor audit P5.

- **Justfile:** Fix pitkeel directory path (Go vs Python), guard 5 targets referencing non-existent test scripts with clear error messages, fix orchestrate.sh path
- **READMEs:** Update all stale file counts, line counts, and table counts to match filesystem reality
- **Doc paths:** Fix `docs/qa-report.md` -> `docs/archive/qa-report.md` in docs/architecture.md and qa/README.md

## Technical decisions

- Chose explicit error guard over commenting out broken justfile targets - agents calling these targets get a clear failure message rather than silent success or confusing absence
- Did not change `qa/parser.ts` and `qa/writer.ts` references to `docs/qa-report.md` as those are functional code paths; changing them would alter runtime behaviour and is outside this PR's documentation-only scope
- Test count (1,289) and table count (22) in root README.md confirmed accurate - left unchanged
- All counts verified against actual filesystem before editing, not assumed from audit plan

## What was tested

- `pnpm run test:ci` - gate green (1,289 passed, 29 skipped)
- `grep -n 'cd pitkeel ' justfile` - returns empty (fixed to pitkeel-py)
- `grep 'free-bout-pool' tests/README.md` - only coverage target refs remain (phantom test file removed from table)
- `grep -rn 'docs/qa-report.md' docs/ qa/` - only source files (parser.ts, writer.ts) and archived doc remain; all README/doc references fixed
- No em-dashes or emojis in any modified file

## Known limitations

- `qa/parser.ts` and `qa/writer.ts` still reference `docs/qa-report.md` - these are code paths, not docs, and would need a separate PR with test coverage
- `docs/archive/agentic-qa-sweep.md` still references old path - outside P5 scope (P2/P3 concern)

Closes #51

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken `justfile` targets and refreshes stale doc counts/links to match the repo.

- **Bug Fixes**
  - `justfile`: guard five missing-script targets with explicit errors; fix `pitkeel` -> `pitkeel-py`; point crew to `midgets/orchestrate.sh`.
  - Docs/READMEs: update counts and paths (tests 119, DB tables 22, Go CLIs 9 incl. `piteval`, slop taxonomy 49, human tests 7); move QA report refs to `docs/archive/qa-report.md`; add `rea-baseline.json`; remove phantom `free-bout-pool.test.ts`; correct line counts for `xml-prompt.ts` and `bout-engine.ts`.

<sup>Written for commit f467164ecb030f9df2fb659e5a23a6c1abd76ba6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

