### PR TITLE
refactor(billing): extract webhook business logic into lib/billing.ts (RD-012)

### DIFF
--- a/app/api/credits/webhook/route.ts
+++ b/app/api/credits/webhook/route.ts
@@ -1,81 +1,29 @@
 import { headers } from 'next/headers';
-import { eq } from 'drizzle-orm';
-import type Stripe from 'stripe';
 
-import { requireDb } from '@/db';
 import { toError } from '@/lib/errors';
 import { log } from '@/lib/logger';
 import { withLogging } from '@/lib/api-logging';
 import { errorResponse, API_ERRORS } from '@/lib/api-utils';
-import { creditTransactions, users } from '@/db/schema';
-import {
-  applyCreditDelta,
-  ensureCreditAccount,
-  MICRO_PER_CREDIT,
-  SUBSCRIPTION_GRANT_PASS,
-  SUBSCRIPTION_GRANT_LAB,
-  MONTHLY_CREDITS_PASS,
-  MONTHLY_CREDITS_LAB,
-} from '@/lib/credits';
 import { stripe } from '@/lib/stripe';
-import { resolveTierFromPriceId, type UserTier } from '@/lib/tier';
-import { serverTrack, serverIdentify } from '@/lib/posthog-server';
+import {
+  handleCheckoutCompleted,
+  handleSubscriptionCreated,
+  handleSubscriptionUpdated,
+  handleSubscriptionDeleted,
+  handleInvoicePaymentFailed,
+  handleInvoicePaymentSucceeded,
+} from '@/lib/billing';
 
 export const runtime = 'nodejs';
 
 /**
- * Update a user's subscription tier and Stripe metadata in the database.
- * Called by subscription lifecycle webhook events.
- */
-async function updateUserSubscription(params: {
-  userId: string;
-  tier: UserTier;
-  subscriptionId: string;
-  subscriptionStatus: string;
-  currentPeriodEnd: Date | null;
-  stripeCustomerId: string | null;
-}) {
-  const db = requireDb();
-  await db
-    .update(users)
-    .set({
-      subscriptionTier: params.tier,
-      subscriptionId: params.subscriptionId,
-      subscriptionStatus: params.subscriptionStatus,
-      subscriptionCurrentPeriodEnd: params.currentPeriodEnd,
-      ...(params.stripeCustomerId
-        ? { stripeCustomerId: params.stripeCustomerId }
-        : {}),
-      updatedAt: new Date(),
-    })
-    .where(eq(users.id, params.userId));
-}
-
-/**
- * Check whether a credit grant with the given referenceId already exists.
- * Used to make all grant paths idempotent against Stripe webhook retries.
- */
-async function hasExistingGrant(referenceId: string): Promise<boolean> {
-  const db = requireDb();
-  const [existing] = await db
-    .select({ id: creditTransactions.id })
-    .from(creditTransactions)
-    .where(eq(creditTransactions.referenceId, referenceId))
-    .limit(1);
-  return !!existing;
-}
-
-/**
- * Handle Stripe webhook events for credit purchases and subscription lifecycle.
+ * Stripe webhook handler - thin transport layer.
  *
- * Idempotency:
- * - checkout.session.completed: guarded by creditTransactions.referenceId lookup.
- * - subscription_grant: guarded by referenceId `{subscriptionId}:subscription_grant`.
- * - subscription_upgrade_grant: guarded by referenceId `{subscriptionId}:upgrade_grant`.
- * - monthly_grant: guarded by referenceId `{invoiceId}:monthly_grant`.
- *   Stripe webhook retries will hit the dedup check and skip.
- * - Subscription tier updates: naturally idempotent — updateUserSubscription
- *   is a SET (not increment), so replayed events write the same values.
+ * Responsibilities: verify signature, parse event, dispatch to billing
+ * domain functions, return 200. All business logic lives in lib/billing.ts.
+ *
+ * Idempotency is handled within each billing function via referenceId
+ * deduplication. See lib/billing.ts for details.
  */
 export const POST = withLogging(async function POST(req: Request) {
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
@@ -98,383 +46,35 @@ export const POST = withLogging(async function POST(req: Request) {
     return errorResponse(API_ERRORS.INVALID_SIGNATURE, 400);
   }
 
-  // --- Credit pack purchase (one-time checkout) ---
-  if (event.type === 'checkout.session.completed') {
-    const session = event.data.object as Stripe.Checkout.Session;
+  // Stripe SDK event.data.object has union types (e.g. customer: string |
+  // Customer | DeletedCustomer). The billing functions use structural types
+  // matching the subset of fields they need. The `as` casts here are safe
+  // because Stripe webhook payloads always deliver these fields as strings.
+  const obj = event.data.object;
+  switch (event.type) {
+    case 'checkout.session.completed':
+      await handleCheckoutCompleted(obj as Parameters<typeof handleCheckoutCompleted>[0]);
+      break;
 
-    // Only process one-time payment checkouts (not subscription checkouts)
-    if (session.mode === 'payment') {
-      const userId = session.metadata?.userId;
-      const credits = session.metadata?.credits
-        ? Number(session.metadata.credits)
-        : 0;
+    case 'customer.subscription.created':
+      await handleSubscriptionCreated(obj as Parameters<typeof handleSubscriptionCreated>[0]);
+      break;
 
-      const db = requireDb();
+    case 'customer.subscription.updated':
+      await handleSubscriptionUpdated(obj as Parameters<typeof handleSubscriptionUpdated>[0]);
+      break;
 
-      // Always check for existing transaction (consistent timing)
-      const [existing] = await db
-        .select({ id: creditTransactions.id })
-        .from(creditTransactions)
-        .where(eq(creditTransactions.referenceId, session.id))
-        .limit(1);
+    case 'customer.subscription.deleted':
+      await handleSubscriptionDeleted(obj as Parameters<typeof handleSubscriptionDeleted>[0]);
+      break;
 
-      const shouldProcess = userId && credits > 0 && !existing;
+    case 'invoice.payment_failed':
+      await handleInvoicePaymentFailed(obj as Parameters<typeof handleInvoicePaymentFailed>[0]);
+      break;
 
-      if (shouldProcess) {
-        await ensureCreditAccount(userId);
-        const deltaMicro = credits * MICRO_PER_CREDIT;
-        await applyCreditDelta(userId, deltaMicro, 'purchase', {
-          referenceId: session.id,
-          credits,
-        });
-        try {
-          await serverTrack(userId, 'credit_purchase_completed', {
-            credits,
-            amount_total: session.amount_total ?? 0,
-            currency: session.currency ?? 'gbp',
-            session_id: session.id,
-          });
-        } catch {
-          // Best-effort - analytics loss is acceptable, webhook failure is not
-        }
-      }
-
-      if (existing) {
-        log.info('Webhook: duplicate session, skipping', { sessionId: session.id });
-      }
-    }
-  }
-
-  // --- Subscription created ---
-  if (event.type === 'customer.subscription.created') {
-    const subscription = event.data.object as {
-      id: string;
-      status: string;
-      customer: string;
-      metadata?: Record<string, string>;
-      items?: { data: Array<{ price: { id: string } }> };
-      current_period_end?: number;
-    };
-
-    const userId = subscription.metadata?.userId;
-    const priceId = subscription.items?.data[0]?.price.id;
-
-    if (userId && priceId) {
-      const tier = resolveTierFromPriceId(priceId);
-      if (tier) {
-        await updateUserSubscription({
-          userId,
-          tier,
-          subscriptionId: subscription.id,
-          subscriptionStatus: subscription.status,
-          currentPeriodEnd: subscription.current_period_end
-            ? new Date(subscription.current_period_end * 1000)
-            : null,
-          stripeCustomerId: subscription.customer,
-        });
-        // One-time credit grant on new subscription (idempotent)
-        const grantCredits = tier === 'lab'
-          ? SUBSCRIPTION_GRANT_LAB
-          : tier === 'pass'
-            ? SUBSCRIPTION_GRANT_PASS
-            : 0;
-        const subscriptionGrantRef = `${subscription.id}:subscription_grant`;
-        if (grantCredits > 0 && !(await hasExistingGrant(subscriptionGrantRef))) {
-          await ensureCreditAccount(userId);
-          await applyCreditDelta(
-            userId,
-            grantCredits * MICRO_PER_CREDIT,
-            'subscription_grant',
-            { referenceId: subscriptionGrantRef, tier, credits: grantCredits },
-          );
-          log.info('Subscription grant applied', { userId, tier, credits: grantCredits });
-        }
-
-        try { await serverTrack(userId, 'subscription_started', {
-            tier,
-            subscription_id: subscription.id,
-            status: subscription.status,
-            grant_credits: grantCredits,
-          });
-        } catch {
-          // Best-effort - analytics loss is acceptable, webhook failure is not
-        }
-        try { await serverIdentify(userId, { current_tier: tier }); } catch {
-          // Best-effort - analytics loss is acceptable, webhook failure is not
-        }
-        log.info('Subscription created', { userId, tier, subscriptionId: subscription.id });
-      }
-    }
-  }
-
-  // --- Subscription updated (upgrade, downgrade, renewal) ---
-  if (event.type === 'customer.subscription.updated') {
-    const subscription = event.data.object as {
-      id: string;
-      status: string;
-      customer: string;
-      metadata?: Record<string, string>;
-      items?: { data: Array<{ price: { id: string } }> };
-      current_period_end?: number;
-    };
-
-    const userId = subscription.metadata?.userId;
-    const priceId = subscription.items?.data[0]?.price.id;
-
-    if (userId && priceId) {
-      const tier = resolveTierFromPriceId(priceId);
-      if (tier) {
-        // Read the old tier BEFORE writing the update — otherwise the
-        // comparison always sees oldTier === newTier.
-        // Exhaustive tier ordering — TypeScript enforces all UserTier values
-        // are mapped, so adding a new tier without updating this map is a
-        // compile-time error (no silent misclassification of upgrades).
-        const tierOrder: Record<UserTier, number> = { free: 0, pass: 1, lab: 2 };
-        const db = requireDb();
-        const [currentUser] = await db
-          .select({ tier: users.subscriptionTier })
-          .from(users)
-          .where(eq(users.id, userId))
-          .limit(1);
-        const oldTier: UserTier = (currentUser?.tier as UserTier) ?? 'free';
-        const oldTierRank = tierOrder[oldTier];
-        const newTierRank = tierOrder[tier];
-
-        await updateUserSubscription({
-          userId,
-          tier,
-          subscriptionId: subscription.id,
-          subscriptionStatus: subscription.status,
-          currentPeriodEnd: subscription.current_period_end
-            ? new Date(subscription.current_period_end * 1000)
-            : null,
-          stripeCustomerId: subscription.customer,
-        });
-
-        if (newTierRank > oldTierRank) {
-          // Incremental credit grant on upgrade (difference between tiers)
-          const grantMap: Record<UserTier, number> = {
-            free: 0,
-            pass: SUBSCRIPTION_GRANT_PASS,
-            lab: SUBSCRIPTION_GRANT_LAB,
-          };
-          const incrementalGrant = grantMap[tier] - grantMap[oldTier];
-          // Include tier transition in referenceId so a user who downgrades
-          // then re-upgrades on the same subscription gets a fresh grant.
-          const upgradeGrantRef = `${subscription.id}:upgrade_grant:${oldTier}:${tier}`;
-          if (incrementalGrant > 0 && !(await hasExistingGrant(upgradeGrantRef))) {
-            await ensureCreditAccount(userId);
-            await applyCreditDelta(
-              userId,
-              incrementalGrant * MICRO_PER_CREDIT,
-              'subscription_upgrade_grant',
-              {
-                referenceId: upgradeGrantRef,
-                from_tier: oldTier,
-                to_tier: tier,
-                credits: incrementalGrant,
-              },
-            );
-            log.info('Upgrade grant applied', { userId, from: oldTier, to: tier, credits: incrementalGrant });
-          }
-
-          try {
-            await serverTrack(userId, 'subscription_upgraded', {
-              from_tier: oldTier,
-              to_tier: tier,
-              subscription_id: subscription.id,
-              grant_credits: incrementalGrant,
-            });
-          } catch {
-            // Best-effort - analytics loss is acceptable, webhook failure is not
-          }
-        } else if (newTierRank < oldTierRank) {
-          try {
-            await serverTrack(userId, 'subscription_downgraded', {
-              from_tier: oldTier,
-              to_tier: tier,
-              subscription_id: subscription.id,
-            });
-          } catch {
-            // Best-effort - analytics loss is acceptable, webhook failure is not
-          }
-        }
-        try {
-          await serverIdentify(userId, { current_tier: tier });
-        } catch {
-          // Best-effort - analytics loss is acceptable, webhook failure is not
-        }
-        log.info('Subscription updated', { userId, tier, status: subscription.status });
-      }
-    }
-  }
-
-  // --- Subscription deleted (cancellation, expiry) ---
-  if (event.type === 'customer.subscription.deleted') {
-    const subscription = event.data.object as {
-      id: string;
-      status: string;
-      customer: string;
-      metadata?: Record<string, string>;
-    };
-
-    const userId = subscription.metadata?.userId;
-    if (userId) {
-      // Read previous tier BEFORE the downgrade for churn analytics
-      const db3 = requireDb();
-      const [churnedUser] = await db3
-        .select({ tier: users.subscriptionTier })
-        .from(users)
-        .where(eq(users.id, userId))
-        .limit(1);
-      const previousTier = churnedUser?.tier ?? 'free';
-
-      // Immediate downgrade to free
-      await updateUserSubscription({
-        userId,
-        tier: 'free',
-        subscriptionId: subscription.id,
-        subscriptionStatus: 'canceled',
-        currentPeriodEnd: null,
-        stripeCustomerId: subscription.customer,
-      });
-      try { await serverTrack(userId, 'subscription_churned', {
-          subscription_id: subscription.id,
-          previous_tier: previousTier,
-        });
-      } catch {
-        // Best-effort - analytics loss is acceptable, webhook failure is not
-      }
-      try { await serverIdentify(userId, { current_tier: 'free' }); } catch {
-        // Best-effort - analytics loss is acceptable, webhook failure is not
-      }
-      log.info('Subscription deleted, downgraded to free', { userId });
-    }
-  }
-
-  // --- Invoice payment failed (immediate downgrade) ---
-  if (event.type === 'invoice.payment_failed') {
-    const invoice = event.data.object as {
-      id: string;
-      customer: string;
-      subscription?: string;
-      subscription_details?: { metadata?: Record<string, string> };
-    };
-
-    // Resolve user from subscription metadata, falling back to DB lookup
-    // by stripeCustomerId when metadata isn't propagated on the invoice.
-    let userId = invoice.subscription_details?.metadata?.userId;
-    if (!userId && invoice.customer) {
-      const db = requireDb();
-      const [found] = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.stripeCustomerId, invoice.customer))
-        .limit(1);
-      userId = found?.id;
-    }
-
-    if (userId && invoice.subscription) {
-      // Read previous tier BEFORE the downgrade for analytics
-      const db4 = requireDb();
-      const [failedUser] = await db4
-        .select({ tier: users.subscriptionTier })
-        .from(users)
-        .where(eq(users.id, userId))
-        .limit(1);
-      const previousTier = failedUser?.tier ?? 'free';
-
-      await updateUserSubscription({
-        userId,
-        tier: 'free',
-        subscriptionId: invoice.subscription,
-        subscriptionStatus: 'past_due',
-        currentPeriodEnd: null,
-        stripeCustomerId: invoice.customer,
-      });
-      try { await serverTrack(userId, 'payment_failed', {
-          subscription_id: invoice.subscription,
-          invoice_id: invoice.id,
-          previous_tier: previousTier,
-        });
-      } catch {
-        // Best-effort - analytics loss is acceptable, webhook failure is not
-      }
-      try { await serverIdentify(userId, { current_tier: 'free' }); } catch {
-        // Best-effort - analytics loss is acceptable, webhook failure is not
-      }
-      log.info('Payment failed, downgraded to free', { userId, subscriptionId: invoice.subscription });
-    }
-  }
-
-  // --- Invoice payment succeeded (restore tier after retry) ---
-  if (event.type === 'invoice.payment_succeeded') {
-    const invoice = event.data.object as {
-      id: string;
-      customer: string;
-      subscription?: string;
-      billing_reason?: string;
-      subscription_details?: { metadata?: Record<string, string> };
-      lines?: { data: Array<{ price: { id: string } }> };
-    };
-
-    // Resolve user from subscription metadata, falling back to DB lookup
-    // by stripeCustomerId when metadata isn't propagated on the invoice.
-    let userId = invoice.subscription_details?.metadata?.userId;
-    if (!userId && invoice.customer) {
-      const db = requireDb();
-      const [found] = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.stripeCustomerId, invoice.customer))
-        .limit(1);
-      userId = found?.id;
-    }
-
-    const priceId = invoice.lines?.data[0]?.price.id;
-
-    if (userId && invoice.subscription && priceId) {
-      const tier = resolveTierFromPriceId(priceId);
-      if (tier) {
-        await updateUserSubscription({
-          userId,
-          tier,
-          subscriptionId: invoice.subscription,
-          subscriptionStatus: 'active',
-          currentPeriodEnd: null, // Will be updated by subscription.updated event
-          stripeCustomerId: invoice.customer,
-        });
-
-        // Monthly recurring credit grant — only on renewal invoices.
-        // Stripe fires both customer.subscription.created AND
-        // invoice.payment_succeeded on initial subscribe. The one-time grant
-        // is handled by subscription.created; skip the monthly grant for the
-        // first invoice to avoid double-granting.
-        const isRenewal = invoice.billing_reason !== 'subscription_create';
-        const monthlyCredits = tier === 'lab'
-          ? MONTHLY_CREDITS_LAB
-          : tier === 'pass'
-            ? MONTHLY_CREDITS_PASS
-            : 0;
-        const monthlyGrantRef = `${invoice.id}:monthly_grant`;
-        if (isRenewal && monthlyCredits > 0 && !(await hasExistingGrant(monthlyGrantRef))) {
-          await ensureCreditAccount(userId);
-          await applyCreditDelta(
-            userId,
-            monthlyCredits * MICRO_PER_CREDIT,
-            'monthly_grant',
-            {
-              referenceId: monthlyGrantRef,
-              tier,
-              credits: monthlyCredits,
-            },
-          );
-          log.info('Monthly credit grant applied', { userId, tier, credits: monthlyCredits });
-        }
-
-        log.info('Payment succeeded, tier restored', { userId, tier });
-      }
-    }
+    case 'invoice.payment_succeeded':
+      await handleInvoicePaymentSucceeded(obj as Parameters<typeof handleInvoicePaymentSucceeded>[0]);
+      break;
   }
 
   return Response.json({ received: true });

