### PR TITLE
fix(ux): surface error feedback for reaction and vote failures (RD-008)

### DIFF
--- a/components/arena.tsx
+++ b/components/arena.tsx
@@ -413,7 +413,7 @@ export function Arena({
   });
 
   // --- Extracted hooks ---
-  const { reactions, sendReaction, reactionsGivenRef, hasReacted } = useBoutReactions(
+  const { reactions, sendReaction, reactionsGivenRef, hasReacted, reactionError } = useBoutReactions(
     boutId,
     initialReactions,
     initialUserReactions,
@@ -557,6 +557,12 @@ export function Arena({
               onCopyMessage={copyMessageShare}
             />
           ))}
+
+          {reactionError && (
+            <p className="text-xs uppercase tracking-[0.3em] text-red-400">
+              {reactionError}
+            </p>
+          )}
 
           {thinkingAgent && status === 'streaming' && (
             <article

--- a/components/feature-request-list.tsx
+++ b/components/feature-request-list.tsx
@@ -65,6 +65,13 @@ export function FeatureRequestList() {
     fetchRequests();
   }, [fetchRequests]);
 
+  // Clean up vote error dismiss timer on unmount
+  useEffect(() => {
+    return () => {
+      if (voteErrorTimerRef.current) clearTimeout(voteErrorTimerRef.current);
+    };
+  }, []);
+
   const handleVote = async (requestId: number) => {
     // Optimistic update
     setRequests((prev) =>

--- a/components/feature-request-list.tsx
+++ b/components/feature-request-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs';
 
 import { trackEvent } from '@/lib/analytics';
@@ -40,6 +40,14 @@ export function FeatureRequestList() {
   const STATUS_LABELS = getStatusLabels(c);
   const [requests, setRequests] = useState<FeatureRequest[]>([]);
   const [loading, setLoading] = useState(true);
+  const [voteError, setVoteError] = useState<number | null>(null);
+  const voteErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showVoteError = (requestId: number) => {
+    setVoteError(requestId);
+    if (voteErrorTimerRef.current) clearTimeout(voteErrorTimerRef.current);
+    voteErrorTimerRef.current = setTimeout(() => setVoteError(null), 3000);
+  };
 
   const fetchRequests = useCallback(async () => {
     try {
@@ -91,9 +99,11 @@ export function FeatureRequestList() {
       } else {
         // Revert optimistic update
         fetchRequests();
+        showVoteError(requestId);
       }
     } catch {
       fetchRequests();
+      showVoteError(requestId);
     }
   };
 
@@ -187,6 +197,11 @@ export function FeatureRequestList() {
               <span className="text-xs font-bold text-foreground">
                 {r.voteCount}
               </span>
+              {voteError === r.id && (
+                <span className="text-[10px] text-red-400">
+                  Vote failed
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/lib/use-bout-reactions.ts
+++ b/lib/use-bout-reactions.ts
@@ -29,11 +29,13 @@ export function useBoutReactions(
   const [userReactions, setUserReactions] = useState<UserReactionSet>(
     () => new Set(initialUserReactions ?? []),
   );
+  const [reactionError, setReactionError] = useState<string | null>(null);
 
   /* Ref tracks the authoritative set — never stale, even in async callbacks */
   const userReactionsRef = useRef<UserReactionSet>(new Set(initialUserReactions ?? []));
   const reactionsGivenRef = useRef(0);
   const pendingRef = useRef<Set<string>>(new Set());
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hasReacted = useCallback(
     (turn: number, type: 'heart' | 'fire') => userReactions.has(reactionKey(turn, type)),
@@ -127,10 +129,15 @@ export function useBoutReactions(
           },
         };
       });
+
+      // Surface error to the UI, auto-dismiss after 3 seconds
+      setReactionError('Failed to save reaction');
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+      errorTimerRef.current = setTimeout(() => setReactionError(null), 3000);
     } finally {
       pendingRef.current.delete(key);
     }
   }, [boutId]);
 
-  return { reactions, sendReaction, reactionsGivenRef, hasReacted };
+  return { reactions, sendReaction, reactionsGivenRef, hasReacted, reactionError };
 }

--- a/lib/use-bout-reactions.ts
+++ b/lib/use-bout-reactions.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { trackEvent } from '@/lib/analytics';
 import type { ReactionCountMap } from '@/lib/reactions';
 
@@ -138,6 +138,13 @@ export function useBoutReactions(
       pendingRef.current.delete(key);
     }
   }, [boutId]);
+
+  // Clean up error dismiss timer on unmount
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    };
+  }, []);
 
   return { reactions, sendReaction, reactionsGivenRef, hasReacted, reactionError };
 }

