### PR TITLE
fix(logging): prevent double-fault in api-logging error path (RD-007)

### DIFF
--- a/lib/api-logging.ts
+++ b/lib/api-logging.ts
@@ -108,7 +108,9 @@ export function withLogging(
         console.error('[DOUBLE-FAULT] Logger failed while handling error. Original error:', error);
         console.error('[DOUBLE-FAULT] Logger error:', loggingError);
       }
-      checkAnomaly({ clientIp, userAgent, route: routeName, status: 500 });
+      try { checkAnomaly({ clientIp, userAgent, route: routeName, status: 500 }); } catch {
+        // Prevent checkAnomaly failure from masking the original error
+      }
       throw error;
     }
   };

--- a/lib/api-logging.ts
+++ b/lib/api-logging.ts
@@ -96,12 +96,18 @@ export function withLogging(
       return response;
     } catch (error) {
       const durationMs = Date.now() - start;
-      log.error(`${method} ${path} unhandled error`, toError(error), {
-        requestId,
-        route: routeName,
-        durationMs,
-        clientIp,
-      });
+      try {
+        log.error(`${method} ${path} unhandled error`, toError(error), {
+          requestId,
+          route: routeName,
+          durationMs,
+          clientIp,
+        });
+      } catch (loggingError) {
+        // Double-fault: logger itself failed. Fall back to console to preserve the original error.
+        console.error('[DOUBLE-FAULT] Logger failed while handling error. Original error:', error);
+        console.error('[DOUBLE-FAULT] Logger error:', loggingError);
+      }
       checkAnomaly({ clientIp, userAgent, route: routeName, status: 500 });
       throw error;
     }

--- a/tests/unit/api-logging.test.ts
+++ b/tests/unit/api-logging.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock dependencies before importing the module under test.
+const mockLogError = vi.fn();
+const mockLogWarn = vi.fn();
+const mockLogInfo = vi.fn();
+
+vi.mock('@/lib/logger', () => ({
+  log: {
+    info: (...args: unknown[]) => mockLogInfo(...args),
+    warn: (...args: unknown[]) => mockLogWarn(...args),
+    error: (...args: unknown[]) => mockLogError(...args),
+  },
+}));
+
+vi.mock('@/lib/request-context', () => ({
+  getRequestId: () => 'req-test-123',
+  getClientIp: () => '127.0.0.1',
+  getUserAgent: () => 'test-agent',
+  getReferer: () => '',
+}));
+
+vi.mock('@/lib/anomaly', () => ({
+  checkAnomaly: vi.fn(),
+}));
+
+vi.mock('@/lib/async-context', () => ({
+  requestStore: {
+    run: (_ctx: unknown, fn: () => unknown) => fn(),
+  },
+}));
+
+describe('withLogging', () => {
+  let withLogging: typeof import('@/lib/api-logging').withLogging;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockLogError.mockReset();
+    mockLogWarn.mockReset();
+    mockLogInfo.mockReset();
+
+    // Re-import with fresh mocks
+    const mod = await import('@/lib/api-logging');
+    withLogging = mod.withLogging;
+
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeRequest(path = '/api/test'): Request {
+    return new Request(`http://localhost${path}`, {
+      method: 'GET',
+      headers: {
+        'x-request-id': 'req-test-123',
+        'x-client-ip': '127.0.0.1',
+        'user-agent': 'test-agent',
+      },
+    });
+  }
+
+  it('logs and re-throws when handler throws', async () => {
+    const originalError = new Error('handler exploded');
+    const handler = vi.fn().mockRejectedValue(originalError);
+    const wrapped = withLogging(handler, 'test-route');
+
+    await expect(wrapped(makeRequest())).rejects.toThrow('handler exploded');
+    expect(mockLogError).toHaveBeenCalledOnce();
+  });
+
+  describe('double-fault resilience', () => {
+    it('falls back to console.error when logger throws during error handling', async () => {
+      const originalError = new Error('handler exploded');
+      const loggerError = new Error('serialization failed');
+
+      // Handler throws the original error
+      const handler = vi.fn().mockRejectedValue(originalError);
+
+      // Logger itself throws when trying to log the error
+      mockLogError.mockImplementation(() => {
+        throw loggerError;
+      });
+
+      const wrapped = withLogging(handler, 'test-route');
+
+      // The original error should still be re-thrown
+      await expect(wrapped(makeRequest())).rejects.toThrow('handler exploded');
+
+      // console.error should have been called with DOUBLE-FAULT messages
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[DOUBLE-FAULT] Logger failed while handling error. Original error:',
+        originalError,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[DOUBLE-FAULT] Logger error:',
+        loggerError,
+      );
+    });
+
+    it('preserves the original error even when logger fails', async () => {
+      const originalError = new Error('the real problem');
+
+      const handler = vi.fn().mockRejectedValue(originalError);
+      mockLogError.mockImplementation(() => {
+        throw new Error('logger broke');
+      });
+
+      const wrapped = withLogging(handler, 'test-route');
+
+      // The thrown error must be the original, not the logger error
+      let caught: unknown;
+      try {
+        await wrapped(makeRequest());
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBe(originalError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap log.error in withLogging catch block with try/catch fallback to console.error
- Wrap checkAnomaly in same path (darkcat caught the incomplete fix)
- 3 new tests verify double-fault resilience and original error preservation

Darkcat: Claude PASS WITH FINDINGS (major: checkAnomaly unprotected - fixed)
Gate: typecheck + 1403 tests green
Roadmap: RD-007 Phase 1 Error Handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents logger failures from masking original API errors in withLogging. Adds console fallbacks and protects anomaly checks, aligning with RD-007 Phase 1 error handling.

- **Bug Fixes**
  - Wrapped log.error in try/catch; on failure, fall back to console.error with [DOUBLE-FAULT] and preserve the original error.
  - Wrapped checkAnomaly in try/catch to avoid masking the original error if it throws.
  - Added unit tests for double-fault resilience and original error identity.

<sup>Written for commit b65702d290e3276f4e50ae9122156c60577354ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

