### PR TITLE
fix(webhook): wrap PostHog calls in Stripe webhook with try/catch (RD-005)

### DIFF
--- a/app/api/credits/webhook/route.ts
+++ b/app/api/credits/webhook/route.ts
@@ -190,15 +190,16 @@ export const POST = withLogging(async function POST(req: Request) {
           log.info('Subscription grant applied', { userId, tier, credits: grantCredits });
         }
 
-        try {
-          await serverTrack(userId, 'subscription_started', {
+        try { await serverTrack(userId, 'subscription_started', {
             tier,
             subscription_id: subscription.id,
             status: subscription.status,
             grant_credits: grantCredits,
           });
-          await serverIdentify(userId, { current_tier: tier });
         } catch {
+          // Best-effort - analytics loss is acceptable, webhook failure is not
+        }
+        try { await serverIdentify(userId, { current_tier: tier }); } catch {
           // Best-effort - analytics loss is acceptable, webhook failure is not
         }
         log.info('Subscription created', { userId, tier, subscriptionId: subscription.id });
@@ -337,13 +338,14 @@ export const POST = withLogging(async function POST(req: Request) {
         currentPeriodEnd: null,
         stripeCustomerId: subscription.customer,
       });
-      try {
-        await serverTrack(userId, 'subscription_churned', {
+      try { await serverTrack(userId, 'subscription_churned', {
           subscription_id: subscription.id,
           previous_tier: previousTier,
         });
-        await serverIdentify(userId, { current_tier: 'free' });
       } catch {
+        // Best-effort - analytics loss is acceptable, webhook failure is not
+      }
+      try { await serverIdentify(userId, { current_tier: 'free' }); } catch {
         // Best-effort - analytics loss is acceptable, webhook failure is not
       }
       log.info('Subscription deleted, downgraded to free', { userId });
@@ -390,14 +392,15 @@ export const POST = withLogging(async function POST(req: Request) {
         currentPeriodEnd: null,
         stripeCustomerId: invoice.customer,
       });
-      try {
-        await serverTrack(userId, 'payment_failed', {
+      try { await serverTrack(userId, 'payment_failed', {
           subscription_id: invoice.subscription,
           invoice_id: invoice.id,
           previous_tier: previousTier,
         });
-        await serverIdentify(userId, { current_tier: 'free' });
       } catch {
+        // Best-effort - analytics loss is acceptable, webhook failure is not
+      }
+      try { await serverIdentify(userId, { current_tier: 'free' }); } catch {
         // Best-effort - analytics loss is acceptable, webhook failure is not
       }
       log.info('Payment failed, downgraded to free', { userId, subscriptionId: invoice.subscription });

--- a/app/api/credits/webhook/route.ts
+++ b/app/api/credits/webhook/route.ts
@@ -127,12 +127,16 @@ export const POST = withLogging(async function POST(req: Request) {
           referenceId: session.id,
           credits,
         });
-        await serverTrack(userId, 'credit_purchase_completed', {
-          credits,
-          amount_total: session.amount_total ?? 0,
-          currency: session.currency ?? 'gbp',
-          session_id: session.id,
-        });
+        try {
+          await serverTrack(userId, 'credit_purchase_completed', {
+            credits,
+            amount_total: session.amount_total ?? 0,
+            currency: session.currency ?? 'gbp',
+            session_id: session.id,
+          });
+        } catch {
+          // Best-effort - analytics loss is acceptable, webhook failure is not
+        }
       }
 
       if (existing) {
@@ -186,13 +190,17 @@ export const POST = withLogging(async function POST(req: Request) {
           log.info('Subscription grant applied', { userId, tier, credits: grantCredits });
         }
 
-        await serverTrack(userId, 'subscription_started', {
-          tier,
-          subscription_id: subscription.id,
-          status: subscription.status,
-          grant_credits: grantCredits,
-        });
-        await serverIdentify(userId, { current_tier: tier });
+        try {
+          await serverTrack(userId, 'subscription_started', {
+            tier,
+            subscription_id: subscription.id,
+            status: subscription.status,
+            grant_credits: grantCredits,
+          });
+          await serverIdentify(userId, { current_tier: tier });
+        } catch {
+          // Best-effort - analytics loss is acceptable, webhook failure is not
+        }
         log.info('Subscription created', { userId, tier, subscriptionId: subscription.id });
       }
     }
@@ -269,20 +277,32 @@ export const POST = withLogging(async function POST(req: Request) {
             log.info('Upgrade grant applied', { userId, from: oldTier, to: tier, credits: incrementalGrant });
           }
 
-          await serverTrack(userId, 'subscription_upgraded', {
-            from_tier: oldTier,
-            to_tier: tier,
-            subscription_id: subscription.id,
-            grant_credits: incrementalGrant,
-          });
+          try {
+            await serverTrack(userId, 'subscription_upgraded', {
+              from_tier: oldTier,
+              to_tier: tier,
+              subscription_id: subscription.id,
+              grant_credits: incrementalGrant,
+            });
+          } catch {
+            // Best-effort - analytics loss is acceptable, webhook failure is not
+          }
         } else if (newTierRank < oldTierRank) {
-          await serverTrack(userId, 'subscription_downgraded', {
-            from_tier: oldTier,
-            to_tier: tier,
-            subscription_id: subscription.id,
-          });
+          try {
+            await serverTrack(userId, 'subscription_downgraded', {
+              from_tier: oldTier,
+              to_tier: tier,
+              subscription_id: subscription.id,
+            });
+          } catch {
+            // Best-effort - analytics loss is acceptable, webhook failure is not
+          }
         }
-        await serverIdentify(userId, { current_tier: tier });
+        try {
+          await serverIdentify(userId, { current_tier: tier });
+        } catch {
+          // Best-effort - analytics loss is acceptable, webhook failure is not
+        }
         log.info('Subscription updated', { userId, tier, status: subscription.status });
       }
     }
@@ -317,11 +337,15 @@ export const POST = withLogging(async function POST(req: Request) {
         currentPeriodEnd: null,
         stripeCustomerId: subscription.customer,
       });
-      await serverTrack(userId, 'subscription_churned', {
-        subscription_id: subscription.id,
-        previous_tier: previousTier,
-      });
-      await serverIdentify(userId, { current_tier: 'free' });
+      try {
+        await serverTrack(userId, 'subscription_churned', {
+          subscription_id: subscription.id,
+          previous_tier: previousTier,
+        });
+        await serverIdentify(userId, { current_tier: 'free' });
+      } catch {
+        // Best-effort - analytics loss is acceptable, webhook failure is not
+      }
       log.info('Subscription deleted, downgraded to free', { userId });
     }
   }
@@ -366,12 +390,16 @@ export const POST = withLogging(async function POST(req: Request) {
         currentPeriodEnd: null,
         stripeCustomerId: invoice.customer,
       });
-      await serverTrack(userId, 'payment_failed', {
-        subscription_id: invoice.subscription,
-        invoice_id: invoice.id,
-        previous_tier: previousTier,
-      });
-      await serverIdentify(userId, { current_tier: 'free' });
+      try {
+        await serverTrack(userId, 'payment_failed', {
+          subscription_id: invoice.subscription,
+          invoice_id: invoice.id,
+          previous_tier: previousTier,
+        });
+        await serverIdentify(userId, { current_tier: 'free' });
+      } catch {
+        // Best-effort - analytics loss is acceptable, webhook failure is not
+      }
       log.info('Payment failed, downgraded to free', { userId, subscriptionId: invoice.subscription });
     }
   }

--- a/tests/api/webhook-subscription.test.ts
+++ b/tests/api/webhook-subscription.test.ts
@@ -10,6 +10,8 @@ const {
   mockEnsureCreditAccount,
   mockResolveTierFromPriceId,
   mockHeaders,
+  mockServerTrack,
+  mockServerIdentify,
 } = vi.hoisted(() => {
   const db = {
     select: vi.fn(),
@@ -26,6 +28,8 @@ const {
   const applyCreditDelta = vi.fn().mockResolvedValue(undefined);
   const ensureCreditAccount = vi.fn().mockResolvedValue(undefined);
   const resolveTierFromPriceId = vi.fn();
+  const serverTrack = vi.fn().mockResolvedValue(undefined);
+  const serverIdentify = vi.fn().mockResolvedValue(undefined);
 
   const headerMap = new Map<string, string>();
   const headers = vi.fn().mockResolvedValue({
@@ -39,6 +43,8 @@ const {
     mockEnsureCreditAccount: ensureCreditAccount,
     mockResolveTierFromPriceId: resolveTierFromPriceId,
     mockHeaders: { fn: headers, map: headerMap },
+    mockServerTrack: serverTrack,
+    mockServerIdentify: serverIdentify,
   };
 });
 
@@ -87,6 +93,11 @@ vi.mock('@/lib/credits', () => ({
 
 vi.mock('@/lib/tier', () => ({
   resolveTierFromPriceId: mockResolveTierFromPriceId,
+}));
+
+vi.mock('@/lib/posthog-server', () => ({
+  serverTrack: mockServerTrack,
+  serverIdentify: mockServerIdentify,
 }));
 
 vi.mock('next/headers', () => ({
@@ -176,6 +187,8 @@ describe('POST /api/credits/webhook', () => {
     // Re-establish mock implementations wiped by resetAllMocks
     mockApplyCreditDelta.mockResolvedValue(undefined);
     mockEnsureCreditAccount.mockResolvedValue(undefined);
+    mockServerTrack.mockResolvedValue(undefined);
+    mockServerIdentify.mockResolvedValue(undefined);
     mockHeaders.fn.mockResolvedValue({
       get: (name: string) => mockHeaders.map.get(name) ?? null,
     });
@@ -922,5 +935,163 @@ describe('POST /api/credits/webhook', () => {
     const res = await POST(makeRequest());
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ received: true });
+  });
+
+  // ==================================================================
+  // PostHog failure resilience - webhook must return 200 even when
+  // analytics calls throw (RD-005)
+  // ==================================================================
+
+  // ------------------------------------------------------------------
+  // 26. checkout.session.completed: returns 200 when serverTrack throws
+  // ------------------------------------------------------------------
+  it('checkout.session.completed: returns 200 when serverTrack throws', async () => {
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_ph_fail',
+          mode: 'payment',
+          metadata: { userId: 'user_ph_fail', credits: '50' },
+        },
+      },
+    });
+
+    setupSelect([]);
+    mockServerTrack.mockRejectedValue(new Error('PostHog outage'));
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+
+    // Business logic still ran
+    expect(mockApplyCreditDelta).toHaveBeenCalledWith(
+      'user_ph_fail',
+      50 * 100,
+      'purchase',
+      { referenceId: 'cs_ph_fail', credits: 50 },
+    );
+  });
+
+  // ------------------------------------------------------------------
+  // 27. customer.subscription.created: returns 200 when PostHog throws
+  // ------------------------------------------------------------------
+  it('customer.subscription.created: returns 200 when PostHog throws', async () => {
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'customer.subscription.created',
+      data: {
+        object: {
+          id: 'sub_ph_fail',
+          status: 'active',
+          customer: 'cus_ph_fail',
+          metadata: { userId: 'user_sub_ph_fail' },
+          items: { data: [{ price: { id: 'price_pass' } }] },
+          current_period_end: 1700000000,
+        },
+      },
+    });
+
+    mockResolveTierFromPriceId.mockReturnValue('pass');
+    setupSelect([]);
+    setupUpdate();
+    mockServerTrack.mockRejectedValue(new Error('PostHog outage'));
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+
+    // Tier update and credit grant still applied
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockApplyCreditDelta).toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------------------
+  // 28. customer.subscription.updated: returns 200 when PostHog throws
+  // ------------------------------------------------------------------
+  it('customer.subscription.updated: returns 200 when PostHog throws', async () => {
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_upd_ph_fail',
+          status: 'active',
+          customer: 'cus_upd_ph_fail',
+          metadata: { userId: 'user_upd_ph_fail' },
+          items: { data: [{ price: { id: 'price_lab' } }] },
+          current_period_end: 1800000000,
+        },
+      },
+    });
+
+    mockResolveTierFromPriceId.mockReturnValue('lab');
+    // User was on pass, upgrading to lab
+    setupSelect([[{ tier: 'pass' }], []]);
+    setupUpdate();
+    mockServerTrack.mockRejectedValue(new Error('PostHog outage'));
+    mockServerIdentify.mockRejectedValue(new Error('PostHog outage'));
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+
+    // Tier update and credit grant still applied
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockApplyCreditDelta).toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------------------
+  // 29. customer.subscription.deleted: returns 200 when PostHog throws
+  // ------------------------------------------------------------------
+  it('customer.subscription.deleted: returns 200 when PostHog throws', async () => {
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'customer.subscription.deleted',
+      data: {
+        object: {
+          id: 'sub_del_ph_fail',
+          status: 'canceled',
+          customer: 'cus_del_ph_fail',
+          metadata: { userId: 'user_del_ph_fail' },
+        },
+      },
+    });
+
+    setupUpdate();
+    mockServerTrack.mockRejectedValue(new Error('PostHog outage'));
+    mockServerIdentify.mockRejectedValue(new Error('PostHog outage'));
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+
+    // Tier downgrade still applied
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------------------
+  // 30. invoice.payment_failed: returns 200 when PostHog throws
+  // ------------------------------------------------------------------
+  it('invoice.payment_failed: returns 200 when PostHog throws', async () => {
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'invoice.payment_failed',
+      data: {
+        object: {
+          id: 'inv_fail_ph',
+          customer: 'cus_fail_ph',
+          subscription: 'sub_fail_ph',
+          subscription_details: { metadata: { userId: 'user_fail_ph' } },
+        },
+      },
+    });
+
+    setupUpdate();
+    mockServerTrack.mockRejectedValue(new Error('PostHog outage'));
+    mockServerIdentify.mockRejectedValue(new Error('PostHog outage'));
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+
+    // Tier downgrade still applied
+    expect(mockDb.update).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Wrap all 7 PostHog call sites across 5 Stripe webhook handlers in try/catch
- Split serverTrack/serverIdentify into separate try/catch blocks so identify always runs
- 5 new tests verify webhook returns 200 when PostHog fails

Darkcat: Claude PASS WITH FINDINGS (major: split try/catch - fixed)
Gate: typecheck + 1405 tests green
Roadmap: RD-005 Phase 1 Error Handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Stripe webhooks resilient to PostHog outages by wrapping analytics calls in try/catch so handlers still return 200 and avoid Stripe retry cascades. Aligns with RD-005 error handling; no business logic changes.

- **Bug Fixes**
  - Wrapped all PostHog `serverTrack`/`serverIdentify` calls across 5 webhook handlers in try/catch.
  - Split `serverTrack` and `serverIdentify` into separate blocks so identify still runs if track fails.
  - Added 5 tests to verify 200 responses when PostHog throws.

<sup>Written for commit f15e33e54ca1026d43d40543260c726434739035. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed webhook processing failures that occurred during analytics service issues, ensuring credit purchases and subscription updates continue to work reliably.

* **Tests**
  * Added resilience tests to verify webhook processing continues when analytics services experience failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->