### PR TITLE
feat(agents): add archive endpoint for soft-delete capability

### DIFF
--- a/app/api/agents/[id]/archive/route.ts
+++ b/app/api/agents/[id]/archive/route.ts
@@ -1,0 +1,57 @@
+import { auth } from '@clerk/nextjs/server';
+import { eq } from 'drizzle-orm';
+
+import { requireDb } from '@/db';
+import { agents } from '@/db/schema';
+import { errorResponse, API_ERRORS } from '@/lib/api-utils';
+
+export const runtime = 'nodejs';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** PATCH /api/agents/[id]/archive - toggle archived status for an agent. */
+export async function PATCH(
+  _req: Request,
+  { params }: RouteParams,
+): Promise<Response> {
+  const { userId } = await auth();
+  if (!userId) {
+    return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
+  }
+
+  const { id: agentId } = await params;
+
+  const db = requireDb();
+
+  // Fetch the agent and verify ownership
+  const [agent] = await db
+    .select({
+      id: agents.id,
+      ownerId: agents.ownerId,
+      archived: agents.archived,
+    })
+    .from(agents)
+    .where(eq(agents.id, agentId))
+    .limit(1);
+
+  if (!agent) {
+    return errorResponse(API_ERRORS.NOT_FOUND, 404);
+  }
+
+  if (agent.ownerId !== userId) {
+    return errorResponse(API_ERRORS.FORBIDDEN, 403);
+  }
+
+  // Toggle archived status
+  const newArchivedStatus = !agent.archived;
+
+  await db
+    .update(agents)
+    .set({ archived: newArchivedStatus })
+    .where(eq(agents.id, agentId));
+
+  return Response.json({
+    id: agentId,
+    archived: newArchivedStatus,
+  });
+}

--- a/tests/api/agents-archive.test.ts
+++ b/tests/api/agents-archive.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockDb, authMock } = vi.hoisted(() => {
+  const db = {
+    select: vi.fn(),
+    update: vi.fn(),
+  };
+  return {
+    mockDb: db,
+    authMock: vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/db', () => ({ requireDb: () => mockDb }));
+
+vi.mock('@/db/schema', () => ({
+  agents: {
+    id: 'id',
+    ownerId: 'owner_id',
+    archived: 'archived',
+  },
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: authMock }));
+
+// ---------------------------------------------------------------------------
+// SUT
+// ---------------------------------------------------------------------------
+
+import { PATCH } from '@/app/api/agents/[id]/archive/route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makePatchRequest = (agentId: string) =>
+  new Request(`http://localhost/api/agents/${agentId}/archive`, {
+    method: 'PATCH',
+  });
+
+const makeRouteParams = (id: string) => ({
+  params: Promise.resolve({ id }),
+});
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  authMock.mockResolvedValue({ userId: 'user-1' });
+});
+
+// ---------------------------------------------------------------------------
+// Happy paths
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/agents/[id]/archive - happy paths', () => {
+  it('archives an unarchived agent (toggles to true)', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ id: 'agent-123', ownerId: 'user-1', archived: false }],
+        }),
+      }),
+    }));
+
+    mockDb.update.mockImplementation(() => ({
+      set: () => ({
+        where: async () => ({}),
+      }),
+    }));
+
+    const res = await PATCH(makePatchRequest('agent-123'), makeRouteParams('agent-123'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ id: 'agent-123', archived: true });
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('unarchives an archived agent (toggles to false)', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ id: 'agent-456', ownerId: 'user-1', archived: true }],
+        }),
+      }),
+    }));
+
+    mockDb.update.mockImplementation(() => ({
+      set: () => ({
+        where: async () => ({}),
+      }),
+    }));
+
+    const res = await PATCH(makePatchRequest('agent-456'), makeRouteParams('agent-456'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ id: 'agent-456', archived: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/agents/[id]/archive - error cases', () => {
+  it('returns 401 when not authenticated', async () => {
+    authMock.mockResolvedValue({ userId: null });
+
+    const res = await PATCH(makePatchRequest('agent-123'), makeRouteParams('agent-123'));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Authentication required.' });
+  });
+
+  it('returns 404 when agent does not exist', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [],
+        }),
+      }),
+    }));
+
+    const res = await PATCH(makePatchRequest('nonexistent'), makeRouteParams('nonexistent'));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Not found.' });
+  });
+
+  it('returns 403 when user does not own the agent', async () => {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ id: 'agent-123', ownerId: 'other-user', archived: false }],
+        }),
+      }),
+    }));
+
+    const res = await PATCH(makePatchRequest('agent-123'), makeRouteParams('agent-123'));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Forbidden.' });
+  });
+});


### PR DESCRIPTION
## Summary

- Add PATCH `/api/agents/[id]/archive` endpoint to toggle agent archived status
- Verify agent ownership before allowing archive operation
- Return appropriate error codes: 401 (unauthenticated), 403 (not owner), 404 (not found)

## Changes

- New API endpoint at `app/api/agents/[id]/archive/route.ts`
- New test file `tests/api/agents-archive.test.ts` with 5 test cases

## Testing

- Gate: `pnpm run test:ci` - PASS
- New tests added: 5 tests covering happy path and error cases

## Gate Results

```
Test Files  116 passed | 6 skipped (122)
Tests  1345 passed | 29 skipped (1374)
```

---

Closes PIT-nan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `PATCH /api/agents/[id]/archive` endpoint to soft-delete agents by toggling their archived flag. Enforces owner-only access and returns 401/403/404 as needed; satisfies the soft-delete requirement in Linear PIT-nan.

- **New Features**
  - Endpoint in `app/api/agents/[id]/archive/route.ts` to toggle `archived` and return `{ id, archived }`.
  - Auth via `@clerk/nextjs/server`; verifies ownership before updating.
  - Tests added for happy paths and 401/403/404 errors.

<sup>Written for commit 6239de92e2e4839a43e2b458135ada046a6e6ba5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now be archived and unarchived through a dedicated toggle action.

* **Tests**
  * Added comprehensive test coverage for the archive feature, including authentication validation, ownership verification, and status state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->