### PR TITLE
docs(credits): document intentional GREATEST(0) balance clamping (RD-009)

### DIFF
--- a/lib/credits.ts
+++ b/lib/credits.ts
@@ -259,6 +259,13 @@ export async function applyCreditDelta(
       metadata,
     });
 
+    // GREATEST(0, ...) clamps the balance so it never goes negative.
+    // This means the balance column can diverge from SUM(credit_transactions.delta_micro)
+    // when a negative delta exceeds the available balance. This is intentional:
+    //   - balance is authoritative for "how much can this user spend"
+    //   - the ledger records the full intended delta for audit purposes
+    //   - reconciliation queries should compare balance against ledger sum
+    //     and treat any difference as clamping loss, not data corruption
     const [updated] = await conn
       .update(credits)
       .set({
@@ -378,8 +385,16 @@ export async function settleCredits(
   if (deltaMicro > 0) {
     // Additional charge: cap at available balance atomically.
     // Wrapped in a transaction so the balance deduction and ledger entry
-    // succeed or fail together — prevents silent balance loss if the
+    // succeed or fail together - prevents silent balance loss if the
     // ledger insert fails after the balance update.
+    //
+    // LEAST/GREATEST clamping: the SQL expression deducts min(deltaMicro, balance)
+    // so the balance never goes negative. The ledger entry below records the full
+    // intended deltaMicro (not the clamped amount). This means:
+    //   - balance diverges from SUM(ledger) when the charge exceeds available balance
+    //   - intendedChargeMicro in metadata records what was requested
+    //   - the difference between intended and actual is clamping loss, not data error
+    //   - balance is authoritative for spendable amount; ledger is the audit trail
     await db.transaction(async (tx) => {
       const [result] = await tx
         .update(credits)


### PR DESCRIPTION
## Summary
- Investigation: GREATEST(0) in credit SQL is intentional, not a bug
- Balance = authoritative spendable amount (clamped to 0)
- Ledger = audit trail (records full intended delta)
- Divergence expected when balance insufficient for full charge
- Added explanatory comments at both GREATEST(0) usage sites

Roadmap: RD-009 Phase 1 (investigation complete)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add inline docs clarifying intentional balance clamping in credits by documenting GREATEST(0) at both update sites. Addresses RD-009: balance is the spendable source of truth (never negative), the ledger records the full intended delta, and any difference when charges exceed balance is expected clamping loss, not data corruption.

<sup>Written for commit 41240c53e4ae71621310b9b940bbcbcfc1d42479. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

