### PR TITLE
fix(credits): make intro pool deduction and user credit grant atomic (RD-001)

### DIFF
--- a/lib/credits.ts
+++ b/lib/credits.ts
@@ -189,9 +189,13 @@ export const computeCostUsd = (
   };
 };
 
-export async function ensureCreditAccount(userId: string) {
-  const db = requireDb();
-  const [existing] = await db
+/** Database-like object with the query methods needed by credit operations.
+ *  Accepts both the root db instance and a transaction handle from db.transaction(). */
+type DbLike = Pick<ReturnType<typeof requireDb>, 'select' | 'insert' | 'update'>;
+
+export async function ensureCreditAccount(userId: string, tx?: DbLike) {
+  const conn = tx ?? requireDb();
+  const [existing] = await conn
     .select()
     .from(credits)
     .where(eq(credits.userId, userId))
@@ -207,7 +211,7 @@ export async function ensureCreditAccount(userId: string) {
 
   // Use onConflictDoNothing to handle concurrent insert races — two
   // simultaneous requests for the same new user won't throw a PK violation.
-  const [created] = await db
+  const [created] = await conn
     .insert(credits)
     .values({
       userId,
@@ -218,7 +222,7 @@ export async function ensureCreditAccount(userId: string) {
 
   if (!created) {
     // Another request inserted first — re-read the row.
-    const [raced] = await db
+    const [raced] = await conn
       .select()
       .from(credits)
       .where(eq(credits.userId, userId))
@@ -241,14 +245,11 @@ export async function applyCreditDelta(
   deltaMicro: number,
   reason: string,
   metadata: Record<string, unknown>,
+  tx?: DbLike,
 ) {
-  const db = requireDb();
-
-  // Wrap ledger insert + balance update in a transaction so they
-  // succeed or fail atomically.  Without this, a failed update
-  // would leave a dangling ledger entry with no balance change.
-  return db.transaction(async (tx) => {
-    await tx.insert(creditTransactions).values({
+  // Core logic: ledger insert + balance update must be atomic.
+  const applyWithin = async (conn: DbLike) => {
+    await conn.insert(creditTransactions).values({
       userId,
       deltaMicro,
       source: reason,
@@ -257,7 +258,7 @@ export async function applyCreditDelta(
       metadata,
     });
 
-    const [updated] = await tx
+    const [updated] = await conn
       .update(credits)
       .set({
         balanceMicro: sql`GREATEST(0, ${credits.balanceMicro} + ${deltaMicro})`,
@@ -267,7 +268,15 @@ export async function applyCreditDelta(
       .returning();
 
     return updated;
-  });
+  };
+
+  // If caller provided a transaction, use it directly (no nested transaction).
+  // Otherwise create our own transaction for atomicity.
+  if (tx) {
+    return applyWithin(tx);
+  }
+  const db = requireDb();
+  return db.transaction(async (innerTx) => applyWithin(innerTx));
 }
 
 export async function getCreditTransactions(userId: string, limit = 20) {

--- a/lib/credits.ts
+++ b/lib/credits.ts
@@ -189,11 +189,12 @@ export const computeCostUsd = (
   };
 };
 
-/** Database-like object with the query methods needed by credit operations.
- *  Accepts both the root db instance and a transaction handle from db.transaction(). */
-type DbLike = Pick<ReturnType<typeof requireDb>, 'select' | 'insert' | 'update'>;
+/** Database or transaction handle for credit operations.
+ *  When a caller provides a DbOrTx, the caller owns the transaction boundary -
+ *  credit operations run within the caller's transaction instead of creating their own. */
+type DbOrTx = Pick<ReturnType<typeof requireDb>, 'select' | 'insert' | 'update'>;
 
-export async function ensureCreditAccount(userId: string, tx?: DbLike) {
+export async function ensureCreditAccount(userId: string, tx?: DbOrTx) {
   const conn = tx ?? requireDb();
   const [existing] = await conn
     .select()
@@ -245,10 +246,10 @@ export async function applyCreditDelta(
   deltaMicro: number,
   reason: string,
   metadata: Record<string, unknown>,
-  tx?: DbLike,
+  tx?: DbOrTx,
 ) {
   // Core logic: ledger insert + balance update must be atomic.
-  const applyWithin = async (conn: DbLike) => {
+  const applyWithin = async (conn: DbOrTx) => {
     await conn.insert(creditTransactions).values({
       userId,
       deltaMicro,

--- a/lib/intro-pool.ts
+++ b/lib/intro-pool.ts
@@ -136,6 +136,7 @@ export async function claimIntroCredits(params: {
       .select({ claimedMicro: introPool.claimedMicro })
       .from(introPool)
       .where(eq(introPool.id, pool.id))
+      .for('update')
       .limit(1);
 
     const baselineClaimedMicro = baseline?.claimedMicro ?? 0;

--- a/lib/intro-pool.ts
+++ b/lib/intro-pool.ts
@@ -125,56 +125,60 @@ export async function claimIntroCredits(params: {
     return { claimedMicro: 0, remainingMicro: 0, exhausted: true };
   }
 
-  // Atomic claim: Calculate remaining in SQL and only increment if sufficient
-  // remaining = FLOOR(initial * 0.5^(elapsed_s / half_life_s)) - claimed
-  // We use LEAST to cap the claim at what's actually available
-  const [result] = await db
-    .update(introPool)
-    .set({
-      claimedMicro: sql`${introPool.claimedMicro} + LEAST(
-        ${requestedMicro},
-        GREATEST(
-          0,
-          FLOOR(${introPool.initialMicro} * POWER(0.5, EXTRACT(EPOCH FROM (NOW() - ${introPool.startedAt})) / ${HALF_LIFE_MINUTES * 60}))
-          - ${introPool.claimedMicro}
-        )
-      )`,
-      updatedAt: new Date(),
-    })
-    .where(eq(introPool.id, pool.id))
-    .returning({
-      claimedMicro: introPool.claimedMicro,
-      initialMicro: introPool.initialMicro,
-      startedAt: introPool.startedAt,
-    });
+  // Wrap pool deduction + user credit in a single transaction.
+  // If the user credit fails, the pool deduction rolls back - no leaked credits.
+  return db.transaction(async (tx) => {
+    // Atomic claim: Calculate remaining in SQL and only increment if sufficient
+    // remaining = FLOOR(initial * 0.5^(elapsed_s / half_life_s)) - claimed
+    // We use LEAST to cap the claim at what's actually available
+    const [result] = await tx
+      .update(introPool)
+      .set({
+        claimedMicro: sql`${introPool.claimedMicro} + LEAST(
+          ${requestedMicro},
+          GREATEST(
+            0,
+            FLOOR(${introPool.initialMicro} * POWER(0.5, EXTRACT(EPOCH FROM (NOW() - ${introPool.startedAt})) / ${HALF_LIFE_MINUTES * 60}))
+            - ${introPool.claimedMicro}
+          )
+        )`,
+        updatedAt: new Date(),
+      })
+      .where(eq(introPool.id, pool.id))
+      .returning({
+        claimedMicro: introPool.claimedMicro,
+        initialMicro: introPool.initialMicro,
+        startedAt: introPool.startedAt,
+      });
 
-  if (!result) {
-    // Pool doesn't exist - shouldn't happen since we called ensureIntroPool
-    return { claimedMicro: 0, remainingMicro: 0, exhausted: true };
-  }
+    if (!result) {
+      // Pool doesn't exist - shouldn't happen since we called ensureIntroPool
+      return { claimedMicro: 0, remainingMicro: 0, exhausted: true };
+    }
 
-  // Calculate what was actually claimed (new claimed - old claimed)
-  const actualClaimed = result.claimedMicro - pool.claimedMicro;
-  const newRemaining = computeRemainingMicro(result);
+    // Calculate what was actually claimed (new claimed - old claimed)
+    const actualClaimed = result.claimedMicro - pool.claimedMicro;
+    const newRemaining = computeRemainingMicro(result);
 
-  if (actualClaimed <= 0) {
-    return { claimedMicro: 0, remainingMicro: newRemaining, exhausted: newRemaining <= 0 };
-  }
+    if (actualClaimed <= 0) {
+      return { claimedMicro: 0, remainingMicro: newRemaining, exhausted: newRemaining <= 0 };
+    }
 
-  // Credit the user
-  await ensureCreditAccount(params.userId);
-  await applyCreditDelta(params.userId, actualClaimed, params.source, {
-    referenceId: params.referenceId,
-    introPoolClaimedMicro: actualClaimed,
-    introPoolRemainingMicro: newRemaining,
-    ...params.metadata,
+    // Credit the user within the same transaction
+    await ensureCreditAccount(params.userId, tx);
+    await applyCreditDelta(params.userId, actualClaimed, params.source, {
+      referenceId: params.referenceId,
+      introPoolClaimedMicro: actualClaimed,
+      introPoolRemainingMicro: newRemaining,
+      ...params.metadata,
+    }, tx);
+
+    return {
+      claimedMicro: actualClaimed,
+      remainingMicro: newRemaining,
+      exhausted: newRemaining <= 0,
+    };
   });
-
-  return {
-    claimedMicro: actualClaimed,
-    remainingMicro: newRemaining,
-    exhausted: newRemaining <= 0,
-  };
 }
 
 /**

--- a/lib/intro-pool.ts
+++ b/lib/intro-pool.ts
@@ -128,6 +128,18 @@ export async function claimIntroCredits(params: {
   // Wrap pool deduction + user credit in a single transaction.
   // If the user credit fails, the pool deduction rolls back - no leaked credits.
   return db.transaction(async (tx) => {
+    // Read a fresh claimedMicro inside the transaction so the baseline for
+    // delta calculation matches the isolation level. The outer ensureIntroPool
+    // call guarantees the row exists, but its claimedMicro may be stale if a
+    // concurrent claim committed between the outer read and this transaction.
+    const [baseline] = await tx
+      .select({ claimedMicro: introPool.claimedMicro })
+      .from(introPool)
+      .where(eq(introPool.id, pool.id))
+      .limit(1);
+
+    const baselineClaimedMicro = baseline?.claimedMicro ?? 0;
+
     // Atomic claim: Calculate remaining in SQL and only increment if sufficient
     // remaining = FLOOR(initial * 0.5^(elapsed_s / half_life_s)) - claimed
     // We use LEAST to cap the claim at what's actually available
@@ -156,8 +168,8 @@ export async function claimIntroCredits(params: {
       return { claimedMicro: 0, remainingMicro: 0, exhausted: true };
     }
 
-    // Calculate what was actually claimed (new claimed - old claimed)
-    const actualClaimed = result.claimedMicro - pool.claimedMicro;
+    // Calculate what was actually claimed using the in-transaction baseline
+    const actualClaimed = result.claimedMicro - baselineClaimedMicro;
     const newRemaining = computeRemainingMicro(result);
 
     if (actualClaimed <= 0) {

--- a/tests/unit/credits.test.ts
+++ b/tests/unit/credits.test.ts
@@ -82,6 +82,9 @@ describe('credits helpers', () => {
     mockDb.select.mockReset();
     mockDb.insert.mockReset();
     mockDb.update.mockReset();
+    mockDb.transaction.mockReset();
+    // Default: transaction executes its callback with mockDb as the tx
+    mockDb.transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(mockDb));
     process.env.CREDIT_VALUE_GBP = '0.01';
     process.env.CREDIT_PLATFORM_MARGIN = '0.10';
     process.env.CREDIT_TOKEN_CHARS_PER = '4';
@@ -409,6 +412,86 @@ describe('credits helpers', () => {
         source: 'preauth',
         referenceId: 'bout-3',
       });
+    });
+  });
+
+  describe('ensureCreditAccount with tx parameter', () => {
+    it('uses provided tx instead of requireDb()', async () => {
+      const txSelect = vi.fn().mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [{ userId: 'user-tx', balanceMicro: 500 }],
+          }),
+        }),
+      }));
+      const tx = { select: txSelect, insert: vi.fn(), update: vi.fn() };
+
+      const { ensureCreditAccount } = await loadCredits();
+      const account = await ensureCreditAccount('user-tx', tx as never);
+
+      expect(txSelect).toHaveBeenCalled();
+      // requireDb's mockDb.select should NOT have been called
+      expect(mockDb.select).not.toHaveBeenCalled();
+      expect(account).toEqual({ userId: 'user-tx', balanceMicro: 500 });
+    });
+
+    it('falls back to requireDb() when tx is not provided', async () => {
+      setupSelect([{ userId: 'user-no-tx', balanceMicro: 999 }]);
+
+      const { ensureCreditAccount } = await loadCredits();
+      const account = await ensureCreditAccount('user-no-tx');
+
+      expect(mockDb.select).toHaveBeenCalled();
+      expect(account).toEqual({ userId: 'user-no-tx', balanceMicro: 999 });
+    });
+  });
+
+  describe('applyCreditDelta with tx parameter', () => {
+    it('uses provided tx directly without creating own transaction', async () => {
+      const txInsert = vi.fn().mockImplementation(() => ({
+        values: vi.fn().mockResolvedValue(undefined),
+      }));
+      const txUpdate = vi.fn().mockImplementation(() => ({
+        set: () => ({
+          where: () => ({
+            returning: vi.fn().mockResolvedValue([{ userId: 'user-tx-delta', balanceMicro: 150 }]),
+          }),
+        }),
+      }));
+      const tx = { select: vi.fn(), insert: txInsert, update: txUpdate };
+
+      const { applyCreditDelta } = await loadCredits();
+      const result = await applyCreditDelta(
+        'user-tx-delta',
+        50,
+        'test-source',
+        { referenceId: 'ref-tx' },
+        tx as never,
+      );
+
+      // tx methods were used
+      expect(txInsert).toHaveBeenCalled();
+      expect(txUpdate).toHaveBeenCalled();
+      // db.transaction was NOT called (no nested transaction)
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+      expect(result).toEqual({ userId: 'user-tx-delta', balanceMicro: 150 });
+    });
+
+    it('creates own transaction when tx is not provided', async () => {
+      setupInsert({ userId: 'user-own-tx', balanceMicro: 200 });
+      setupUpdate({ userId: 'user-own-tx', balanceMicro: 200 });
+
+      const { applyCreditDelta } = await loadCredits();
+      const result = await applyCreditDelta(
+        'user-own-tx',
+        100,
+        'test-source',
+        { referenceId: 'ref-own' },
+      );
+
+      // db.transaction was called (creates its own)
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ userId: 'user-own-tx', balanceMicro: 200 });
     });
   });
 });

--- a/tests/unit/intro-pool.test.ts
+++ b/tests/unit/intro-pool.test.ts
@@ -13,6 +13,7 @@ const { mockDb, introPoolTable, mockCredits } = vi.hoisted(() => {
     select: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
+    transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(db)),
   };
   const credits = {
     ensureCreditAccount: vi.fn(),
@@ -56,6 +57,9 @@ describe('intro-pool', () => {
     mockDb.select.mockReset();
     mockDb.insert.mockReset();
     mockDb.update.mockReset();
+    mockDb.transaction.mockReset();
+    // Default: transaction executes its callback with mockDb as the tx
+    mockDb.transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(mockDb));
     mockCredits.ensureCreditAccount.mockReset();
     mockCredits.applyCreditDelta.mockReset();
     process.env.INTRO_POOL_TOTAL_CREDITS = '15000';
@@ -228,7 +232,7 @@ describe('intro-pool', () => {
 
       expect(result.claimedMicro).toBe(10_000);
       expect(result.exhausted).toBe(false);
-      expect(mockCredits.ensureCreditAccount).toHaveBeenCalledWith('user-1');
+      expect(mockCredits.ensureCreditAccount).toHaveBeenCalledWith('user-1', mockDb);
       expect(mockCredits.applyCreditDelta).toHaveBeenCalledWith(
         'user-1',
         10_000,
@@ -237,6 +241,7 @@ describe('intro-pool', () => {
           referenceId: 'ref-1',
           introPoolClaimedMicro: 10_000,
         }),
+        mockDb,
       );
     });
 
@@ -293,6 +298,7 @@ describe('intro-pool', () => {
         3_000,
         'signup',
         expect.objectContaining({ introPoolClaimedMicro: 3_000 }),
+        mockDb,
       );
     });
 
@@ -398,6 +404,169 @@ describe('intro-pool', () => {
       expect(result.claimedMicro).toBe(0);
       expect(mockCredits.ensureCreditAccount).not.toHaveBeenCalled();
       expect(mockCredits.applyCreditDelta).not.toHaveBeenCalled();
+    });
+
+    it('wraps pool deduction and user credit in db.transaction()', async () => {
+      const poolRow = makePoolRow({
+        initialMicro: 1_000_000,
+        claimedMicro: 0,
+        startedAt: new Date(),
+        drainRateMicroPerMinute: 100,
+      });
+
+      mockDb.select.mockImplementation(() => ({
+        from: () => ({
+          limit: vi.fn().mockResolvedValue([poolRow]),
+        }),
+      }));
+
+      const updatedClaimedMicro = 10_000;
+      mockDb.update.mockImplementation(() => ({
+        set: () => ({
+          where: () => ({
+            returning: vi.fn().mockResolvedValue([{
+              claimedMicro: updatedClaimedMicro,
+              initialMicro: poolRow.initialMicro,
+              startedAt: poolRow.startedAt,
+            }]),
+          }),
+        }),
+      }));
+
+      mockCredits.ensureCreditAccount.mockResolvedValue({
+        userId: 'user-tx',
+        balanceMicro: 0,
+      });
+      mockCredits.applyCreditDelta.mockResolvedValue({
+        userId: 'user-tx',
+        balanceMicro: 10_000,
+      });
+
+      const { claimIntroCredits } = await loadIntroPool();
+      await claimIntroCredits({
+        userId: 'user-tx',
+        credits: 100,
+        source: 'signup',
+      });
+
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(mockDb.transaction).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('rolls back pool deduction when applyCreditDelta throws', async () => {
+      const poolRow = makePoolRow({
+        initialMicro: 1_000_000,
+        claimedMicro: 0,
+        startedAt: new Date(),
+        drainRateMicroPerMinute: 100,
+      });
+
+      mockDb.select.mockImplementation(() => ({
+        from: () => ({
+          limit: vi.fn().mockResolvedValue([poolRow]),
+        }),
+      }));
+
+      const updatedClaimedMicro = 10_000;
+      mockDb.update.mockImplementation(() => ({
+        set: () => ({
+          where: () => ({
+            returning: vi.fn().mockResolvedValue([{
+              claimedMicro: updatedClaimedMicro,
+              initialMicro: poolRow.initialMicro,
+              startedAt: poolRow.startedAt,
+            }]),
+          }),
+        }),
+      }));
+
+      mockCredits.ensureCreditAccount.mockResolvedValue({
+        userId: 'user-fail',
+        balanceMicro: 0,
+      });
+      // Simulate transient DB failure during user credit
+      mockCredits.applyCreditDelta.mockRejectedValue(
+        new Error('connection dropped'),
+      );
+
+      // Make transaction propagate the rejection (as real Drizzle does)
+      mockDb.transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(mockDb));
+
+      const { claimIntroCredits } = await loadIntroPool();
+      await expect(
+        claimIntroCredits({
+          userId: 'user-fail',
+          credits: 100,
+          source: 'signup',
+        }),
+      ).rejects.toThrow('connection dropped');
+
+      // The transaction was called (and would roll back in a real DB)
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('happy path: pool deduction and user credit both succeed in transaction', async () => {
+      const poolRow = makePoolRow({
+        initialMicro: 1_000_000,
+        claimedMicro: 0,
+        startedAt: new Date(),
+        drainRateMicroPerMinute: 100,
+      });
+
+      mockDb.select.mockImplementation(() => ({
+        from: () => ({
+          limit: vi.fn().mockResolvedValue([poolRow]),
+        }),
+      }));
+
+      const updatedClaimedMicro = 10_000;
+      mockDb.update.mockImplementation(() => ({
+        set: () => ({
+          where: () => ({
+            returning: vi.fn().mockResolvedValue([{
+              claimedMicro: updatedClaimedMicro,
+              initialMicro: poolRow.initialMicro,
+              startedAt: poolRow.startedAt,
+            }]),
+          }),
+        }),
+      }));
+
+      mockCredits.ensureCreditAccount.mockResolvedValue({
+        userId: 'user-happy',
+        balanceMicro: 0,
+      });
+      mockCredits.applyCreditDelta.mockResolvedValue({
+        userId: 'user-happy',
+        balanceMicro: 10_000,
+      });
+
+      const { claimIntroCredits } = await loadIntroPool();
+      const result = await claimIntroCredits({
+        userId: 'user-happy',
+        credits: 100,
+        source: 'signup',
+        referenceId: 'ref-happy',
+      });
+
+      // Both operations completed within the transaction
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+      expect(result.claimedMicro).toBe(10_000);
+      expect(result.exhausted).toBe(false);
+      // Pool update happened via tx (which is mockDb in tests)
+      expect(mockDb.update).toHaveBeenCalledWith(introPoolTable);
+      // User credit happened with tx passed through
+      expect(mockCredits.ensureCreditAccount).toHaveBeenCalledWith('user-happy', mockDb);
+      expect(mockCredits.applyCreditDelta).toHaveBeenCalledWith(
+        'user-happy',
+        10_000,
+        'signup',
+        expect.objectContaining({
+          referenceId: 'ref-happy',
+          introPoolClaimedMicro: 10_000,
+        }),
+        mockDb,
+      );
     });
   });
 });

--- a/tests/unit/intro-pool.test.ts
+++ b/tests/unit/intro-pool.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDb, introPoolTable, mockCredits } = vi.hoisted(() => {
+const { mockDb, mockTx, introPoolTable, mockCredits } = vi.hoisted(() => {
   const pool = {
     id: 'id',
     initialMicro: 'initial_micro',
@@ -9,11 +9,16 @@ const { mockDb, introPoolTable, mockCredits } = vi.hoisted(() => {
     startedAt: 'started_at',
     updatedAt: 'updated_at',
   };
+  const tx = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  };
   const db = {
     select: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
-    transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(db)),
+    transaction: vi.fn(async (fn: (txArg: unknown) => unknown) => fn(tx)),
   };
   const credits = {
     ensureCreditAccount: vi.fn(),
@@ -21,7 +26,7 @@ const { mockDb, introPoolTable, mockCredits } = vi.hoisted(() => {
     MICRO_PER_CREDIT: 100,
     CREDITS_ENABLED: true,
   };
-  return { mockDb: db, introPoolTable: pool, mockCredits: credits };
+  return { mockDb: db, mockTx: tx, introPoolTable: pool, mockCredits: credits };
 });
 
 vi.mock('@/db', () => ({
@@ -58,8 +63,11 @@ describe('intro-pool', () => {
     mockDb.insert.mockReset();
     mockDb.update.mockReset();
     mockDb.transaction.mockReset();
-    // Default: transaction executes its callback with mockDb as the tx
-    mockDb.transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(mockDb));
+    mockTx.select.mockReset();
+    mockTx.insert.mockReset();
+    mockTx.update.mockReset();
+    // Default: transaction executes its callback with mockTx (distinct from mockDb)
+    mockDb.transaction.mockImplementation(async (fn: (txArg: unknown) => unknown) => fn(mockTx));
     mockCredits.ensureCreditAccount.mockReset();
     mockCredits.applyCreditDelta.mockReset();
     process.env.INTRO_POOL_TOTAL_CREDITS = '15000';
@@ -183,16 +191,24 @@ describe('intro-pool', () => {
   });
 
   describe('claimIntroCredits', () => {
-    /** Build a select mock that handles both ensureIntroPool (no where) and
-     *  the in-transaction baseline read (with where). Both return the pool row. */
-    const makeSelectMock = (poolRow: ReturnType<typeof makePoolRow>) => {
-      const limitFn = vi.fn().mockResolvedValue([poolRow]);
-      return () => ({
+    /** Set up select mocks for both mockDb (ensureIntroPool) and mockTx
+     *  (in-transaction baseline read with FOR UPDATE). */
+    const setupSelectMocks = (poolRow: ReturnType<typeof makePoolRow>) => {
+      // mockDb.select: used by ensureIntroPool (outside transaction)
+      mockDb.select.mockImplementation(() => ({
         from: () => ({
-          limit: limitFn,
-          where: () => ({ limit: vi.fn().mockResolvedValue([poolRow]) }),
+          limit: vi.fn().mockResolvedValue([poolRow]),
         }),
-      });
+      }));
+      // mockTx.select: used inside the transaction (baseline read with .for('update'))
+      mockTx.select.mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            for: () => ({ limit: vi.fn().mockResolvedValue([poolRow]) }),
+          }),
+        }),
+      }));
+      // mockTx.update: mirror mockDb.update setup (done per-test)
     };
 
     it('H3: successfully claims and credits user', async () => {
@@ -204,11 +220,11 @@ describe('intro-pool', () => {
       });
 
       // ensureIntroPool select + in-transaction baseline read
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
-      // Atomic update returning updated pool state
+      // Atomic update returning updated pool state (inside tx)
       const updatedClaimedMicro = 10_000; // 100 credits * 100 micro
-      mockDb.update.mockImplementation(() => ({
+      mockTx.update.mockImplementation(() => ({
         set: () => ({
           where: () => ({
             returning: vi.fn().mockResolvedValue([{
@@ -240,7 +256,7 @@ describe('intro-pool', () => {
 
       expect(result.claimedMicro).toBe(10_000);
       expect(result.exhausted).toBe(false);
-      expect(mockCredits.ensureCreditAccount).toHaveBeenCalledWith('user-1', mockDb);
+      expect(mockCredits.ensureCreditAccount).toHaveBeenCalledWith('user-1', mockTx);
       expect(mockCredits.applyCreditDelta).toHaveBeenCalledWith(
         'user-1',
         10_000,
@@ -249,11 +265,11 @@ describe('intro-pool', () => {
           referenceId: 'ref-1',
           introPoolClaimedMicro: 10_000,
         }),
-        mockDb,
+        mockTx,
       );
     });
 
-    it('U3: claim amount exceeds remaining → partial claim', async () => {
+    it('U3: claim amount exceeds remaining - partial claim', async () => {
       // Pool has only 5000 micro remaining, but user requests 10_000
       const poolRow = makePoolRow({
         initialMicro: 10_000,
@@ -262,11 +278,11 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 0,
       });
 
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
       // SQL LEAST caps the claim: actual claimed = old + LEAST(requested, available)
       // Simulating: only 3000 actually claimed (partial)
-      mockDb.update.mockImplementation(() => ({
+      mockTx.update.mockImplementation(() => ({
         set: () => ({
           where: () => ({
             returning: vi.fn().mockResolvedValue([{
@@ -302,7 +318,7 @@ describe('intro-pool', () => {
         3_000,
         'signup',
         expect.objectContaining({ introPoolClaimedMicro: 3_000 }),
-        mockDb,
+        mockTx,
       );
     });
 
@@ -316,7 +332,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
       const { claimIntroCredits } = await loadIntroPool();
       const result = await claimIntroCredits({
@@ -328,11 +344,11 @@ describe('intro-pool', () => {
       expect(result.claimedMicro).toBe(0);
       expect(result.exhausted).toBe(true);
       // No update attempted since pre-check fails
-      expect(mockDb.update).not.toHaveBeenCalled();
+      expect(mockTx.update).not.toHaveBeenCalled();
       expect(mockCredits.ensureCreditAccount).not.toHaveBeenCalled();
     });
 
-    it('atomic update returns nothing → returns exhausted', async () => {
+    it('atomic update returns nothing - returns exhausted', async () => {
       const poolRow = makePoolRow({
         initialMicro: 100_000,
         claimedMicro: 50_000,
@@ -340,10 +356,10 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 0,
       });
 
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
       // Update returns empty (pool row not found)
-      mockDb.update.mockImplementation(() => ({
+      mockTx.update.mockImplementation(() => ({
         set: () => ({
           where: () => ({
             returning: vi.fn().mockResolvedValue([]),
@@ -362,7 +378,7 @@ describe('intro-pool', () => {
       expect(result.exhausted).toBe(true);
     });
 
-    it('zero actual claimed → no credit applied', async () => {
+    it('zero actual claimed - no credit applied', async () => {
       const poolRow = makePoolRow({
         initialMicro: 100_000,
         claimedMicro: 50_000,
@@ -370,10 +386,10 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 0,
       });
 
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
       // Update returns but claimed didn't change (actualClaimed = 0)
-      mockDb.update.mockImplementation(() => ({
+      mockTx.update.mockImplementation(() => ({
         set: () => ({
           where: () => ({
             returning: vi.fn().mockResolvedValue([{
@@ -406,10 +422,10 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
       const updatedClaimedMicro = 10_000;
-      mockDb.update.mockImplementation(() => ({
+      mockTx.update.mockImplementation(() => ({
         set: () => ({
           where: () => ({
             returning: vi.fn().mockResolvedValue([{
@@ -449,10 +465,10 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
       const updatedClaimedMicro = 10_000;
-      mockDb.update.mockImplementation(() => ({
+      mockTx.update.mockImplementation(() => ({
         set: () => ({
           where: () => ({
             returning: vi.fn().mockResolvedValue([{
@@ -474,7 +490,7 @@ describe('intro-pool', () => {
       );
 
       // Make transaction propagate the rejection (as real Drizzle does)
-      mockDb.transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn(mockDb));
+      mockDb.transaction.mockImplementation(async (fn: (txArg: unknown) => unknown) => fn(mockTx));
 
       const { claimIntroCredits } = await loadIntroPool();
       await expect(
@@ -497,10 +513,10 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(makeSelectMock(poolRow));
+      setupSelectMocks(poolRow);
 
       const updatedClaimedMicro = 10_000;
-      mockDb.update.mockImplementation(() => ({
+      mockTx.update.mockImplementation(() => ({
         set: () => ({
           where: () => ({
             returning: vi.fn().mockResolvedValue([{
@@ -533,10 +549,10 @@ describe('intro-pool', () => {
       expect(mockDb.transaction).toHaveBeenCalledTimes(1);
       expect(result.claimedMicro).toBe(10_000);
       expect(result.exhausted).toBe(false);
-      // Pool update happened via tx (which is mockDb in tests)
-      expect(mockDb.update).toHaveBeenCalledWith(introPoolTable);
+      // Pool update happened via tx (distinct from mockDb)
+      expect(mockTx.update).toHaveBeenCalledWith(introPoolTable);
       // User credit happened with tx passed through
-      expect(mockCredits.ensureCreditAccount).toHaveBeenCalledWith('user-happy', mockDb);
+      expect(mockCredits.ensureCreditAccount).toHaveBeenCalledWith('user-happy', mockTx);
       expect(mockCredits.applyCreditDelta).toHaveBeenCalledWith(
         'user-happy',
         10_000,
@@ -545,7 +561,7 @@ describe('intro-pool', () => {
           referenceId: 'ref-happy',
           introPoolClaimedMicro: 10_000,
         }),
-        mockDb,
+        mockTx,
       );
     });
   });

--- a/tests/unit/intro-pool.test.ts
+++ b/tests/unit/intro-pool.test.ts
@@ -183,6 +183,18 @@ describe('intro-pool', () => {
   });
 
   describe('claimIntroCredits', () => {
+    /** Build a select mock that handles both ensureIntroPool (no where) and
+     *  the in-transaction baseline read (with where). Both return the pool row. */
+    const makeSelectMock = (poolRow: ReturnType<typeof makePoolRow>) => {
+      const limitFn = vi.fn().mockResolvedValue([poolRow]);
+      return () => ({
+        from: () => ({
+          limit: limitFn,
+          where: () => ({ limit: vi.fn().mockResolvedValue([poolRow]) }),
+        }),
+      });
+    };
+
     it('H3: successfully claims and credits user', async () => {
       const poolRow = makePoolRow({
         initialMicro: 1_000_000,
@@ -191,12 +203,8 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      // ensureIntroPool select
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      // ensureIntroPool select + in-transaction baseline read
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       // Atomic update returning updated pool state
       const updatedClaimedMicro = 10_000; // 100 credits * 100 micro
@@ -254,11 +262,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 0,
       });
 
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       // SQL LEAST caps the claim: actual claimed = old + LEAST(requested, available)
       // Simulating: only 3000 actually claimed (partial)
@@ -312,11 +316,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       const { claimIntroCredits } = await loadIntroPool();
       const result = await claimIntroCredits({
@@ -340,11 +340,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 0,
       });
 
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       // Update returns empty (pool row not found)
       mockDb.update.mockImplementation(() => ({
@@ -374,11 +370,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 0,
       });
 
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       // Update returns but claimed didn't change (actualClaimed = 0)
       mockDb.update.mockImplementation(() => ({
@@ -414,11 +406,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       const updatedClaimedMicro = 10_000;
       mockDb.update.mockImplementation(() => ({
@@ -453,7 +441,7 @@ describe('intro-pool', () => {
       expect(mockDb.transaction).toHaveBeenCalledWith(expect.any(Function));
     });
 
-    it('rolls back pool deduction when applyCreditDelta throws', async () => {
+    it('propagates applyCreditDelta errors out of transaction callback', async () => {
       const poolRow = makePoolRow({
         initialMicro: 1_000_000,
         claimedMicro: 0,
@@ -461,11 +449,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       const updatedClaimedMicro = 10_000;
       mockDb.update.mockImplementation(() => ({
@@ -513,11 +497,7 @@ describe('intro-pool', () => {
         drainRateMicroPerMinute: 100,
       });
 
-      mockDb.select.mockImplementation(() => ({
-        from: () => ({
-          limit: vi.fn().mockResolvedValue([poolRow]),
-        }),
-      }));
+      mockDb.select.mockImplementation(makeSelectMock(poolRow));
 
       const updatedClaimedMicro = 10_000;
       mockDb.update.mockImplementation(() => ({


### PR DESCRIPTION
## Summary

- Wrap intro pool claim + user credit grant in a single `db.transaction()` so both succeed or fail atomically
- Add optional `tx` parameter to `applyCreditDelta` and `ensureCreditAccount` for outer transaction threading
- Read fresh pool baseline inside the transaction to prevent stale-snapshot delta inflation under concurrent claims

## Problem

`claimIntroCredits` performed two separate DB operations: pool deduction (atomic UPDATE) then user credit (`applyCreditDelta`). If the second failed after the first succeeded, credits leaked permanently from the finite intro pool without reaching the user. No reconciliation mechanism existed.

## Technical decisions

- `DbOrTx` type accepts both root db instance and transaction handle via `Pick<>` on Drizzle's return type
- When `tx` is provided, `applyCreditDelta` executes directly on it (no nested transaction); when absent, creates its own as before
- `ensureIntroPool()` remains outside the transaction (guarantees row exists) but a fresh `claimedMicro` SELECT runs inside the transaction for accurate delta computation
- `consumeIntroPoolAnonymous` unchanged (does not credit a user account)

## Darkcat review

- DC-1 (Claude): PASS WITH FINDINGS - 1 major (stale snapshot, fixed), 2 minor (type naming, test rename - both fixed)
- DC-2 (Codex): rate limited
- DC-3 (Gemini): rate limited

## Tests

- 7 new tests across `tests/unit/intro-pool.test.ts` and `tests/unit/credits.test.ts`
- Verify transaction wrapping, error propagation, tx parameter threading, backward compatibility
- Gate: lint + typecheck + 1380 tests passed

Roadmap ref: RD-001 (Phase 0: Safety Net)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make intro pool deduction and user credit grant atomic to prevent leaked credits during failures or concurrent claims. Aligns with RD-001 by ensuring claims either fully credit the user or roll back.

- **Bug Fixes**
  - Wrapped pool deduction and user credit in a single `db.transaction()` in `claimIntroCredits` so both succeed or fail together.
  - Added optional `tx` to `ensureCreditAccount` and `applyCreditDelta`; uses caller’s transaction when provided, otherwise opens its own (backward compatible, avoids nested transactions).
  - Inside the transaction, re-read the pool baseline with `SELECT ... FOR UPDATE` before `UPDATE` to avoid stale baselines and inflated deltas under concurrent claims.

<sup>Written for commit c447c7ca2148f700ca132556964848a85bf385fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

