### PR TITLE
refactor(agents): consolidate agent snapshot resolution (RD-013)

### DIFF
--- a/lib/agent-detail.ts
+++ b/lib/agent-detail.ts
@@ -2,15 +2,11 @@
 // clone lineage (up to maxDepth generations of parent agents). Falls back to
 // preset definitions when the agent isn't yet in the database.
 
-import { getPresetById } from '@/lib/presets';
 import { requireDb } from '@/db';
 import { agents } from '@/db/schema';
 import { eq } from 'drizzle-orm';
 import type { AgentSnapshot } from '@/lib/agent-registry';
-import { parsePresetAgentId } from '@/lib/agent-registry';
-import { rowToSnapshot } from '@/lib/agent-mapper';
-import { DEFAULT_RESPONSE_LENGTH } from '@/lib/response-lengths';
-import { DEFAULT_RESPONSE_FORMAT } from '@/lib/response-formats';
+import { findPresetAgent, presetToSnapshot, rowToSnapshot } from '@/lib/agent-mapper';
 
 export type AgentLineageEntry = {
   id: string;
@@ -19,51 +15,6 @@ export type AgentLineageEntry = {
 
 export type AgentDetail = AgentSnapshot & {
   lineage: AgentLineageEntry[];
-};
-
-const findPresetAgentById = (agentId: string) => {
-  const parsed = parsePresetAgentId(agentId);
-  if (!parsed) return null;
-  const preset = getPresetById(parsed.presetId);
-  if (!preset) return null;
-  const agent = preset.agents.find((item) => item.id === parsed.agentId);
-  if (!agent) return null;
-  return { preset, agent };
-};
-
-const snapshotFromPreset = (agentId: string): AgentSnapshot | null => {
-  const presetMatch = findPresetAgentById(agentId);
-  if (!presetMatch) return null;
-  return {
-    id: agentId,
-    name: presetMatch.agent.name,
-    presetId: presetMatch.preset.id,
-    presetName: presetMatch.preset.name,
-    tier: presetMatch.preset.tier,
-    color: presetMatch.agent.color,
-    avatar: presetMatch.agent.avatar,
-    systemPrompt: presetMatch.agent.systemPrompt,
-    responseLength: DEFAULT_RESPONSE_LENGTH,
-    responseFormat: DEFAULT_RESPONSE_FORMAT,
-    archetype: null,
-    tone: null,
-    quirks: null,
-    speechPattern: null,
-    openingMove: null,
-    signatureMove: null,
-    weakness: null,
-    goal: null,
-    fears: null,
-    customInstructions: null,
-    createdAt: null,
-    ownerId: null,
-    parentId: null,
-    promptHash: null,
-    manifestHash: null,
-    attestationUid: null,
-    attestationTxHash: null,
-    archived: false,
-  };
 };
 
 export const getAgentDetail = async (
@@ -79,10 +30,11 @@ export const getAgentDetail = async (
 
   let snapshot: AgentSnapshot | null = null;
   if (row) {
-    const presetMatch = findPresetAgentById(row.id);
+    const presetMatch = findPresetAgent(row.id);
     snapshot = rowToSnapshot(row, presetMatch);
   } else {
-    snapshot = snapshotFromPreset(agentId);
+    const presetMatch = findPresetAgent(agentId);
+    snapshot = presetMatch ? presetToSnapshot(agentId, presetMatch) : null;
   }
 
   if (!snapshot) return null;
@@ -102,12 +54,12 @@ export const getAgentDetail = async (
       lineage.push({ id: parentRow.id, name: parentRow.name });
       currentParent = parentRow.parentId ?? null;
     } else {
-      /* Parent not in DB — try preset definitions (preset agents are not persisted) */
-      const presetMatch = findPresetAgentById(currentParent);
+      /* Parent not in DB - try preset definitions (preset agents are not persisted) */
+      const presetMatch = findPresetAgent(currentParent);
       if (presetMatch) {
         lineage.push({ id: currentParent, name: presetMatch.agent.name });
       }
-      break; /* Preset agents have no parentId — end of chain */
+      break; /* Preset agents have no parentId - end of chain */
     }
     depth += 1;
   }

--- a/lib/agent-mapper.ts
+++ b/lib/agent-mapper.ts
@@ -1,14 +1,39 @@
-// Shared agent row-to-snapshot mapping, used by agent-registry and agent-detail.
+// Shared agent snapshot resolution, used by agent-registry, agent-detail,
+// and leaderboard. Two entry points:
+//
+//   rowToSnapshot    - DB row + optional preset enrichment -> AgentSnapshot
+//   presetToSnapshot - pure preset definition -> AgentSnapshot (no DB)
+//
+// Both produce the same AgentSnapshot shape. Consumers should not build
+// snapshots inline.
 
 import type { AgentSnapshot } from '@/lib/agent-registry';
+import { parsePresetAgentId } from '@/lib/agent-registry';
 import type { agents } from '@/db/schema';
+import { getPresetById } from '@/lib/presets';
+import { DEFAULT_RESPONSE_FORMAT } from '@/lib/response-formats';
+import { DEFAULT_RESPONSE_LENGTH } from '@/lib/response-lengths';
 
 type AgentRow = typeof agents.$inferSelect;
 
-type PresetMatch = {
-  preset: { name: string };
-  agent: { color?: string; avatar?: string };
+export type PresetMatch = {
+  preset: { name: string; id: string; tier: 'free' | 'premium' };
+  agent: { id: string; name: string; systemPrompt: string; color?: string; avatar?: string };
 } | null;
+
+/**
+ * Resolve a preset agent by its composite ID (e.g. "preset:roast-battle:judge").
+ * Returns the matched preset and agent, or null if not found.
+ */
+export function findPresetAgent(agentId: string): PresetMatch {
+  const parsed = parsePresetAgentId(agentId);
+  if (!parsed) return null;
+  const preset = getPresetById(parsed.presetId);
+  if (!preset) return null;
+  const agent = preset.agents.find((item) => item.id === parsed.agentId);
+  if (!agent) return null;
+  return { preset, agent };
+}
 
 /**
  * Map a Drizzle agent row + optional preset match to an AgentSnapshot.
@@ -47,5 +72,45 @@ export function rowToSnapshot(
     attestationUid: row.attestationUid ?? null,
     attestationTxHash: row.attestationTxHash ?? null,
     archived: row.archived ?? false,
+  } satisfies AgentSnapshot;
+}
+
+/**
+ * Build an AgentSnapshot from a preset definition (no DB row).
+ * Used as fallback when the agent is not yet persisted.
+ */
+export function presetToSnapshot(
+  agentId: string,
+  match: NonNullable<PresetMatch>,
+): AgentSnapshot {
+  return {
+    id: agentId,
+    name: match.agent.name,
+    presetId: match.preset.id,
+    presetName: match.preset.name,
+    tier: match.preset.tier,
+    color: match.agent.color,
+    avatar: match.agent.avatar,
+    systemPrompt: match.agent.systemPrompt,
+    responseLength: DEFAULT_RESPONSE_LENGTH,
+    responseFormat: DEFAULT_RESPONSE_FORMAT,
+    archetype: null,
+    tone: null,
+    quirks: null,
+    speechPattern: null,
+    openingMove: null,
+    signatureMove: null,
+    weakness: null,
+    goal: null,
+    fears: null,
+    customInstructions: null,
+    createdAt: null,
+    ownerId: null,
+    parentId: null,
+    promptHash: null,
+    manifestHash: null,
+    attestationUid: null,
+    attestationTxHash: null,
+    archived: false,
   } satisfies AgentSnapshot;
 }

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -16,9 +16,9 @@ import { requireDb } from '@/db';
 import { agents } from '@/db/schema';
 import { DEFAULT_RESPONSE_FORMAT } from '@/lib/response-formats';
 import { DEFAULT_RESPONSE_LENGTH } from '@/lib/response-lengths';
-import { ALL_PRESETS, getPresetById } from '@/lib/presets';
+import { ALL_PRESETS } from '@/lib/presets';
 import { buildAgentManifest, hashAgentManifest, hashAgentPrompt } from '@/lib/agent-dna';
-import { rowToSnapshot } from '@/lib/agent-mapper';
+import { findPresetAgent, presetToSnapshot, rowToSnapshot } from '@/lib/agent-mapper';
 import { toError } from '@/lib/errors';
 import { log } from '@/lib/logger';
 
@@ -69,25 +69,13 @@ export const parsePresetAgentId = (agentId: string) => {
   return { presetId, agentId: innerId };
 };
 
-const findPresetAgent = (presetId: string, agentId: string) => {
-  const preset = getPresetById(presetId);
-  if (!preset) return null;
-  const agent = preset.agents.find((item) => item.id === agentId);
-  if (!agent) return null;
-  return { preset, agent };
-};
-
 export const getAgentSnapshots = async (): Promise<AgentSnapshot[]> => {
   try {
     const db = requireDb();
     const rows = await db.select().from(agents).where(eq(agents.archived, false));
     if (rows.length) {
       return rows.map((row) => {
-        const parsed = parsePresetAgentId(row.id);
-        const presetMatch =
-          parsed && row.presetId
-            ? findPresetAgent(parsed.presetId, parsed.agentId)
-            : null;
+        const presetMatch = findPresetAgent(row.id);
         return rowToSnapshot(row, presetMatch);
       });
     }
@@ -97,36 +85,14 @@ export const getAgentSnapshots = async (): Promise<AgentSnapshot[]> => {
 
   const fallback = await Promise.all(
     ALL_PRESETS.flatMap((preset) =>
-      preset.agents.map(async (agent) => ({
-        id: buildPresetAgentId(preset.id, agent.id),
-        name: agent.name,
-        presetId: preset.id,
-        presetName: preset.name,
-        tier: preset.tier,
-        color: agent.color,
-        avatar: agent.avatar,
-        systemPrompt: agent.systemPrompt,
-        responseLength: DEFAULT_RESPONSE_LENGTH,
-        responseFormat: DEFAULT_RESPONSE_FORMAT,
-        archetype: null,
-        tone: null,
-        quirks: null,
-        speechPattern: null,
-        openingMove: null,
-        signatureMove: null,
-        weakness: null,
-        goal: null,
-        fears: null,
-        customInstructions: null,
-        createdAt: null,
-        ownerId: null,
-        parentId: null,
-        promptHash: await hashAgentPrompt(agent.systemPrompt),
-        manifestHash: null,
-        attestationUid: null,
-        attestationTxHash: null,
-        archived: false,
-      })),
+      preset.agents.map(async (agent) => {
+        const agentId = buildPresetAgentId(preset.id, agent.id);
+        const snapshot = presetToSnapshot(agentId, { preset, agent });
+        return {
+          ...snapshot,
+          promptHash: await hashAgentPrompt(agent.systemPrompt),
+        };
+      }),
     ),
   );
 

--- a/tests/unit/agent-mapper.test.ts
+++ b/tests/unit/agent-mapper.test.ts
@@ -51,8 +51,8 @@ describe('rowToSnapshot', () => {
 
   it('uses preset match for name, color, and avatar', () => {
     const presetMatch = {
-      preset: { name: 'Test Preset' },
-      agent: { color: '#ff0000', avatar: 'star' },
+      preset: { name: 'Test Preset', id: 'test', tier: 'free' as const },
+      agent: { id: 'agent-1', name: 'Test Agent', systemPrompt: 'test', color: '#ff0000', avatar: 'star' },
     };
 
     const snapshot = rowToSnapshot(mockRow, presetMatch);

--- a/tests/unit/billing.test.ts
+++ b/tests/unit/billing.test.ts
@@ -152,7 +152,7 @@ describe('lib/billing', () => {
         metadata: { userId: 'u1', credits: '50' },
         amount_total: 500,
         currency: 'gbp',
-      } as any);
+      } as unknown as Parameters<typeof handleCheckoutCompleted>[0]);
 
       expect(mockEnsureCreditAccount).toHaveBeenCalledWith('u1');
       expect(mockApplyCreditDelta).toHaveBeenCalledWith(
@@ -168,7 +168,7 @@ describe('lib/billing', () => {
         id: 'cs_2',
         mode: 'subscription',
         metadata: { userId: 'u2', credits: '50' },
-      } as any);
+      } as unknown as Parameters<typeof handleCheckoutCompleted>[0]);
 
       expect(mockApplyCreditDelta).not.toHaveBeenCalled();
     });
@@ -179,7 +179,7 @@ describe('lib/billing', () => {
         id: 'cs_dup',
         mode: 'payment',
         metadata: { userId: 'u_dup', credits: '10' },
-      } as any);
+      } as unknown as Parameters<typeof handleCheckoutCompleted>[0]);
 
       expect(mockApplyCreditDelta).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- Consolidate 4 independent snapshot resolution paths into 2 shared functions in agent-mapper.ts
- findPresetAgent() and presetToSnapshot() replace duplicated logic in agent-registry.ts and agent-detail.ts
- Net: -106 lines removed, +89 added

Gate: typecheck + tests green
Roadmap: RD-013 Phase 2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized agent snapshot resolution in `lib/agent-mapper.ts` via `findPresetAgent`, `presetToSnapshot`, and `rowToSnapshot`, removing duplicated logic in the registry and detail flows with no behavior changes. Supports RD-013 Phase 2.

- **Refactors**
  - Replaced inline preset lookup and snapshot construction in `agent-registry.ts` and `agent-detail.ts` with `findPresetAgent` and `presetToSnapshot`.
  - Unified snapshot shape by widening `PresetMatch`; updated a unit test to match.
  - Net: -106/+89 LOC; typecheck and tests pass.

- **Bug Fixes**
  - Fixed lint in billing tests by replacing `as any` with a typed cast.

<sup>Written for commit e8820dcd34740c92c76090b021f2d61552a05c41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