--- a/lib/use-bout-voting.ts
+++ b/lib/use-bout-voting.ts
@@ -46,6 +46,8 @@ export function useBoutVoting(
         [agentId]: (prev[agentId] ?? 0) + 1,
       }));
       trackEvent('winner_voted', { bout_id: boutId, agent_id: agentId });
+    } catch {
+      setVoteError('Vote failed. Try again.');
     } finally {
       setVotePending(null);
     }

--- a/tests/unit/use-bout-reactions-error.test.ts
+++ b/tests/unit/use-bout-reactions-error.test.ts
@@ -45,6 +45,9 @@ vi.mock('react', () => {
       capturedCallbacks.push(fn);
       return fn;
     },
+    useEffect: (_fn: () => void) => {
+      // No-op in unit tests - cleanup timer tested via timer assertions
+    },
   };
 });
 

--- a/tests/unit/use-bout-reactions-error.test.ts
+++ b/tests/unit/use-bout-reactions-error.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// useBoutReactions error state tests
+//
+// The hook is a React hook (useState, useRef, useCallback) so we cannot call
+// it outside a React render tree without @testing-library/react. Instead, we
+// test the error state contract by extracting and verifying the behavior:
+//
+// 1. When fetch returns non-OK, error state is set
+// 2. Error auto-dismisses after 3 seconds
+// 3. Error is cleared on next successful reaction
+//
+// We mock React's hooks to capture state changes, then drive the hook's
+// sendReaction callback directly.
+// ---------------------------------------------------------------------------
+
+// Captured state setters from useState calls
+type StateSetter<T> = (val: T | ((prev: T) => T)) => void;
+
+let capturedStates: Array<{ value: unknown; setter: StateSetter<unknown> }>;
+let capturedRefs: Array<{ current: unknown }>;
+let capturedCallbacks: Array<(...args: unknown[]) => unknown>;
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('react', () => {
+  return {
+    useState: (init: unknown) => {
+      const val = typeof init === 'function' ? (init as () => unknown)() : init;
+      const entry = { value: val, setter: vi.fn((v: unknown) => {
+        entry.value = typeof v === 'function' ? (v as (prev: unknown) => unknown)(entry.value) : v;
+      }) };
+      capturedStates.push(entry as { value: unknown; setter: StateSetter<unknown> });
+      return [entry.value, entry.setter];
+    },
+    useRef: (init: unknown) => {
+      const ref = { current: init };
+      capturedRefs.push(ref);
+      return ref;
+    },
+    useCallback: (fn: (...args: unknown[]) => unknown) => {
+      capturedCallbacks.push(fn);
+      return fn;
+    },
+  };
+});
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+describe('useBoutReactions - error state', () => {
+  beforeEach(() => {
+    capturedStates = [];
+    capturedRefs = [];
+    capturedCallbacks = [];
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Helper: import the hook fresh (after mocks are wired) and call it.
+   * Returns the sendReaction callback and the error state entry.
+   *
+   * useState call order in useBoutReactions:
+   *   0: reactions (ReactionCountMap)
+   *   1: userReactions (UserReactionSet)
+   *   2: reactionError (string | null)
+   *
+   * useCallback call order:
+   *   0: hasReacted
+   *   1: sendReaction
+   */
+  async function setupHook() {
+    vi.resetModules();
+    const mod = await import('@/lib/use-bout-reactions');
+    mod.useBoutReactions('bout-test');
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const errorState = capturedStates[2]!;
+    const sendReaction = capturedCallbacks[1] as (
+      turn: number,
+      type: 'heart' | 'fire',
+    ) => Promise<void>;
+
+    return { errorState, sendReaction };
+  }
+
+  it('sets reactionError when API returns non-OK', async () => {
+    const { errorState, sendReaction } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429 });
+
+    await sendReaction(0, 'heart');
+
+    expect(errorState.value).toBe('Failed to save reaction');
+  });
+
+  it('sets reactionError when fetch throws', async () => {
+    const { errorState, sendReaction } = await setupHook();
+
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    await sendReaction(0, 'fire');
+
+    expect(errorState.value).toBe('Failed to save reaction');
+  });
+
+  it('auto-clears error after 3 seconds', async () => {
+    const { errorState, sendReaction } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await sendReaction(0, 'heart');
+    expect(errorState.value).toBe('Failed to save reaction');
+
+    vi.advanceTimersByTime(3000);
+    // The setter should have been called with null
+    expect(errorState.value).toBe(null);
+  });
+
+  it('does not set error on successful reaction', async () => {
+    const { errorState, sendReaction } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ counts: { heart: 1, fire: 0 }, turnIndex: 0, action: 'added' }),
+    });
+
+    await sendReaction(0, 'heart');
+
+    expect(errorState.value).toBe(null);
+  });
+
+  it('resets dismiss timer on consecutive errors', async () => {
+    const { errorState, sendReaction } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await sendReaction(0, 'heart');
+    expect(errorState.value).toBe('Failed to save reaction');
+
+    // Advance 2s, then trigger another error
+    vi.advanceTimersByTime(2000);
+    expect(errorState.value).toBe('Failed to save reaction');
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await sendReaction(1, 'fire');
+
+    // First timer would have fired at 3s, but was cleared.
+    // Advance another 2s (4s total) - error should still be present
+    vi.advanceTimersByTime(2000);
+    expect(errorState.value).toBe('Failed to save reaction');
+
+    // Advance to 3s from second error - now it should clear
+    vi.advanceTimersByTime(1000);
+    expect(errorState.value).toBe(null);
+  });
+});

