### PR TITLE
fix(roadmap): revert false 'creator profiles done' from polecat PIT-607

### DIFF
--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -77,7 +77,7 @@ const LANES: Lane[] = [
       { label: 'On-chain EAS attestation', status: 'planned', detail: '125 development attestations on Base L2 mainnet; automated production pipeline not yet enabled' },
       { label: 'Structured agent builder', status: 'done', detail: 'Archetype, tone, quirks, goals, fears' },
       { label: 'Prompt lineage tracking', status: 'done', detail: 'Parent/child agent genealogy' },
-      { label: 'Creator profiles', status: 'done', detail: 'Public pages with agent portfolio and stats' },
+      { label: 'Creator profiles', status: 'planned', detail: 'Public pages with agent portfolio and stats' },
       { label: 'Remix rewards', status: 'done', detail: 'Credits for remixing and being remixed' },
       { label: 'Agent marketplace', status: 'planned', detail: 'Browse, fork, and trade agent prompts' },
       { label: 'Social graph', status: 'planned', detail: 'Follow creators, get notified on new agents' },

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@ What we're shipping. Three tracks running in parallel. Source of truth: `app/roa
 - [x] Prompt lineage tracking (parent/child agent genealogy)
 - [x] Remix rewards (credits for remixing and being remixed)
 - [ ] On-chain EAS attestation (125 dev attestations on Base L2; prod pipeline not yet enabled)
-- [x] Creator profiles (public pages with agent portfolio and stats)
+- [ ] Creator profiles (public pages with agent portfolio and stats)
 - [ ] Agent marketplace (browse, fork, and trade agent prompts)
 - [ ] Social graph (follow creators, get notified on new agents)
 - [ ] Collaborative agents (multi-author agent construction)


### PR DESCRIPTION
## Summary

Reverts the incorrect roadmap change from polecat commit caf8a89 (PIT-607) which marked creator profiles as done. Creator profiles (#12) are not implemented - sub-issues #61-65 are still open.

## Context

Gastown polecats pushed unauthorized commits directly to main overnight. The mayor dispatched PIT-607 to mark creator profiles as done, but the actual feature work has not been started. This forward-fix corrects the roadmap to reflect reality.

## Changes

- `app/roadmap/page.tsx`: Creator profiles status reverted from 'done' to 'planned'
- `docs/roadmap.md`: Creator profiles checkbox reverted from `[x]` to `[ ]`

## Testing

- Gate: `pnpm run test:ci` - 1340 passed, 95.32% coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the mistaken roadmap update from Linear PIT-607 that marked “Creator profiles” as done. Sets it back to “planned” in the app and docs to reflect that the feature (#12) and sub-issues (#61–#65) are still open.

- **Bug Fixes**
  - app/roadmap/page.tsx: change “Creator profiles” status from “done” to “planned”
  - docs/roadmap.md: revert “Creator profiles” checkbox from [x] to [ ]

<sup>Written for commit 7e7c59ee3c4e5c9675e8a3782bf1e2adc9bc2d4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the public roadmap status for the Creator profiles feature in the Community track, moving it from completed to planned status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->