### PR TITLE
refactor(env): consolidate process.env reads through lib/env.ts (RD-014)

### DIFF
--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,4 +1,8 @@
 // Shared admin authentication for admin API routes.
+//
+// NOTE: Reads process.env.ADMIN_SEED_TOKEN at call time (not module load)
+// so the check reflects the current runtime value. This is intentional -
+// admin token validation must read the live value, not a cached snapshot.
 
 import { timingSafeEqual } from 'crypto';
 

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,6 +1,8 @@
 // Admin authorization: checks user IDs against a comma-separated allowlist.
 
-const ADMIN_USER_IDS = (process.env.ADMIN_USER_IDS ?? '').split(',').filter(Boolean);
+import { env } from '@/lib/env';
+
+const ADMIN_USER_IDS = (env.ADMIN_USER_IDS ?? '').split(',').filter(Boolean);
 
 export function isAdmin(userId: string | null): boolean {
   if (!userId) return false;

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -25,7 +25,6 @@ import {
   OPENROUTER_MODELS,
   ALL_OPENROUTER_MODEL_IDS,
   DEFAULT_FREE_MODEL,
-  DEFAULT_PREMIUM_MODELS,
   DEFAULT_PREMIUM_MODEL,
   detectProvider,
 } from '@/lib/models';
@@ -45,16 +44,18 @@ export const FREE_MODEL_ID =
   process.env.ANTHROPIC_MODEL ??
   DEFAULT_FREE_MODEL;
 
-const premiumModelEnv =
-  env.ANTHROPIC_PREMIUM_MODELS ?? DEFAULT_PREMIUM_MODELS;
+const premiumModelEnv = env.ANTHROPIC_PREMIUM_MODELS;
 
 const parsedPremiumModels = premiumModelEnv
   .split(',')
   .map((model) => model.trim())
   .filter(Boolean);
 
+// Raw process.env check: warn only when the user explicitly set the var
+// to something unparseable. env.ANTHROPIC_PREMIUM_MODELS always has a
+// value (Zod default), so it cannot distinguish "unset" from "defaulted".
 if (
-  env.ANTHROPIC_PREMIUM_MODELS &&
+  process.env.ANTHROPIC_PREMIUM_MODELS &&
   parsedPremiumModels.length === 0
 ) {
   console.warn(
@@ -68,10 +69,7 @@ export const PREMIUM_MODEL_OPTIONS =
     ? parsedPremiumModels
     : [DEFAULT_PREMIUM_MODEL];
 
-export const DEFAULT_PREMIUM_MODEL_ID =
-  env.ANTHROPIC_PREMIUM_MODEL ??
-  PREMIUM_MODEL_OPTIONS[0] ??
-  DEFAULT_PREMIUM_MODEL;
+export const DEFAULT_PREMIUM_MODEL_ID = env.ANTHROPIC_PREMIUM_MODEL;
 
 export const BYOK_MODEL_ID =
   env.ANTHROPIC_BYOK_MODEL ?? FREE_MODEL_ID;

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -29,18 +29,24 @@ import {
   DEFAULT_PREMIUM_MODEL,
   detectProvider,
 } from '@/lib/models';
+import { env } from '@/lib/env';
 
 const defaultAnthropic = createAnthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
+  apiKey: env.ANTHROPIC_API_KEY,
 });
 
+// Model ID resolution uses process.env directly for the fallback chain
+// because env.ts applies defaults (e.g. ANTHROPIC_FREE_MODEL defaults to
+// DEFAULT_FREE_MODEL), which means env.ANTHROPIC_FREE_MODEL is never
+// undefined and the ?? fallback to ANTHROPIC_MODEL would never trigger.
+// Reading process.env preserves the "unset = try next fallback" semantics.
 export const FREE_MODEL_ID =
   process.env.ANTHROPIC_FREE_MODEL ??
   process.env.ANTHROPIC_MODEL ??
   DEFAULT_FREE_MODEL;
 
 const premiumModelEnv =
-  process.env.ANTHROPIC_PREMIUM_MODELS ?? DEFAULT_PREMIUM_MODELS;
+  env.ANTHROPIC_PREMIUM_MODELS ?? DEFAULT_PREMIUM_MODELS;
 
 const parsedPremiumModels = premiumModelEnv
   .split(',')
@@ -48,7 +54,7 @@ const parsedPremiumModels = premiumModelEnv
   .filter(Boolean);
 
 if (
-  process.env.ANTHROPIC_PREMIUM_MODELS &&
+  env.ANTHROPIC_PREMIUM_MODELS &&
   parsedPremiumModels.length === 0
 ) {
   console.warn(
@@ -63,12 +69,12 @@ export const PREMIUM_MODEL_OPTIONS =
     : [DEFAULT_PREMIUM_MODEL];
 
 export const DEFAULT_PREMIUM_MODEL_ID =
-  process.env.ANTHROPIC_PREMIUM_MODEL ??
+  env.ANTHROPIC_PREMIUM_MODEL ??
   PREMIUM_MODEL_OPTIONS[0] ??
   DEFAULT_PREMIUM_MODEL;
 
 export const BYOK_MODEL_ID =
-  process.env.ANTHROPIC_BYOK_MODEL ?? FREE_MODEL_ID;
+  env.ANTHROPIC_BYOK_MODEL ?? FREE_MODEL_ID;
 
 /** Default OpenRouter model when an OpenRouter key is supplied without a model selection. */
 export const DEFAULT_OPENROUTER_MODEL = OPENROUTER_MODELS.GPT_4O;

--- a/lib/ask-the-pit-config.ts
+++ b/lib/ask-the-pit-config.ts
@@ -1,15 +1,16 @@
 // Configuration for the "Ask the Pit" feature: an AI assistant that can
 // answer questions about the platform by reading project documentation.
 
-export const ASK_THE_PIT_ENABLED = process.env.ASK_THE_PIT_ENABLED === 'true';
+import { FREE_MODEL_ID } from '@/lib/ai';
+import { env } from '@/lib/env';
+
+export const ASK_THE_PIT_ENABLED = env.ASK_THE_PIT_ENABLED;
 
 export const ASK_THE_PIT_DOCS = [
   'README.md',
   'AGENTS.md',
 ];
 
-import { FREE_MODEL_ID } from '@/lib/ai';
-
-export const ASK_THE_PIT_MODEL = process.env.ASK_THE_PIT_MODEL ?? FREE_MODEL_ID;
+export const ASK_THE_PIT_MODEL = env.ASK_THE_PIT_MODEL ?? FREE_MODEL_ID;
 
 export const ASK_THE_PIT_MAX_TOKENS = 2_000;

--- a/lib/credits.ts
+++ b/lib/credits.ts
@@ -17,53 +17,31 @@ import { desc, eq, sql } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
 import { creditTransactions, credits } from '@/db/schema';
+import { env } from '@/lib/env';
 import { MODEL_IDS } from '@/lib/models';
 
-export const CREDIT_VALUE_GBP = Number(
-  process.env.CREDIT_VALUE_GBP ?? '0.01',
-);
+export const CREDIT_VALUE_GBP = env.CREDIT_VALUE_GBP;
 export const MICRO_PER_CREDIT = 100;
 export const MICRO_VALUE_GBP = CREDIT_VALUE_GBP / MICRO_PER_CREDIT;
-export const CREDITS_ENABLED = process.env.CREDITS_ENABLED === 'true';
-export const CREDITS_ADMIN_ENABLED =
-  process.env.CREDITS_ADMIN_ENABLED === 'true';
-export const CREDITS_ADMIN_GRANT = Number(
-  process.env.CREDITS_ADMIN_GRANT ?? '100',
-);
-export const CREDIT_PLATFORM_MARGIN = Number(
-  process.env.CREDIT_PLATFORM_MARGIN ?? '0.10',
-);
+export const CREDITS_ENABLED = env.CREDITS_ENABLED;
+export const CREDITS_ADMIN_ENABLED = env.CREDITS_ADMIN_ENABLED;
+export const CREDITS_ADMIN_GRANT = env.CREDITS_ADMIN_GRANT;
+export const CREDIT_PLATFORM_MARGIN = env.CREDIT_PLATFORM_MARGIN;
 
 // --- Tier credit grants (one-time on subscription creation / upgrade) ---
-export const SUBSCRIPTION_GRANT_PASS = Number(
-  process.env.SUBSCRIPTION_GRANT_PASS ?? '300',
-);
-export const SUBSCRIPTION_GRANT_LAB = Number(
-  process.env.SUBSCRIPTION_GRANT_LAB ?? '600',
-);
+export const SUBSCRIPTION_GRANT_PASS = env.SUBSCRIPTION_GRANT_PASS;
+export const SUBSCRIPTION_GRANT_LAB = env.SUBSCRIPTION_GRANT_LAB;
 
 // --- Monthly recurring credit grants (on invoice.payment_succeeded) ---
-export const MONTHLY_CREDITS_PASS = Number(
-  process.env.MONTHLY_CREDITS_PASS ?? '300',
-);
-export const MONTHLY_CREDITS_LAB = Number(
-  process.env.MONTHLY_CREDITS_LAB ?? '600',
-);
-const TOKEN_CHARS_PER = Number(
-  process.env.CREDIT_TOKEN_CHARS_PER ?? '4',
-);
-const OUTPUT_TOKENS_PER_TURN = Number(
-  process.env.CREDIT_OUTPUT_TOKENS_PER_TURN ?? '120',
-);
-const INPUT_FACTOR = Number(
-  process.env.CREDIT_INPUT_FACTOR ?? '5.5',
-);
+export const MONTHLY_CREDITS_PASS = env.MONTHLY_CREDITS_PASS;
+export const MONTHLY_CREDITS_LAB = env.MONTHLY_CREDITS_LAB;
+const TOKEN_CHARS_PER = env.CREDIT_TOKEN_CHARS_PER;
+const OUTPUT_TOKENS_PER_TURN = env.CREDIT_OUTPUT_TOKENS_PER_TURN;
+const INPUT_FACTOR = env.CREDIT_INPUT_FACTOR;
 
-export const BYOK_ENABLED = process.env.BYOK_ENABLED === 'true';
-const BYOK_FEE_GBP_PER_1K_TOKENS = Number(
-  process.env.BYOK_FEE_GBP_PER_1K_TOKENS ?? '0.0002',
-);
-const BYOK_MIN_GBP = Number(process.env.BYOK_MIN_GBP ?? '0.001');
+export const BYOK_ENABLED = env.BYOK_ENABLED;
+const BYOK_FEE_GBP_PER_1K_TOKENS = env.BYOK_FEE_GBP_PER_1K_TOKENS;
+const BYOK_MIN_GBP = env.BYOK_MIN_GBP;
 
 /** GBP/USD exchange rate used for pricing conversions. */
 const GBP_TO_USD = 1.366; // inverse of ~0.732 GBP/USD
@@ -78,7 +56,7 @@ const DEFAULT_MODEL_PRICES_GBP: Record<string, { in: number; out: number }> = {
 };
 
 const ENV_MODEL_PRICES = (() => {
-  const raw = process.env.MODEL_PRICES_GBP_JSON;
+  const raw = env.MODEL_PRICES_GBP_JSON;
   if (!raw) return {} as Record<string, { in: number; out: number }>;
   try {
     return JSON.parse(raw) as Record<string, { in: number; out: number }>;
@@ -204,7 +182,7 @@ export async function ensureCreditAccount(userId: string, tx?: DbOrTx) {
 
   if (existing) return existing;
 
-  const startingCredits = Number(process.env.CREDITS_STARTING_CREDITS ?? '100');
+  const startingCredits = env.CREDITS_STARTING_CREDITS;
   const balanceMicro = Math.max(
     0,
     Math.round(startingCredits * MICRO_PER_CREDIT),

--- a/lib/eas.ts
+++ b/lib/eas.ts
@@ -16,20 +16,21 @@ import { EAS, SchemaEncoder } from '@ethereum-attestation-service/eas-sdk';
 import { ethers } from 'ethers';
 
 import type { AgentManifest } from '@/lib/agent-dna';
+import { env } from '@/lib/env';
 import { log } from '@/lib/logger';
 
 // Base L2 pre-deployed EAS contract addresses (same for all Base deployments)
 const DEFAULT_EAS_ADDRESS = '0x4200000000000000000000000000000000000021';
 const DEFAULT_SCHEMA_REGISTRY = '0x4200000000000000000000000000000000000020';
 
-export const EAS_ENABLED = process.env.EAS_ENABLED === 'true';
-export const EAS_CHAIN_ID = Number(process.env.EAS_CHAIN_ID ?? 8453);
-export const EAS_SCHEMA_UID = process.env.EAS_SCHEMA_UID ?? '';
-export const EAS_RPC_URL = process.env.EAS_RPC_URL ?? '';
+export const EAS_ENABLED = env.EAS_ENABLED;
+export const EAS_CHAIN_ID = env.EAS_CHAIN_ID;
+export const EAS_SCHEMA_UID = env.EAS_SCHEMA_UID ?? '';
+export const EAS_RPC_URL = env.EAS_RPC_URL ?? '';
 export const EAS_CONTRACT_ADDRESS =
-  process.env.EAS_CONTRACT_ADDRESS ?? DEFAULT_EAS_ADDRESS;
+  env.EAS_CONTRACT_ADDRESS ?? DEFAULT_EAS_ADDRESS;
 export const EAS_SCHEMA_REGISTRY_ADDRESS =
-  process.env.EAS_SCHEMA_REGISTRY_ADDRESS ?? DEFAULT_SCHEMA_REGISTRY;
+  env.EAS_SCHEMA_REGISTRY_ADDRESS ?? DEFAULT_SCHEMA_REGISTRY;
 
 // The on-chain schema defines the attestation structure. Each field maps to a
 // Solidity type: strings for human-readable IDs, bytes32 for the 32-byte
@@ -70,7 +71,7 @@ const requireEasConfig = () => {
   if (!EAS_RPC_URL) {
     throw new Error('EAS_RPC_URL is required.');
   }
-  if (!process.env.EAS_SIGNER_PRIVATE_KEY) {
+  if (!env.EAS_SIGNER_PRIVATE_KEY) {
     throw new Error('EAS_SIGNER_PRIVATE_KEY is required.');
   }
 };
@@ -85,7 +86,7 @@ export const attestAgent = async (params: {
 
   const provider = new ethers.JsonRpcProvider(EAS_RPC_URL, EAS_CHAIN_ID);
   const signer = new ethers.Wallet(
-    process.env.EAS_SIGNER_PRIVATE_KEY as string,
+    env.EAS_SIGNER_PRIVATE_KEY as string,
     provider,
   );
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -9,9 +9,27 @@
  *   env.DATABASE_URL   // string (validated)
  *   env.CREDITS_ENABLED // boolean (coerced from 'true'/'false')
  *
- * NOTE: NEXT_PUBLIC_* variables are NOT validated here — they are bundled
+ * NOTE: NEXT_PUBLIC_* variables are NOT validated here - they are bundled
  * at build time by Next.js and accessed directly in client components.
  * Server-side env vars only.
+ *
+ * TODO(RD-014): The following files still read process.env directly and
+ * should be migrated to use `env.*` in a follow-up PR:
+ *   - lib/bout-execution.ts (1 read: ANTHROPIC_BYOK_MODEL)
+ *   - lib/bout-validation.ts (1 read: RESEARCH_API_KEY)
+ *   - lib/models.ts (validateModelEnvVars - intentionally reads raw env)
+ *   - lib/logger.ts (LOG_LEVEL - cannot import env.ts, circular dep)
+ *   - lib/posthog-server.ts (NEXT_PUBLIC_* - client vars, excluded)
+ *   - lib/brand.ts (NEXT_PUBLIC_* - client vars, excluded)
+ *   - lib/openapi.ts (NEXT_PUBLIC_SITE_URL - client var)
+ *   - lib/attestation-links.ts (NEXT_PUBLIC_EAS_SCAN_BASE - client var)
+ *   - app/actions.ts (3 reads: APP_URL, STRIPE_SECRET_KEY, price IDs)
+ *   - app/api/credits/webhook/route.ts (STRIPE_WEBHOOK_SECRET)
+ *   - app/api/contact/route.ts (RESEND_API_KEY, CONTACT_TO/FROM_EMAIL)
+ *   - app/api/pv/route.ts (PV_INTERNAL_SECRET)
+ *   - app/api/v1/bout/route.ts (RESEARCH_API_KEY)
+ *   - app/api/byok-stash/route.ts (NODE_ENV)
+ *   - app/sitemap.ts, app/robots.ts (NEXT_PUBLIC_SITE_URL - client var)
  */
 
 import { z } from 'zod/v4';

--- a/lib/intro-pool.ts
+++ b/lib/intro-pool.ts
@@ -14,21 +14,14 @@ import { eq, sql } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
 import { introPool } from '@/db/schema';
+import { env } from '@/lib/env';
 import { MICRO_PER_CREDIT, ensureCreditAccount, applyCreditDelta } from '@/lib/credits';
 
-export const INTRO_POOL_TOTAL_CREDITS = Number(
-  process.env.INTRO_POOL_TOTAL_CREDITS ?? '10000',
-);
+export const INTRO_POOL_TOTAL_CREDITS = env.INTRO_POOL_TOTAL_CREDITS;
 /** Half-life in days. Pool halves every N days via exponential decay. */
-export const INTRO_POOL_HALF_LIFE_DAYS = Number(
-  process.env.INTRO_POOL_HALF_LIFE_DAYS ?? '3',
-);
-export const INTRO_SIGNUP_CREDITS = Number(
-  process.env.INTRO_SIGNUP_CREDITS ?? '0',
-);
-export const INTRO_REFERRAL_CREDITS = Number(
-  process.env.INTRO_REFERRAL_CREDITS ?? '50',
-);
+export const INTRO_POOL_HALF_LIFE_DAYS = env.INTRO_POOL_HALF_LIFE_DAYS;
+export const INTRO_SIGNUP_CREDITS = env.INTRO_SIGNUP_CREDITS;
+export const INTRO_REFERRAL_CREDITS = env.INTRO_REFERRAL_CREDITS;
 
 /** Half-life in minutes. Used in TS for computeRemainingMicro.
  *  In SQL expressions, multiply by 60 to convert to seconds (EXTRACT EPOCH returns seconds). */

--- a/lib/langsmith.ts
+++ b/lib/langsmith.ts
@@ -20,13 +20,14 @@
 
 import * as ai from 'ai';
 
+import { env } from '@/lib/env';
 import { log } from '@/lib/logger';
 
 // ---------------------------------------------------------------------------
-// Feature flag — read once at module load
+// Feature flag - read once at module load
 // ---------------------------------------------------------------------------
 
-const LANGSMITH_ENABLED = process.env.LANGSMITH_ENABLED === 'true';
+const LANGSMITH_ENABLED = env.LANGSMITH_ENABLED;
 
 // ---------------------------------------------------------------------------
 // LangSmith Client singleton
@@ -58,7 +59,7 @@ export function getLangSmithClient(): import('langsmith').Client | null {
       // LANGSMITH_PROJECT env vars by the SDK automatically.
     });
     log.info('LangSmith client initialized', {
-      project: process.env.LANGSMITH_PROJECT ?? 'default',
+      project: env.LANGSMITH_PROJECT ?? 'default',
     });
   }
 

--- a/lib/remix-events.ts
+++ b/lib/remix-events.ts
@@ -8,16 +8,13 @@ import { eq, sql } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
 import { remixEvents, agents } from '@/db/schema';
+import { env } from '@/lib/env';
 import { log } from '@/lib/logger';
 import { applyCreditDelta, CREDITS_ENABLED } from '@/lib/credits';
 
 // Configurable reward amounts in micro-credits (env vars, default 0 = disabled)
-export const REMIX_REWARD_REMIXER_MICRO = Number(
-  process.env.REMIX_REWARD_REMIXER_MICRO ?? '0',
-);
-export const REMIX_REWARD_SOURCE_OWNER_MICRO = Number(
-  process.env.REMIX_REWARD_SOURCE_OWNER_MICRO ?? '0',
-);
+export const REMIX_REWARD_REMIXER_MICRO = env.REMIX_REWARD_REMIXER_MICRO;
+export const REMIX_REWARD_SOURCE_OWNER_MICRO = env.REMIX_REWARD_SOURCE_OWNER_MICRO;
 
 export type RemixOutcome = 'completed' | 'failed';
 

--- a/lib/research-anonymize.ts
+++ b/lib/research-anonymize.ts
@@ -5,11 +5,12 @@
 // cross-dataset de-anonymization while preserving within-dataset
 // consistency (same userId always maps to the same hash).
 
+import { env } from '@/lib/env';
 import { sha256Hex } from '@/lib/hash';
 
 const ANONYMIZE_SALT = (() => {
-  const salt = process.env.RESEARCH_ANONYMIZE_SALT;
-  if (!salt && process.env.NODE_ENV === 'production') {
+  const salt = env.RESEARCH_ANONYMIZE_SALT;
+  if (!salt && env.NODE_ENV === 'production') {
     throw new Error(
       'RESEARCH_ANONYMIZE_SALT must be set in production to protect PII in research exports. ' +
       'Generate a random value: openssl rand -hex 32',

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -7,12 +7,14 @@
 
 import Stripe from 'stripe';
 
+import { env } from '@/lib/env';
+
 let _stripe: Stripe | null = null;
 
 export const stripe = new Proxy({} as Stripe, {
   get(_target, prop) {
     if (!_stripe) {
-      const key = process.env.STRIPE_SECRET_KEY;
+      const key = env.STRIPE_SECRET_KEY;
       if (!key) {
         throw new Error('STRIPE_SECRET_KEY is not configured.');
       }

--- a/lib/tier.ts
+++ b/lib/tier.ts
@@ -12,6 +12,7 @@
 import { eq, sql } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
+import { env } from '@/lib/env';
 import { log } from '@/lib/logger';
 import { users } from '@/db/schema';
 import { isAdmin } from '@/lib/admin';
@@ -19,16 +20,15 @@ import { MODEL_FAMILY } from '@/lib/models';
 
 export type UserTier = 'free' | 'pass' | 'lab';
 
-export const SUBSCRIPTIONS_ENABLED =
-  process.env.SUBSCRIPTIONS_ENABLED === 'true';
+export const SUBSCRIPTIONS_ENABLED = env.SUBSCRIPTIONS_ENABLED;
 
 /** Map Stripe price IDs to subscription tiers. */
 const PRICE_TO_TIER: Record<string, UserTier> = {
-  ...(process.env.STRIPE_PASS_PRICE_ID
-    ? { [process.env.STRIPE_PASS_PRICE_ID]: 'pass' as const }
+  ...(env.STRIPE_PASS_PRICE_ID
+    ? { [env.STRIPE_PASS_PRICE_ID]: 'pass' as const }
     : {}),
-  ...(process.env.STRIPE_LAB_PRICE_ID
-    ? { [process.env.STRIPE_LAB_PRICE_ID]: 'lab' as const }
+  ...(env.STRIPE_LAB_PRICE_ID
+    ? { [env.STRIPE_LAB_PRICE_ID]: 'lab' as const }
     : {}),
 };
 


### PR DESCRIPTION
## Summary
- Migrate ~50 process.env reads across 11 lib/ files to use Zod-validated env.ts
- Remove dead fallback chains exposed by Zod defaults
- Preserve raw process.env for warning guard semantic (intentional)
- TODO comment listing remaining files for future PRs

Darkcat: Claude PASS WITH FINDINGS (2 major - both fixed)
Gate: typecheck + 1443 tests green
Roadmap: RD-014 Phase 2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated environment variable access through Zod-validated `lib/env.ts` across 11 server libs to improve safety and consistency. Removed dead fallbacks and preserved runtime-sensitive reads where needed, aligning with RD-014 Phase 2.

- **Refactors**
  - Replaced `process.env` with `env` in 11 files: credits, tier, ai, eas, intro-pool, admin, ask-the-pit-config, remix-events, langsmith, stripe, research-anonymize.
  - Kept intentional raw reads: `ADMIN_SEED_TOKEN` at call time, and Anthropic model fallback/warning guard in `ai.ts` to preserve “unset” semantics.
  - Removed unreachable fallback chains in `ai.ts` now covered by Zod defaults; use validated values for premiums and BYOK.
  - Added a TODO in `lib/env.ts` listing remaining files for follow-up; `NEXT_PUBLIC_*` client vars remain unchanged.

<sup>Written for commit 5aeb6ab3ae4774ddbfce68ccee944cc87361d496. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

