### PR TITLE
fix(webhook): add unique constraint on referenceId to prevent duplicate grants (PIT-acx)

### DIFF
--- a/app/api/credits/webhook/route.ts
+++ b/app/api/credits/webhook/route.ts
@@ -87,7 +87,7 @@ export const POST = withLogging(async function POST(req: Request) {
   const headerList = await headers();
   const signature = headerList.get('stripe-signature');
   if (!signature) {
-    return errorResponse('Missing signature.', 400);
+    return errorResponse(API_ERRORS.MISSING_SIGNATURE, 400);
   }
 
   let event;
@@ -95,7 +95,7 @@ export const POST = withLogging(async function POST(req: Request) {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
   } catch (error) {
     log.warn('Stripe webhook signature failed', toError(error));
-    return errorResponse('Invalid signature.', 400);
+    return errorResponse(API_ERRORS.INVALID_SIGNATURE, 400);
   }
 
   // --- Credit pack purchase (one-time checkout) ---

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -12,6 +12,7 @@
 //   - winnerVotes has a unique index on (boutId, userId) to enforce one vote per
 //     user per bout at the database level.
 
+import { sql } from 'drizzle-orm';
 import {
   jsonb,
   pgEnum,
@@ -141,6 +142,11 @@ export const creditTransactions = pgTable('credit_transactions', {
     table.createdAt,
   ),
   referenceIdIdx: index('credit_txn_reference_id_idx').on(table.referenceId),
+  // Unique partial index prevents duplicate credit grants from webhook retries.
+  // Enforces uniqueness only for non-null reference_id values.
+  referenceIdUnique: uniqueIndex('credit_txn_reference_id_unique')
+    .on(table.referenceId)
+    .where(sql`${table.referenceId} IS NOT NULL`),
 }));
 
 export const introPool = pgTable('intro_pool', {

--- a/drizzle/0001_add_reference_id_unique.sql
+++ b/drizzle/0001_add_reference_id_unique.sql
@@ -1,0 +1,8 @@
+-- Add unique partial index on credit_transactions.reference_id to prevent
+-- duplicate webhook deliveries from double-granting credits.
+--
+-- Partial index (WHERE reference_id IS NOT NULL) allows multiple NULLs
+-- while enforcing uniqueness for non-null values.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "credit_txn_reference_id_unique"
+  ON "credit_transactions" ("reference_id")
+  WHERE "reference_id" IS NOT NULL;

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -39,6 +39,8 @@ export const API_ERRORS = {
   INTERNAL: 'Internal server error.',
   SERVICE_UNAVAILABLE: 'Service unavailable.',
   UNSAFE_CONTENT: 'Input contains disallowed content.',
+  MISSING_SIGNATURE: 'Missing signature.',
+  INVALID_SIGNATURE: 'Invalid signature.',
 } as const;
 
 // ─── Error response factory ─────────────────────────────────────────────────

--- a/tests/api/webhook-subscription.test.ts
+++ b/tests/api/webhook-subscription.test.ts
@@ -701,6 +701,40 @@ describe('POST /api/credits/webhook', () => {
   });
 
   // ------------------------------------------------------------------
+  // 19b. subscription.updated (downgrade): does NOT grant credits
+  // ------------------------------------------------------------------
+  it('customer.subscription.updated: does NOT grant credits on lab-to-pass downgrade', async () => {
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_downgrade',
+          status: 'active',
+          customer: 'cus_downgrade',
+          metadata: { userId: 'user_downgrade' },
+          items: { data: [{ price: { id: 'price_pass' } }] },
+          current_period_end: 1800000000,
+        },
+      },
+    });
+
+    mockResolveTierFromPriceId.mockReturnValue('pass');
+    // User was on lab tier, now downgrading to pass
+    setupSelect([[{ tier: 'lab' }], []]);
+    setupUpdate();
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    // Tier update happens, but NO credit grant (downgrade)
+    expect(mockDb.update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'id' }),
+    );
+    expect(mockApplyCreditDelta).not.toHaveBeenCalled();
+    expect(mockEnsureCreditAccount).not.toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------------------
   // 20. invoice.payment_succeeded: grants monthly credits on renewal
   // ------------------------------------------------------------------
   it('invoice.payment_succeeded: grants monthly 300 credits for pass tier on renewal', async () => {


### PR DESCRIPTION
## Summary

- Add partial unique index on `credit_transactions.reference_id` to prevent race condition where concurrent webhook deliveries could double-grant credits
- Standardize webhook error responses using API_ERRORS constants

## Audit Findings

**CRITICAL (Fixed):**
- `referenceId` column had only a regular index, not a unique constraint. This meant concurrent webhook deliveries could both pass the application-level idempotency check and insert duplicate credit grants.

**MODERATE (Fixed):**
- Error responses used hardcoded strings instead of `API_ERRORS` constants, inconsistent with the rest of the codebase.

**MINOR (Fixed):**
- Added explicit test for downgrade not granting credits.

## Changes

1. **Migration**: `drizzle/0001_add_reference_id_unique.sql` - Creates partial unique index `credit_txn_reference_id_unique` on `reference_id` WHERE `reference_id IS NOT NULL`

2. **Schema**: Updated `db/schema.ts` to reflect the unique partial index in the Drizzle schema

3. **API Utils**: Added `MISSING_SIGNATURE` and `INVALID_SIGNATURE` to `API_ERRORS` constants

4. **Webhook Handler**: Updated to use new `API_ERRORS` constants instead of hardcoded strings

5. **Tests**: Added test case verifying downgrade does not grant credits

## Test plan

- [x] Gate: `pnpm run test:ci` - PASS (1341 tests)
- [x] Typecheck: PASS
- [x] Lint: PASS (warnings only, pre-existing)

## Gate Results

```
Test Files  115 passed | 6 skipped (121)
     Tests  1341 passed | 29 skipped (1370)
```

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a partial unique index on `credit_transactions.reference_id` to enforce idempotency and stop duplicate credit grants from concurrent Stripe webhook deliveries. Also standardizes webhook error responses using `API_ERRORS`.

- **Bug Fixes**
  - Add DB migration and Drizzle schema for a partial unique index on `credit_transactions.reference_id` (`WHERE reference_id IS NOT NULL`) to block duplicate inserts.
  - Use `API_ERRORS.MISSING_SIGNATURE` and `API_ERRORS.INVALID_SIGNATURE` in the Stripe webhook.
  - Add test to ensure a lab→pass downgrade does not grant credits.

<sup>Written for commit 324832058e2ece331f6d972c2c69b4495691945b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

