### PR TITLE
refactor(bouts): extract bout loading into lib/bouts.ts (RD-011)

### DIFF
--- a/app/b/[id]/page.tsx
+++ b/app/b/[id]/page.tsx
@@ -10,6 +10,7 @@ import { BoutHero } from '@/components/bout-hero';
 import { TrackPageEvent } from '@/components/track-page-event';
 import { requireDb } from '@/db';
 import { bouts, type TranscriptEntry } from '@/db/schema';
+import { getBoutById } from '@/lib/bouts';
 import { getCopy } from '@/lib/copy';
 import { getPresetById, ARENA_PRESET_ID } from '@/lib/presets';
 import { buildArenaPresetFromLineup } from '@/lib/bout-lineup';
@@ -72,13 +73,8 @@ export default async function ReplayPage({
 }: {
   params: Promise<{ id: string }> | { id: string };
 }) {
-  const db = requireDb();
   const [resolved, { userId }] = await Promise.all([params, auth()]);
-  const [bout] = await db
-    .select()
-    .from(bouts)
-    .where(eq(bouts.id, resolved.id))
-    .limit(1);
+  const bout = await getBoutById(resolved.id);
 
   if (!bout) {
     notFound();

--- a/app/bout/[id]/page.tsx
+++ b/app/bout/[id]/page.tsx
@@ -1,16 +1,16 @@
 import type { Metadata } from 'next';
-import { eq } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
 import { auth } from '@clerk/nextjs/server';
 
 import { Arena } from '@/components/arena';
-import { db, requireDb } from '@/db';
+import { requireDb } from '@/db';
 import { bouts, type TranscriptEntry, type ArenaAgent } from '@/db/schema';
 import {
   DEFAULT_PREMIUM_MODEL_ID,
   FREE_MODEL_ID,
   PREMIUM_MODEL_OPTIONS,
 } from '@/lib/ai';
+import { getBoutById } from '@/lib/bouts';
 import { log } from '@/lib/logger';
 import {
   BYOK_ENABLED,
@@ -36,15 +36,7 @@ export async function generateMetadata({ params }: MetadataProps): Promise<Metad
   const c = await getCopy();
   const { id } = await params;
 
-  let bout: (typeof bouts.$inferSelect) | null = null;
-  if (db) {
-    const [result] = await db
-      .select()
-      .from(bouts)
-      .where(eq(bouts.id, id))
-      .limit(1);
-    bout = result ?? null;
-  }
+  const bout = await getBoutById(id);
 
   const presetId = bout?.presetId;
   const preset = presetId ? getPresetById(presetId) ?? null : null;
@@ -134,13 +126,9 @@ export default async function BoutPage({
       ? resolvedSearchParams.format
       : null;
 
-  let bout: (typeof bouts.$inferSelect) | undefined;
+  let bout: (typeof bouts.$inferSelect) | null = null;
   try {
-    [bout] = await db
-      .select()
-      .from(bouts)
-      .where(eq(bouts.id, resolvedParams.id))
-      .limit(1);
+    bout = await getBoutById(resolvedParams.id);
   } catch (error) {
     log.error('Failed to load bout', error as Error, { boutId: resolvedParams.id });
   }

--- a/lib/bouts.ts
+++ b/lib/bouts.ts
@@ -1,0 +1,31 @@
+// Shared bout loading queries.
+//
+// Encapsulates the common `SELECT * FROM bouts WHERE id = ?` pattern
+// used across page routes and OG image generation. API routes that
+// select a subset of columns for validation (reactions, winner-vote,
+// short-links, bout-validation) intentionally keep their own narrower
+// queries to avoid fetching unused data.
+
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { bouts } from '@/db/schema';
+
+export type Bout = typeof bouts.$inferSelect;
+
+/**
+ * Load a bout by ID, returning the full row or null if not found (or if
+ * the database connection is unavailable).
+ *
+ * Uses the nullable `db` export so callers in metadata generators (where
+ * requireDb would throw) can safely get null when DATABASE_URL is unset.
+ */
+export async function getBoutById(id: string): Promise<Bout | null> {
+  if (!db) return null;
+  const [row] = await db
+    .select()
+    .from(bouts)
+    .where(eq(bouts.id, id))
+    .limit(1);
+  return row ?? null;
+}

--- a/lib/og-bout-image.tsx
+++ b/lib/og-bout-image.tsx
@@ -2,10 +2,9 @@
 // Used by both /bout/[id]/opengraph-image and /b/[id]/opengraph-image.
 
 import { ImageResponse } from 'next/og';
-import { eq } from 'drizzle-orm';
 
-import { db } from '@/db';
-import { bouts, type TranscriptEntry, type ArenaAgent } from '@/db/schema';
+import { type TranscriptEntry, type ArenaAgent } from '@/db/schema';
+import { getBoutById } from '@/lib/bouts';
 import { getPresetById, ARENA_PRESET_ID, DEFAULT_AGENT_COLOR } from '@/lib/presets';
 import { getMostReactedTurnIndex, getReactionCounts } from '@/lib/reactions';
 
@@ -13,15 +12,7 @@ export const ogSize = { width: 1200, height: 630 };
 
 export async function renderBoutOGImage(boutId: string): Promise<ImageResponse> {
   // Fetch bout data
-  let bout: (typeof bouts.$inferSelect) | null = null;
-  if (db) {
-    const [result] = await db
-      .select()
-      .from(bouts)
-      .where(eq(bouts.id, boutId))
-      .limit(1);
-    bout = result ?? null;
-  }
+  const bout = await getBoutById(boutId);
 
   // Get preset and agents
   const presetId = bout?.presetId;
@@ -47,7 +38,7 @@ export async function renderBoutOGImage(boutId: string): Promise<ImageResponse> 
   // Hero message: surface the most-reacted turn as the OG quote.
   // Fallback chain: most-reacted turn > shareLine > first qualifying transcript entry.
   let topTurn: Awaited<ReturnType<typeof getMostReactedTurnIndex>> = null;
-  if (db && bout) {
+  if (bout) {
     try {
       const [topResult, reactionMap] = await Promise.all([
         getMostReactedTurnIndex(boutId),

--- a/tests/unit/bouts.test.ts
+++ b/tests/unit/bouts.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Hoisted mocks - drizzle chain: db.select().from(bouts).where(eq(bouts.id, X)).limit(1)
+const { mockDb, mockSelectLimit } = vi.hoisted(() => {
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+  const mockDb = {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+      }),
+    }),
+  };
+  return { mockDb, mockSelectLimit };
+});
+
+vi.mock('@/db', () => ({
+  db: mockDb,
+}));
+
+vi.mock('@/db/schema', () => ({
+  bouts: { id: 'id' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+}));
+
+import { getBoutById } from '@/lib/bouts';
+
+describe('lib/bouts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-establish chain after clearAllMocks
+    mockDb.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+      }),
+    });
+    mockSelectLimit.mockResolvedValue([]);
+  });
+
+  it('returns null when no bout matches', async () => {
+    mockSelectLimit.mockResolvedValue([]);
+    const result = await getBoutById('nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('returns the bout row when found', async () => {
+    const fakeBout = {
+      id: 'abc123',
+      presetId: 'debate-classic',
+      status: 'completed',
+      transcript: [],
+      ownerId: 'user-1',
+      topic: 'cats vs dogs',
+      responseLength: null,
+      responseFormat: null,
+      maxTurns: 6,
+      agentLineup: null,
+      shareLine: 'A heated debate',
+      shareGeneratedAt: null,
+      createdAt: new Date('2026-01-01'),
+      updatedAt: new Date('2026-01-01'),
+    };
+    mockSelectLimit.mockResolvedValue([fakeBout]);
+
+    const result = await getBoutById('abc123');
+    expect(result).toEqual(fakeBout);
+  });
+
+  it('calls the drizzle chain with correct structure', async () => {
+    await getBoutById('test-id');
+    expect(mockDb.select).toHaveBeenCalledOnce();
+  });
+
+  it('returns null when db is null', async () => {
+    vi.doMock('@/db', () => ({ db: null }));
+    const { getBoutById: getBoutByIdNullDb } = await import('@/lib/bouts');
+    const result = await getBoutByIdNullDb('any-id');
+    expect(result).toBeNull();
+    vi.doMock('@/db', () => ({ db: mockDb }));
+  });
+
+  it('propagates database errors', async () => {
+    mockSelectLimit.mockRejectedValue(new Error('connection refused'));
+    await expect(getBoutById('err-id')).rejects.toThrow('connection refused');
+  });
+});


### PR DESCRIPTION
## Summary
- New lib/bouts.ts with getBoutById() shared query
- Updated 4 call sites (2 pages + OG image + replay page)
- API routes with partial selects left unchanged (intentional)
- 5 new tests

Gate: typecheck + 1448 tests green
Roadmap: RD-011 Phase 2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized bout loading with a shared `getBoutById()` in `lib/bouts.ts` to reduce duplicate queries and handle missing `db` safely in metadata/OG flows. Supports RD-011 Phase 2.

- **Refactors**
  - Added `lib/bouts.ts` with `getBoutById(id)` that returns the full row or `null` and works with a nullable `db`.
  - Replaced inline selects in `app/bout/[id]/page.tsx` (metadata + page), `app/b/[id]/page.tsx`, and `lib/og-bout-image.tsx`.
  - Left API routes with partial selects unchanged to avoid fetching unused columns.
  - Added 5 unit tests for found/not-found/null-db/error cases.

<sup>Written for commit 227417ab26dd7f8722beabf406863b0e7ca8e065. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized bout data retrieval logic into a shared helper function, improving consistency and maintainability across the application.

* **Tests**
  * Added comprehensive unit tests for bout data retrieval, covering successful retrievals, missing data scenarios, database unavailability, and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->