--- a/tests/unit/use-bout-voting-error.test.ts
+++ b/tests/unit/use-bout-voting-error.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// useBoutVoting error state tests
+//
+// Verifies that voteError is set when the API call fails, and surfaces
+// the correct error messages for different failure modes. The voting hook
+// already exposes voteError - these tests lock the contract.
+// ---------------------------------------------------------------------------
+
+type StateSetter<T> = (val: T | ((prev: T) => T)) => void;
+
+let capturedStates: Array<{ value: unknown; setter: StateSetter<unknown> }>;
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('react', () => {
+  return {
+    useState: (init: unknown) => {
+      const val = typeof init === 'function' ? (init as () => unknown)() : init;
+      const entry = { value: val, setter: vi.fn((v: unknown) => {
+        entry.value = typeof v === 'function' ? (v as (prev: unknown) => unknown)(entry.value) : v;
+      }) };
+      capturedStates.push(entry as { value: unknown; setter: StateSetter<unknown> });
+      return [entry.value, entry.setter];
+    },
+  };
+});
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+describe('useBoutVoting - error state', () => {
+  beforeEach(() => {
+    capturedStates = [];
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * useState call order in useBoutVoting:
+   *   0: winnerVotes (WinnerVoteCounts)
+   *   1: userVote (string | null)
+   *   2: voteError (string | null)
+   *   3: votePending (string | null)
+   */
+  async function setupHook() {
+    vi.resetModules();
+    const mod = await import('@/lib/use-bout-voting');
+    const result = mod.useBoutVoting('bout-test');
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const voteErrorState = capturedStates[2]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const votePendingState = capturedStates[3]!;
+
+    return {
+      voteErrorState,
+      votePendingState,
+      castWinnerVote: result.castWinnerVote,
+    };
+  }
+
+  it('sets voteError when API returns 401', async () => {
+    const { voteErrorState, castWinnerVote } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+
+    await castWinnerVote('agent-a');
+
+    expect(voteErrorState.value).toBe('Sign in to cast a winner vote.');
+  });
+
+  it('sets voteError when API returns non-OK non-401', async () => {
+    const { voteErrorState, castWinnerVote } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await castWinnerVote('agent-a');
+
+    expect(voteErrorState.value).toBe('Vote failed. Try again.');
+  });
+
+  it('clears votePending after error', async () => {
+    const { votePendingState, castWinnerVote } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await castWinnerVote('agent-a');
+
+    expect(votePendingState.value).toBe(null);
+  });
+
+  it('does not set voteError on success', async () => {
+    const { voteErrorState, castWinnerVote } = await setupHook();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    await castWinnerVote('agent-a');
+
+    expect(voteErrorState.value).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
- Expose reactionError state from useBoutReactions hook with 3s auto-dismiss
- Add catch block to castWinnerVote (darkcat caught unhandled network errors)
- Add voteError state to feature-request-list with inline error display
- Timer cleanup on unmount for all error dismiss timers
- 9 new tests across reaction and voting error scenarios

Darkcat: Claude FAIL (critical: voting catch missing - fixed, minor: timer cleanup - fixed)
Gate: typecheck + 1409 tests green
Roadmap: RD-008 Phase 1 Error Handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show inline error messages when reactions or winner votes fail, with 3s auto-dismiss, so users aren’t left guessing. Aligns with RD-008 Phase 1 error handling and fixes an unhandled rejection in `castWinnerVote`.

- **Bug Fixes**
  - Reactions: added `reactionError` in `useBoutReactions`, rendered in `Arena`, auto-dismiss after 3s with unmount cleanup.
  - Voting: added catch in `castWinnerVote`, set `voteError` (401 vs generic), and always clear `votePending`.
  - Feature requests: per-item “Vote failed” message with 3s auto-dismiss and unmount cleanup.
  - Tests: 9 unit tests covering reaction and voting error states and timer behavior.

<sup>Written for commit fee7d0b08463297c41f77df0a3839c97c3af1b25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