--- a/lib/billing.ts
+++ b/lib/billing.ts
@@ -35,7 +35,7 @@ async function updateUserSubscription(params: {
   tier: UserTier;
   subscriptionId: string;
   subscriptionStatus: string;
-  currentPeriodEnd: Date | null;
+  currentPeriodEnd?: Date | null;
   stripeCustomerId: string | null;
 }) {
   const db = requireDb();
@@ -45,7 +45,9 @@ async function updateUserSubscription(params: {
       subscriptionTier: params.tier,
       subscriptionId: params.subscriptionId,
       subscriptionStatus: params.subscriptionStatus,
-      subscriptionCurrentPeriodEnd: params.currentPeriodEnd,
+      ...(params.currentPeriodEnd !== undefined
+        ? { subscriptionCurrentPeriodEnd: params.currentPeriodEnd }
+        : {}),
       ...(params.stripeCustomerId
         ? { stripeCustomerId: params.stripeCustomerId }
         : {}),
@@ -105,15 +107,7 @@ export async function handleCheckoutCompleted(
     ? Number(session.metadata.credits)
     : 0;
 
-  const db = requireDb();
-
-  // Always check for existing transaction (consistent timing)
-  const [existing] = await db
-    .select({ id: creditTransactions.id })
-    .from(creditTransactions)
-    .where(eq(creditTransactions.referenceId, session.id))
-    .limit(1);
-
+  const existing = await hasExistingGrant(session.id);
   const shouldProcess = userId && credits > 0 && !existing;
 
   if (shouldProcess) {
@@ -436,12 +430,14 @@ export async function handleInvoicePaymentSucceeded(
   const tier = resolveTierFromPriceId(priceId);
   if (!tier) return;
 
+  // Omit currentPeriodEnd - Stripe doesn't guarantee webhook delivery
+  // order, so subscription.updated may arrive before or after this event.
+  // Preserving the existing value avoids overwriting a correct date with null.
   await updateUserSubscription({
     userId,
     tier,
     subscriptionId: invoice.subscription,
     subscriptionStatus: 'active',
-    currentPeriodEnd: null, // Will be updated by subscription.updated event
     stripeCustomerId: invoice.customer,
   });
 

--- a/lib/billing.ts
+++ b/lib/billing.ts
@@ -1,0 +1,476 @@
+// Billing domain logic extracted from the Stripe webhook handler.
+//
+// Each function handles one webhook event type. The webhook route
+// (app/api/credits/webhook/route.ts) is the transport layer: it
+// verifies the Stripe signature, parses the event, and dispatches
+// to these functions. Business rules, credit grants, tier changes,
+// idempotency guards, and analytics calls live here.
+
+import { eq } from 'drizzle-orm';
+import type Stripe from 'stripe';
+
+import { requireDb } from '@/db';
+import { creditTransactions, users } from '@/db/schema';
+import {
+  applyCreditDelta,
+  ensureCreditAccount,
+  MICRO_PER_CREDIT,
+  SUBSCRIPTION_GRANT_PASS,
+  SUBSCRIPTION_GRANT_LAB,
+  MONTHLY_CREDITS_PASS,
+  MONTHLY_CREDITS_LAB,
+} from '@/lib/credits';
+import { log } from '@/lib/logger';
+import { serverTrack, serverIdentify } from '@/lib/posthog-server';
+import { resolveTierFromPriceId, type UserTier } from '@/lib/tier';
+
+// ---- Internal helpers ----
+
+/**
+ * Update a user's subscription tier and Stripe metadata in the database.
+ * Called by subscription lifecycle webhook events.
+ */
+async function updateUserSubscription(params: {
+  userId: string;
+  tier: UserTier;
+  subscriptionId: string;
+  subscriptionStatus: string;
+  currentPeriodEnd: Date | null;
+  stripeCustomerId: string | null;
+}) {
+  const db = requireDb();
+  await db
+    .update(users)
+    .set({
+      subscriptionTier: params.tier,
+      subscriptionId: params.subscriptionId,
+      subscriptionStatus: params.subscriptionStatus,
+      subscriptionCurrentPeriodEnd: params.currentPeriodEnd,
+      ...(params.stripeCustomerId
+        ? { stripeCustomerId: params.stripeCustomerId }
+        : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, params.userId));
+}
+
+/**
+ * Check whether a credit grant with the given referenceId already exists.
+ * Used to make all grant paths idempotent against Stripe webhook retries.
+ */
+async function hasExistingGrant(referenceId: string): Promise<boolean> {
+  const db = requireDb();
+  const [existing] = await db
+    .select({ id: creditTransactions.id })
+    .from(creditTransactions)
+    .where(eq(creditTransactions.referenceId, referenceId))
+    .limit(1);
+  return !!existing;
+}
+
+/**
+ * Resolve a userId from an invoice, falling back to DB lookup by
+ * stripeCustomerId when metadata isn't propagated on the invoice.
+ */
+async function resolveUserIdFromInvoice(invoice: {
+  customer: string;
+  subscription_details?: { metadata?: Record<string, string> };
+}): Promise<string | undefined> {
+  let userId = invoice.subscription_details?.metadata?.userId;
+  if (!userId && invoice.customer) {
+    const db = requireDb();
+    const [found] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.stripeCustomerId, invoice.customer))
+      .limit(1);
+    userId = found?.id;
+  }
+  return userId;
+}
+
+// ---- Exported event handlers ----
+
+/**
+ * Handle checkout.session.completed - credit pack purchase (one-time payment).
+ */
+export async function handleCheckoutCompleted(
+  session: Stripe.Checkout.Session,
+): Promise<void> {
+  // Only process one-time payment checkouts (not subscription checkouts)
+  if (session.mode !== 'payment') return;
+
+  const userId = session.metadata?.userId;
+  const credits = session.metadata?.credits
+    ? Number(session.metadata.credits)
+    : 0;
+
+  const db = requireDb();
+
+  // Always check for existing transaction (consistent timing)
+  const [existing] = await db
+    .select({ id: creditTransactions.id })
+    .from(creditTransactions)
+    .where(eq(creditTransactions.referenceId, session.id))
+    .limit(1);
+
+  const shouldProcess = userId && credits > 0 && !existing;
+
+  if (shouldProcess) {
+    await ensureCreditAccount(userId);
+    const deltaMicro = credits * MICRO_PER_CREDIT;
+    await applyCreditDelta(userId, deltaMicro, 'purchase', {
+      referenceId: session.id,
+      credits,
+    });
+    try {
+      await serverTrack(userId, 'credit_purchase_completed', {
+        credits,
+        amount_total: session.amount_total ?? 0,
+        currency: session.currency ?? 'gbp',
+        session_id: session.id,
+      });
+    } catch {
+      // Best-effort - analytics loss is acceptable, webhook failure is not
+    }
+  }
+
+  if (existing) {
+    log.info('Webhook: duplicate session, skipping', { sessionId: session.id });
+  }
+}
+
+/**
+ * Handle customer.subscription.created - resolve tier, update user,
+ * apply one-time credit grant, identify user in PostHog.
+ */
+export async function handleSubscriptionCreated(
+  subscription: {
+    id: string;
+    status: string;
+    customer: string;
+    metadata?: Record<string, string>;
+    items?: { data: Array<{ price: { id: string } }> };
+    current_period_end?: number;
+  },
+): Promise<void> {
+  const userId = subscription.metadata?.userId;
+  const priceId = subscription.items?.data[0]?.price.id;
+
+  if (!userId || !priceId) return;
+
+  const tier = resolveTierFromPriceId(priceId);
+  if (!tier) return;
+
+  await updateUserSubscription({
+    userId,
+    tier,
+    subscriptionId: subscription.id,
+    subscriptionStatus: subscription.status,
+    currentPeriodEnd: subscription.current_period_end
+      ? new Date(subscription.current_period_end * 1000)
+      : null,
+    stripeCustomerId: subscription.customer,
+  });
+
+  // One-time credit grant on new subscription (idempotent)
+  const grantCredits = tier === 'lab'
+    ? SUBSCRIPTION_GRANT_LAB
+    : tier === 'pass'
+      ? SUBSCRIPTION_GRANT_PASS
+      : 0;
+  const subscriptionGrantRef = `${subscription.id}:subscription_grant`;
+  if (grantCredits > 0 && !(await hasExistingGrant(subscriptionGrantRef))) {
+    await ensureCreditAccount(userId);
+    await applyCreditDelta(
+      userId,
+      grantCredits * MICRO_PER_CREDIT,
+      'subscription_grant',
+      { referenceId: subscriptionGrantRef, tier, credits: grantCredits },
+    );
+    log.info('Subscription grant applied', { userId, tier, credits: grantCredits });
+  }
+
+  try {
+    await serverTrack(userId, 'subscription_started', {
+      tier,
+      subscription_id: subscription.id,
+      status: subscription.status,
+      grant_credits: grantCredits,
+    });
+  } catch {
+    // Best-effort - analytics loss is acceptable, webhook failure is not
+  }
+  try {
+    await serverIdentify(userId, { current_tier: tier });
+  } catch {
+    // Best-effort - analytics loss is acceptable, webhook failure is not
+  }
+  log.info('Subscription created', { userId, tier, subscriptionId: subscription.id });
+}
+
+/**
+ * Handle customer.subscription.updated - detect upgrade/downgrade,
+ * adjust credits on upgrade, update tier.
+ */
+export async function handleSubscriptionUpdated(
+  subscription: {
+    id: string;
+    status: string;
+    customer: string;
+    metadata?: Record<string, string>;
+    items?: { data: Array<{ price: { id: string } }> };
+    current_period_end?: number;
+  },
+): Promise<void> {
+  const userId = subscription.metadata?.userId;
+  const priceId = subscription.items?.data[0]?.price.id;
+
+  if (!userId || !priceId) return;
+
+  const tier = resolveTierFromPriceId(priceId);
+  if (!tier) return;
+
+  // Read the old tier BEFORE writing the update - otherwise the
+  // comparison always sees oldTier === newTier.
+  // Exhaustive tier ordering - TypeScript enforces all UserTier values
+  // are mapped, so adding a new tier without updating this map is a
+  // compile-time error (no silent misclassification of upgrades).
+  const tierOrder: Record<UserTier, number> = { free: 0, pass: 1, lab: 2 };
+  const db = requireDb();
+  const [currentUser] = await db
+    .select({ tier: users.subscriptionTier })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  const oldTier: UserTier = (currentUser?.tier as UserTier) ?? 'free';
+  const oldTierRank = tierOrder[oldTier];
+  const newTierRank = tierOrder[tier];
+
+  await updateUserSubscription({
+    userId,
+    tier,
+    subscriptionId: subscription.id,
+    subscriptionStatus: subscription.status,
+    currentPeriodEnd: subscription.current_period_end
+      ? new Date(subscription.current_period_end * 1000)
+      : null,
+    stripeCustomerId: subscription.customer,
+  });
+
+  if (newTierRank > oldTierRank) {
+    // Incremental credit grant on upgrade (difference between tiers)
+    const grantMap: Record<UserTier, number> = {
+      free: 0,
+      pass: SUBSCRIPTION_GRANT_PASS,
+      lab: SUBSCRIPTION_GRANT_LAB,
+    };
+    const incrementalGrant = grantMap[tier] - grantMap[oldTier];
+    // Include tier transition in referenceId so a user who downgrades
+    // then re-upgrades on the same subscription gets a fresh grant.
+    const upgradeGrantRef = `${subscription.id}:upgrade_grant:${oldTier}:${tier}`;
+    if (incrementalGrant > 0 && !(await hasExistingGrant(upgradeGrantRef))) {
+      await ensureCreditAccount(userId);
+      await applyCreditDelta(
+        userId,
+        incrementalGrant * MICRO_PER_CREDIT,
+        'subscription_upgrade_grant',
+        {
+          referenceId: upgradeGrantRef,
+          from_tier: oldTier,
+          to_tier: tier,
+          credits: incrementalGrant,
+        },
+      );
+      log.info('Upgrade grant applied', { userId, from: oldTier, to: tier, credits: incrementalGrant });
+    }
+
+    try {
+      await serverTrack(userId, 'subscription_upgraded', {
+        from_tier: oldTier,
+        to_tier: tier,
+        subscription_id: subscription.id,
+        grant_credits: incrementalGrant,
+      });
+    } catch {
+      // Best-effort - analytics loss is acceptable, webhook failure is not
+    }
+  } else if (newTierRank < oldTierRank) {
+    try {
+      await serverTrack(userId, 'subscription_downgraded', {
+        from_tier: oldTier,
+        to_tier: tier,
+        subscription_id: subscription.id,
+      });
+    } catch {
+      // Best-effort - analytics loss is acceptable, webhook failure is not
+    }
+  }
+  try {
+    await serverIdentify(userId, { current_tier: tier });
+  } catch {
+    // Best-effort - analytics loss is acceptable, webhook failure is not
+  }
+  log.info('Subscription updated', { userId, tier, status: subscription.status });
+}
+
+/**
+ * Handle customer.subscription.deleted - downgrade to free tier on
+ * cancellation or expiry.
+ */
+export async function handleSubscriptionDeleted(
+  subscription: {
+    id: string;
+    status: string;
+    customer: string;
+    metadata?: Record<string, string>;
+  },
+): Promise<void> {
+  const userId = subscription.metadata?.userId;
+  if (!userId) return;
+
+  // Read previous tier BEFORE the downgrade for churn analytics
+  const db = requireDb();
+  const [churnedUser] = await db
+    .select({ tier: users.subscriptionTier })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  const previousTier = churnedUser?.tier ?? 'free';
+
+  // Immediate downgrade to free
+  await updateUserSubscription({
+    userId,
+    tier: 'free',
+    subscriptionId: subscription.id,
+    subscriptionStatus: 'canceled',
+    currentPeriodEnd: null,
+    stripeCustomerId: subscription.customer,
+  });
+  try {
+    await serverTrack(userId, 'subscription_churned', {
+      subscription_id: subscription.id,
+      previous_tier: previousTier,
+    });
+  } catch {
+    // Best-effort - analytics loss is acceptable, webhook failure is not
+  }
+  try {
+    await serverIdentify(userId, { current_tier: 'free' });
+  } catch {
+    // Best-effort - analytics loss is acceptable, webhook failure is not
+  }
+  log.info('Subscription deleted, downgraded to free', { userId });
+}
+
+/**
+ * Handle invoice.payment_failed - immediate downgrade to free tier,
+ * track failed payment.
+ */
+export async function handleInvoicePaymentFailed(
+  invoice: {
+    id: string;
+    customer: string;
+    subscription?: string;
+    subscription_details?: { metadata?: Record<string, string> };
+  },
+): Promise<void> {
+  const userId = await resolveUserIdFromInvoice(invoice);
+
+  if (!userId || !invoice.subscription) return;
+
+  // Read previous tier BEFORE the downgrade for analytics
+  const db = requireDb();
+  const [failedUser] = await db
+    .select({ tier: users.subscriptionTier })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  const previousTier = failedUser?.tier ?? 'free';
+
+  await updateUserSubscription({
+    userId,
+    tier: 'free',
+    subscriptionId: invoice.subscription,
+    subscriptionStatus: 'past_due',
+    currentPeriodEnd: null,
+    stripeCustomerId: invoice.customer,
+  });
+  try {
+    await serverTrack(userId, 'payment_failed', {
+      subscription_id: invoice.subscription,
+      invoice_id: invoice.id,
+      previous_tier: previousTier,
+    });
+  } catch {
+    // Best-effort - analytics loss is acceptable, webhook failure is not
+  }
+  try {
+    await serverIdentify(userId, { current_tier: 'free' });
+  } catch {
+    // Best-effort - analytics loss is acceptable, webhook failure is not
+  }
+  log.info('Payment failed, downgraded to free', { userId, subscriptionId: invoice.subscription });
+}
+
+/**
+ * Handle invoice.payment_succeeded - restore tier after retry,
+ * apply monthly recurring credit grant on renewals.
+ */
+export async function handleInvoicePaymentSucceeded(
+  invoice: {
+    id: string;
+    customer: string;
+    subscription?: string;
+    billing_reason?: string;
+    subscription_details?: { metadata?: Record<string, string> };
+    lines?: { data: Array<{ price: { id: string } }> };
+  },
+): Promise<void> {
+  const userId = await resolveUserIdFromInvoice(invoice);
+
+  const priceId = invoice.lines?.data[0]?.price.id;
+
+  if (!userId || !invoice.subscription || !priceId) return;
+
+  const tier = resolveTierFromPriceId(priceId);
+  if (!tier) return;
+
+  await updateUserSubscription({
+    userId,
+    tier,
+    subscriptionId: invoice.subscription,
+    subscriptionStatus: 'active',
+    currentPeriodEnd: null, // Will be updated by subscription.updated event
+    stripeCustomerId: invoice.customer,
+  });
+
+  // Monthly recurring credit grant - only on renewal invoices.
+  // Stripe fires both customer.subscription.created AND
+  // invoice.payment_succeeded on initial subscribe. The one-time grant
+  // is handled by subscription.created; skip the monthly grant for the
+  // first invoice to avoid double-granting.
+  const isRenewal = invoice.billing_reason !== 'subscription_create';
+  const monthlyCredits = tier === 'lab'
+    ? MONTHLY_CREDITS_LAB
+    : tier === 'pass'
+      ? MONTHLY_CREDITS_PASS
+      : 0;
+  const monthlyGrantRef = `${invoice.id}:monthly_grant`;
+  if (isRenewal && monthlyCredits > 0 && !(await hasExistingGrant(monthlyGrantRef))) {
+    await ensureCreditAccount(userId);
+    await applyCreditDelta(
+      userId,
+      monthlyCredits * MICRO_PER_CREDIT,
+      'monthly_grant',
+      {
+        referenceId: monthlyGrantRef,
+        tier,
+        credits: monthlyCredits,
+      },
+    );
+    log.info('Monthly credit grant applied', { userId, tier, credits: monthlyCredits });
+  }
+
+  log.info('Payment succeeded, tier restored', { userId, tier });
+}

--- a/tests/unit/billing.test.ts
+++ b/tests/unit/billing.test.ts
@@ -1,0 +1,571 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const {
+  mockDb,
+  mockApplyCreditDelta,
+  mockEnsureCreditAccount,
+  mockResolveTierFromPriceId,
+  mockServerTrack,
+  mockServerIdentify,
+} = vi.hoisted(() => {
+  const db = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  };
+
+  return {
+    mockDb: db,
+    mockApplyCreditDelta: vi.fn().mockResolvedValue(undefined),
+    mockEnsureCreditAccount: vi.fn().mockResolvedValue(undefined),
+    mockResolveTierFromPriceId: vi.fn(),
+    mockServerTrack: vi.fn().mockResolvedValue(undefined),
+    mockServerIdentify: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock('@/db', () => ({
+  requireDb: () => mockDb,
+}));
+
+vi.mock('@/db/schema', () => ({
+  creditTransactions: {
+    id: 'id',
+    userId: 'user_id',
+    deltaMicro: 'delta_micro',
+    source: 'source',
+    referenceId: 'reference_id',
+    metadata: 'metadata',
+    createdAt: 'created_at',
+  },
+  users: {
+    id: 'id',
+    email: 'email',
+    subscriptionTier: 'subscription_tier',
+    subscriptionStatus: 'subscription_status',
+    subscriptionId: 'subscription_id',
+    subscriptionCurrentPeriodEnd: 'subscription_current_period_end',
+    stripeCustomerId: 'stripe_customer_id',
+    updatedAt: 'updated_at',
+  },
+}));
+
+vi.mock('@/lib/credits', () => ({
+  applyCreditDelta: mockApplyCreditDelta,
+  ensureCreditAccount: mockEnsureCreditAccount,
+  MICRO_PER_CREDIT: 100,
+  SUBSCRIPTION_GRANT_PASS: 300,
+  SUBSCRIPTION_GRANT_LAB: 600,
+  MONTHLY_CREDITS_PASS: 300,
+  MONTHLY_CREDITS_LAB: 600,
+}));
+
+vi.mock('@/lib/tier', () => ({
+  resolveTierFromPriceId: mockResolveTierFromPriceId,
+}));
+
+vi.mock('@/lib/posthog-server', () => ({
+  serverTrack: mockServerTrack,
+  serverIdentify: mockServerIdentify,
+}));
+
+// ---------------------------------------------------------------------------
+// Import billing functions under test (AFTER mocks are registered)
+// ---------------------------------------------------------------------------
+import {
+  handleCheckoutCompleted,
+  handleSubscriptionCreated,
+  handleSubscriptionUpdated,
+  handleSubscriptionDeleted,
+  handleInvoicePaymentFailed,
+  handleInvoicePaymentSucceeded,
+} from '@/lib/billing';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Configure mockDb.select to return chainable query resolving to `rows`.
+ *  When called with an array of arrays, each call returns the next set of rows. */
+const setupSelect = (rows: unknown[] | unknown[][]) => {
+  if (Array.isArray(rows[0])) {
+    let callIndex = 0;
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (rows as unknown[][])[callIndex++] ?? [],
+        }),
+      }),
+    }));
+  } else {
+    mockDb.select.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => rows,
+        }),
+      }),
+    }));
+  }
+};
+
+/** Configure mockDb.update to record calls and resolve. */
+const setupUpdate = () => {
+  const setCalls: unknown[] = [];
+  mockDb.update.mockImplementation(() => ({
+    set: vi.fn().mockImplementation((values: unknown) => {
+      setCalls.push(values);
+      return {
+        where: vi.fn().mockResolvedValue(undefined),
+      };
+    }),
+  }));
+  return setCalls;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('lib/billing', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockApplyCreditDelta.mockResolvedValue(undefined);
+    mockEnsureCreditAccount.mockResolvedValue(undefined);
+    mockServerTrack.mockResolvedValue(undefined);
+    mockServerIdentify.mockResolvedValue(undefined);
+    setupSelect([]);
+    setupUpdate();
+  });
+
+  // ---- handleCheckoutCompleted ----
+  describe('handleCheckoutCompleted', () => {
+    it('credits user on one-time payment', async () => {
+      setupSelect([]);
+      await handleCheckoutCompleted({
+        id: 'cs_1',
+        mode: 'payment',
+        metadata: { userId: 'u1', credits: '50' },
+        amount_total: 500,
+        currency: 'gbp',
+      } as any);
+
+      expect(mockEnsureCreditAccount).toHaveBeenCalledWith('u1');
+      expect(mockApplyCreditDelta).toHaveBeenCalledWith(
+        'u1',
+        5000,
+        'purchase',
+        { referenceId: 'cs_1', credits: 50 },
+      );
+    });
+
+    it('skips subscription-mode checkouts', async () => {
+      await handleCheckoutCompleted({
+        id: 'cs_2',
+        mode: 'subscription',
+        metadata: { userId: 'u2', credits: '50' },
+      } as any);
+
+      expect(mockApplyCreditDelta).not.toHaveBeenCalled();
+    });
+
+    it('skips duplicate sessions (idempotent)', async () => {
+      setupSelect([{ id: 1 }]);
+      await handleCheckoutCompleted({
+        id: 'cs_dup',
+        mode: 'payment',
+        metadata: { userId: 'u_dup', credits: '10' },
+      } as any);
+
+      expect(mockApplyCreditDelta).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- handleSubscriptionCreated ----
+  describe('handleSubscriptionCreated', () => {
+    it('updates tier and grants pass credits', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      setupSelect([]);
+      const setCalls = setupUpdate();
+
+      await handleSubscriptionCreated({
+        id: 'sub_1',
+        status: 'active',
+        customer: 'cus_1',
+        metadata: { userId: 'u1' },
+        items: { data: [{ price: { id: 'price_pass' } }] },
+        current_period_end: 1700000000,
+      });
+
+      expect(setCalls[0]).toMatchObject({ subscriptionTier: 'pass' });
+      expect(mockApplyCreditDelta).toHaveBeenCalledWith(
+        'u1',
+        30000,
+        'subscription_grant',
+        expect.objectContaining({
+          referenceId: 'sub_1:subscription_grant',
+          tier: 'pass',
+          credits: 300,
+        }),
+      );
+    });
+
+    it('grants lab credits (600)', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('lab');
+      setupSelect([]);
+      setupUpdate();
+
+      await handleSubscriptionCreated({
+        id: 'sub_lab',
+        status: 'active',
+        customer: 'cus_lab',
+        metadata: { userId: 'u_lab' },
+        items: { data: [{ price: { id: 'price_lab' } }] },
+      });
+
+      expect(mockApplyCreditDelta).toHaveBeenCalledWith(
+        'u_lab',
+        60000,
+        'subscription_grant',
+        expect.objectContaining({ credits: 600 }),
+      );
+    });
+
+    it('skips when userId is missing', async () => {
+      await handleSubscriptionCreated({
+        id: 'sub_noid',
+        status: 'active',
+        customer: 'cus_noid',
+        metadata: {},
+        items: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('skips when price is unrecognized', async () => {
+      mockResolveTierFromPriceId.mockReturnValue(null);
+      await handleSubscriptionCreated({
+        id: 'sub_unknown',
+        status: 'active',
+        customer: 'cus_unknown',
+        metadata: { userId: 'u_unknown' },
+        items: { data: [{ price: { id: 'price_x' } }] },
+      });
+
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('calls serverIdentify with current_tier', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      setupSelect([]);
+      setupUpdate();
+
+      await handleSubscriptionCreated({
+        id: 'sub_ph',
+        status: 'active',
+        customer: 'cus_ph',
+        metadata: { userId: 'u_ph' },
+        items: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(mockServerIdentify).toHaveBeenCalledWith('u_ph', { current_tier: 'pass' });
+    });
+  });
+
+  // ---- handleSubscriptionUpdated ----
+  describe('handleSubscriptionUpdated', () => {
+    it('grants incremental credits on upgrade', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('lab');
+      setupSelect([[{ tier: 'pass' }], []]);
+      setupUpdate();
+
+      await handleSubscriptionUpdated({
+        id: 'sub_upg',
+        status: 'active',
+        customer: 'cus_upg',
+        metadata: { userId: 'u_upg' },
+        items: { data: [{ price: { id: 'price_lab' } }] },
+      });
+
+      expect(mockApplyCreditDelta).toHaveBeenCalledWith(
+        'u_upg',
+        30000, // lab(600) - pass(300) = 300 credits
+        'subscription_upgrade_grant',
+        expect.objectContaining({
+          referenceId: 'sub_upg:upgrade_grant:pass:lab',
+          from_tier: 'pass',
+          to_tier: 'lab',
+        }),
+      );
+    });
+
+    it('does not grant credits on downgrade', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      setupSelect([[{ tier: 'lab' }], []]);
+      setupUpdate();
+
+      await handleSubscriptionUpdated({
+        id: 'sub_down',
+        status: 'active',
+        customer: 'cus_down',
+        metadata: { userId: 'u_down' },
+        items: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(mockApplyCreditDelta).not.toHaveBeenCalled();
+      // But tier update still happens
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it('tracks downgrade event in analytics', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      setupSelect([[{ tier: 'lab' }], []]);
+      setupUpdate();
+
+      await handleSubscriptionUpdated({
+        id: 'sub_down2',
+        status: 'active',
+        customer: 'cus_down2',
+        metadata: { userId: 'u_down2' },
+        items: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(mockServerTrack).toHaveBeenCalledWith(
+        'u_down2',
+        'subscription_downgraded',
+        expect.objectContaining({
+          from_tier: 'lab',
+          to_tier: 'pass',
+        }),
+      );
+    });
+  });
+
+  // ---- handleSubscriptionDeleted ----
+  describe('handleSubscriptionDeleted', () => {
+    it('downgrades to free', async () => {
+      const setCalls = setupUpdate();
+      await handleSubscriptionDeleted({
+        id: 'sub_del',
+        status: 'canceled',
+        customer: 'cus_del',
+        metadata: { userId: 'u_del' },
+      });
+
+      expect(setCalls[0]).toMatchObject({
+        subscriptionTier: 'free',
+        subscriptionStatus: 'canceled',
+      });
+    });
+
+    it('skips when userId is missing', async () => {
+      await handleSubscriptionDeleted({
+        id: 'sub_del2',
+        status: 'canceled',
+        customer: 'cus_del2',
+        metadata: {},
+      });
+
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('identifies user as free tier in PostHog', async () => {
+      setupUpdate();
+      await handleSubscriptionDeleted({
+        id: 'sub_del_ph',
+        status: 'canceled',
+        customer: 'cus_del_ph',
+        metadata: { userId: 'u_del_ph' },
+      });
+
+      expect(mockServerIdentify).toHaveBeenCalledWith('u_del_ph', { current_tier: 'free' });
+    });
+  });
+
+  // ---- handleInvoicePaymentFailed ----
+  describe('handleInvoicePaymentFailed', () => {
+    it('downgrades to free on payment failure', async () => {
+      const setCalls = setupUpdate();
+      await handleInvoicePaymentFailed({
+        id: 'inv_fail',
+        customer: 'cus_fail',
+        subscription: 'sub_fail',
+        subscription_details: { metadata: { userId: 'u_fail' } },
+      });
+
+      expect(setCalls[0]).toMatchObject({
+        subscriptionTier: 'free',
+        subscriptionStatus: 'past_due',
+      });
+    });
+
+    it('falls back to DB lookup by stripeCustomerId', async () => {
+      setupSelect([{ id: 'u_found' }]);
+      const setCalls = setupUpdate();
+
+      await handleInvoicePaymentFailed({
+        id: 'inv_fail2',
+        customer: 'cus_lookup',
+        subscription: 'sub_fail2',
+        subscription_details: { metadata: {} },
+      });
+
+      expect(mockDb.select).toHaveBeenCalled();
+      expect(setCalls[0]).toMatchObject({
+        subscriptionTier: 'free',
+        subscriptionStatus: 'past_due',
+      });
+    });
+
+    it('skips when no userId and no DB match', async () => {
+      setupSelect([]);
+      await handleInvoicePaymentFailed({
+        id: 'inv_fail3',
+        customer: 'cus_ghost',
+        subscription: 'sub_fail3',
+        subscription_details: { metadata: {} },
+      });
+
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- handleInvoicePaymentSucceeded ----
+  describe('handleInvoicePaymentSucceeded', () => {
+    it('restores tier on payment success', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      const setCalls = setupUpdate();
+
+      await handleInvoicePaymentSucceeded({
+        id: 'inv_ok',
+        customer: 'cus_ok',
+        subscription: 'sub_ok',
+        subscription_details: { metadata: { userId: 'u_ok' } },
+        lines: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(setCalls[0]).toMatchObject({
+        subscriptionTier: 'pass',
+        subscriptionStatus: 'active',
+      });
+    });
+
+    it('grants monthly credits on renewal', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      setupSelect([]);
+      setupUpdate();
+
+      await handleInvoicePaymentSucceeded({
+        id: 'inv_renew',
+        customer: 'cus_renew',
+        subscription: 'sub_renew',
+        billing_reason: 'subscription_cycle',
+        subscription_details: { metadata: { userId: 'u_renew' } },
+        lines: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(mockEnsureCreditAccount).toHaveBeenCalledWith('u_renew');
+      expect(mockApplyCreditDelta).toHaveBeenCalledWith(
+        'u_renew',
+        30000,
+        'monthly_grant',
+        expect.objectContaining({
+          referenceId: 'inv_renew:monthly_grant',
+          tier: 'pass',
+          credits: 300,
+        }),
+      );
+    });
+
+    it('skips monthly grant on initial subscribe', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      setupUpdate();
+
+      await handleInvoicePaymentSucceeded({
+        id: 'inv_init',
+        customer: 'cus_init',
+        subscription: 'sub_init',
+        billing_reason: 'subscription_create',
+        subscription_details: { metadata: { userId: 'u_init' } },
+        lines: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(mockApplyCreditDelta).not.toHaveBeenCalled();
+    });
+
+    it('skips duplicate monthly grant', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('lab');
+      setupSelect([{ id: 1 }]);
+      setupUpdate();
+
+      await handleInvoicePaymentSucceeded({
+        id: 'inv_dup',
+        customer: 'cus_dup',
+        subscription: 'sub_dup',
+        billing_reason: 'subscription_cycle',
+        subscription_details: { metadata: { userId: 'u_dup' } },
+        lines: { data: [{ price: { id: 'price_lab' } }] },
+      });
+
+      expect(mockApplyCreditDelta).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- Analytics resilience (PostHog failures) ----
+  describe('analytics resilience', () => {
+    it('handleSubscriptionCreated succeeds when PostHog throws', async () => {
+      mockResolveTierFromPriceId.mockReturnValue('pass');
+      setupSelect([]);
+      setupUpdate();
+      mockServerTrack.mockRejectedValue(new Error('PostHog down'));
+      mockServerIdentify.mockRejectedValue(new Error('PostHog down'));
+
+      // Should not throw
+      await handleSubscriptionCreated({
+        id: 'sub_ph_fail',
+        status: 'active',
+        customer: 'cus_ph_fail',
+        metadata: { userId: 'u_ph_fail' },
+        items: { data: [{ price: { id: 'price_pass' } }] },
+      });
+
+      expect(mockDb.update).toHaveBeenCalled();
+      expect(mockApplyCreditDelta).toHaveBeenCalled();
+    });
+
+    it('handleSubscriptionDeleted succeeds when PostHog throws', async () => {
+      setupUpdate();
+      mockServerTrack.mockRejectedValue(new Error('PostHog down'));
+      mockServerIdentify.mockRejectedValue(new Error('PostHog down'));
+
+      await handleSubscriptionDeleted({
+        id: 'sub_del_ph_fail',
+        status: 'canceled',
+        customer: 'cus_del_ph_fail',
+        metadata: { userId: 'u_del_ph_fail' },
+      });
+
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it('handleInvoicePaymentFailed succeeds when PostHog throws', async () => {
+      setupUpdate();
+      mockServerTrack.mockRejectedValue(new Error('PostHog down'));
+      mockServerIdentify.mockRejectedValue(new Error('PostHog down'));
+
+      await handleInvoicePaymentFailed({
+        id: 'inv_fail_ph',
+        customer: 'cus_fail_ph',
+        subscription: 'sub_fail_ph',
+        subscription_details: { metadata: { userId: 'u_fail_ph' } },
+      });
+
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract 6 billing handler functions from webhook route into lib/billing.ts (345 lines)
- Webhook route reduced from 481 to 80 lines (verify, dispatch, respond)
- 24 new unit tests for billing functions directly
- All 31 existing webhook API tests pass unchanged

Darkcat: Claude PASS WITH FINDINGS (2 major fixed: null period-end overwrite, inline idempotency)
Gate: typecheck + 1443 tests green
Roadmap: RD-012 Phase 2 Structural Decomposition

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Stripe billing business logic into `lib/billing.ts` and made the webhook route a thin dispatcher. Aligns with RD-012 by simplifying the transport layer and adding focused unit coverage.

- **Refactors**
  - Moved 6 handlers to `lib/billing.ts`; webhook route now only verifies, dispatches, and responds (481 → 80 lines).
  - Added 24 unit tests for billing functions; all existing webhook API tests pass unchanged.

- **Bug Fixes**
  - Prevented overwriting `subscriptionCurrentPeriodEnd` with null by only updating when a value is provided.
  - Applied a shared idempotency check to `checkout.session.completed` (via `referenceId`), matching other grant paths.

<sup>Written for commit 4d5bffd6b79167052f0c792139732e5346c9c427. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

