### PR TITLE
fix(actions): add try/catch to createBout and createArenaBout DB inserts (RD-006)

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -163,18 +163,23 @@ export async function createArenaBout(formData: FormData) {
 
   const db = requireDb();
   const id = nanoid();
-  await db.insert(bouts).values({
-    id,
-    presetId: ARENA_PRESET_ID,
-    status: 'running',
-    transcript: [],
-    ownerId: userId ?? null,
-    topic: topic || null,
-    responseLength: lengthConfig.id,
-    responseFormat: formatConfig.id,
-    maxTurns,
-    agentLineup: lineup,
-  });
+  try {
+    await db.insert(bouts).values({
+      id,
+      presetId: ARENA_PRESET_ID,
+      status: 'running',
+      transcript: [],
+      ownerId: userId ?? null,
+      topic: topic || null,
+      responseLength: lengthConfig.id,
+      responseFormat: formatConfig.id,
+      maxTurns,
+      agentLineup: lineup,
+    });
+  } catch (error) {
+    console.error('Failed to create arena bout:', error);
+    redirect('/arena?error=service-unavailable');
+  }
 
   const params = new URLSearchParams();
   if (model) {

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -86,16 +86,21 @@ export async function createBout(presetId: string, formData?: FormData) {
     await ensureUserRecord(userId);
   }
 
-  await db.insert(bouts).values({
-    id,
-    presetId,
-    status: 'running',
-    transcript: [],
-    ownerId: userId ?? null,
-    topic: topic ?? null,
-    responseLength: lengthConfig.id,
-    responseFormat: formatConfig.id,
-  });
+  try {
+    await db.insert(bouts).values({
+      id,
+      presetId,
+      status: 'running',
+      transcript: [],
+      ownerId: userId ?? null,
+      topic: topic ?? null,
+      responseLength: lengthConfig.id,
+      responseFormat: formatConfig.id,
+    });
+  } catch (error) {
+    console.error('Failed to create bout:', error);
+    redirect('/arena?error=service-unavailable');
+  }
 
   const params = new URLSearchParams({ presetId });
   if (topic) {

--- a/tests/unit/actions.test.ts
+++ b/tests/unit/actions.test.ts
@@ -472,6 +472,19 @@ describe('server actions', () => {
   });
 
   // ================================================================
+  // createBout - DB error handling
+  // ================================================================
+  describe('createBout - DB error handling', () => {
+    it('redirects to /arena?error=service-unavailable when DB insert throws', async () => {
+      const mockValues = vi.fn().mockRejectedValue(new Error('connection refused'));
+      mockDb.insert.mockReturnValue({ values: mockValues });
+
+      const url = await catchRedirect(() => createBout('darwin-special'));
+      expect(url).toBe('/arena?error=service-unavailable');
+    });
+  });
+
+  // ================================================================
   // archiveAgent / restoreAgent
   // ================================================================
   describe('archiveAgent', () => {


### PR DESCRIPTION
## Summary
- Wrap DB insert in createBout with try/catch, redirect to /arena?error=service-unavailable
- Apply same pattern to createArenaBout (darkcat caught the omission)
- Tests verify error redirect behaviour

Darkcat: Claude PASS WITH FINDINGS (major: createArenaBout unprotected - fixed)
Gate: typecheck + 1401 tests green
Roadmap: RD-006 Phase 1 Error Handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add try/catch around DB inserts in `createBout` and `createArenaBout` to handle failures by redirecting to `/arena?error=service-unavailable`. Adds a unit test verifying the redirect in `createBout`, fulfilling RD-006 Phase 1 error handling.

<sup>Written for commit c1dbb5875c8ab4d735eda664d576288381e8503f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

