### PR TITLE
refactor(dal): extract engagement and community DB queries from app/ into lib/ (RD-015b, RD-016)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,10 +1,9 @@
-import { requireDb } from '@/db';
-import { contactSubmissions } from '@/db/schema';
 import { checkRateLimit, getClientIdentifier } from '@/lib/rate-limit';
 import { log } from '@/lib/logger';
 import { withLogging } from '@/lib/api-logging';
 import { parseValidBody, rateLimitResponse } from '@/lib/api-utils';
 import { contactSchema } from '@/lib/api-schemas';
+import { submitContact } from '@/lib/submissions';
 
 export const runtime = 'nodejs';
 
@@ -31,11 +30,10 @@ export const POST = withLogging(async function POST(req: Request) {
   if (parsed.error) return parsed.error;
   const { name, email, message } = parsed.data;
 
-  /* Always capture to DB first — this is the durable record */
-  const db = requireDb();
-  await db.insert(contactSubmissions).values({ name, email, message });
+  /* Always capture to DB first - this is the durable record */
+  await submitContact({ name, email, message });
 
-  /* Best-effort email delivery — log failure but do not fail the request */
+  /* Best-effort email delivery - log failure but do not fail the request */
   const apiKey = process.env.RESEND_API_KEY;
   const toEmail = process.env.CONTACT_TO_EMAIL;
   const fromEmail = process.env.CONTACT_FROM_EMAIL ?? 'The Pit <contact@thepit.ai>';
@@ -52,7 +50,7 @@ export const POST = withLogging(async function POST(req: Request) {
         body: JSON.stringify({
           from: fromEmail,
           to: [toEmail],
-          subject: `The Pit contact — ${name.replace(/[\r\n]+/g, ' ').trim()}`,
+          subject: `The Pit contact - ${name.replace(/[\r\n]+/g, ' ').trim()}`,
           html: `<p><strong>Name:</strong> ${escapeHtml(name)}</p><p><strong>Email:</strong> ${escapeHtml(email)}</p><p>${escapeHtml(message).replace(/\n/g, '<br/>')}</p>`,
         }),
       });

--- a/app/api/feature-requests/route.ts
+++ b/app/api/feature-requests/route.ts
@@ -1,69 +1,24 @@
 import { auth } from '@clerk/nextjs/server';
-import { eq, ne, sql, desc } from 'drizzle-orm';
 
-import { requireDb } from '@/db';
-import { featureRequests, featureRequestVotes, users } from '@/db/schema';
 import { errorResponse, parseValidBody, rateLimitResponse, API_ERRORS } from '@/lib/api-utils';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { withLogging } from '@/lib/api-logging';
 import { ensureUserRecord } from '@/lib/users';
 import { featureRequestSchema } from '@/lib/api-schemas';
+import { listFeatureRequests, createFeatureRequest } from '@/lib/feature-requests';
 
 export const runtime = 'nodejs';
 
-/** GET /api/feature-requests — public list of non-declined requests with vote counts. */
+/** GET /api/feature-requests - public list of non-declined requests with vote counts. */
 export const GET = withLogging(async function GET() {
-  const db = requireDb();
   const { userId } = await auth();
 
-  const voteCount = sql<number>`(
-    select count(*)::int from feature_request_votes
-    where feature_request_votes.feature_request_id = ${featureRequests.id}
-  )`.as('vote_count');
-
-  const rows = await db
-    .select({
-      id: featureRequests.id,
-      title: featureRequests.title,
-      description: featureRequests.description,
-      category: featureRequests.category,
-      status: featureRequests.status,
-      createdAt: featureRequests.createdAt,
-      userId: featureRequests.userId,
-      displayName: users.displayName,
-      voteCount,
-    })
-    .from(featureRequests)
-    .leftJoin(users, eq(featureRequests.userId, users.id))
-    .where(ne(featureRequests.status, 'declined'))
-    .orderBy(desc(voteCount), desc(featureRequests.createdAt));
-
-  // If the caller is authenticated, check which requests they've voted on.
-  let votedIds: Set<number> = new Set();
-  if (userId) {
-    const userVotes = await db
-      .select({ featureRequestId: featureRequestVotes.featureRequestId })
-      .from(featureRequestVotes)
-      .where(eq(featureRequestVotes.userId, userId));
-    votedIds = new Set(userVotes.map((v) => v.featureRequestId));
-  }
-
-  const requests = rows.map((r) => ({
-    id: r.id,
-    title: r.title,
-    description: r.description,
-    category: r.category,
-    status: r.status,
-    createdAt: r.createdAt,
-    displayName: r.displayName ?? 'Anonymous',
-    voteCount: r.voteCount,
-    userVoted: votedIds.has(r.id),
-  }));
+  const requests = await listFeatureRequests(userId);
 
   return Response.json({ requests });
 }, 'feature-requests-list');
 
-/** POST /api/feature-requests — auth-required, rate-limited submission. */
+/** POST /api/feature-requests - auth-required, rate-limited submission. */
 export const POST = withLogging(async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) {
@@ -84,16 +39,7 @@ export const POST = withLogging(async function POST(req: Request) {
 
   await ensureUserRecord(userId);
 
-  const db = requireDb();
-  const [created] = await db
-    .insert(featureRequests)
-    .values({
-      userId,
-      title,
-      description,
-      category,
-    })
-    .returning({ id: featureRequests.id });
+  const created = await createFeatureRequest(userId, { title, description, category });
 
-  return Response.json({ ok: true, id: created!.id });
+  return Response.json({ ok: true, id: created.id });
 }, 'feature-requests');

--- a/app/api/feature-requests/vote/route.ts
+++ b/app/api/feature-requests/vote/route.ts
@@ -1,16 +1,14 @@
 import { auth } from '@clerk/nextjs/server';
-import { eq, and, sql } from 'drizzle-orm';
 
-import { requireDb } from '@/db';
-import { featureRequestVotes } from '@/db/schema';
 import { errorResponse, parseValidBody, rateLimitResponse, API_ERRORS } from '@/lib/api-utils';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { withLogging } from '@/lib/api-logging';
 import { featureRequestVoteSchema } from '@/lib/api-schemas';
+import { toggleFeatureRequestVote } from '@/lib/feature-requests';
 
 export const runtime = 'nodejs';
 
-/** POST /api/feature-requests/vote — toggle a vote on a feature request. */
+/** POST /api/feature-requests/vote - toggle a vote on a feature request. */
 export const POST = withLogging(async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) {
@@ -29,43 +27,7 @@ export const POST = withLogging(async function POST(req: Request) {
   if (parsed.error) return parsed.error;
   const { featureRequestId } = parsed.data;
 
-  const db = requireDb();
+  const result = await toggleFeatureRequestVote(userId, featureRequestId);
 
-  // Check if the user already voted.
-  const [existing] = await db
-    .select({ id: featureRequestVotes.id })
-    .from(featureRequestVotes)
-    .where(
-      and(
-        eq(featureRequestVotes.featureRequestId, featureRequestId),
-        eq(featureRequestVotes.userId, userId),
-      ),
-    )
-    .limit(1);
-
-  if (existing) {
-    // Unvote
-    await db
-      .delete(featureRequestVotes)
-      .where(eq(featureRequestVotes.id, existing.id));
-  } else {
-    // Vote
-    await db
-      .insert(featureRequestVotes)
-      .values({ featureRequestId, userId })
-      .onConflictDoNothing();
-  }
-
-  // Get current vote count
-  const [result] = await db
-    .select({
-      count: sql<number>`count(*)::int`,
-    })
-    .from(featureRequestVotes)
-    .where(eq(featureRequestVotes.featureRequestId, featureRequestId));
-
-  return Response.json({
-    voted: !existing,
-    voteCount: result!.count,
-  });
+  return Response.json(result);
 }, 'feature-request-vote');

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,9 +1,8 @@
-import { requireDb } from '@/db';
-import { newsletterSignups } from '@/db/schema';
 import { checkRateLimit, getClientIdentifier } from '@/lib/rate-limit';
 import { withLogging } from '@/lib/api-logging';
 import { parseValidBody, rateLimitResponse } from '@/lib/api-utils';
 import { newsletterSchema } from '@/lib/api-schemas';
+import { subscribeNewsletter } from '@/lib/submissions';
 
 export const runtime = 'nodejs';
 
@@ -21,11 +20,7 @@ export const POST = withLogging(async function POST(req: Request) {
   if (parsed.error) return parsed.error;
   const { email } = parsed.data;
 
-  const db = requireDb();
-  await db
-    .insert(newsletterSignups)
-    .values({ email })
-    .onConflictDoNothing();
+  await subscribeNewsletter(email);
 
   return Response.json({ ok: true });
 }, 'newsletter');

--- a/app/api/paper-submissions/route.ts
+++ b/app/api/paper-submissions/route.ts
@@ -1,13 +1,12 @@
 import { auth } from '@clerk/nextjs/server';
 
-import { requireDb } from '@/db';
-import { paperSubmissions } from '@/db/schema';
 import { errorResponse, parseValidBody, rateLimitResponse, API_ERRORS } from '@/lib/api-utils';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { withLogging } from '@/lib/api-logging';
 import { parseArxivId, fetchArxivMetadata } from '@/lib/arxiv';
 import { ensureUserRecord } from '@/lib/users';
 import { paperSubmissionSchema } from '@/lib/api-schemas';
+import { submitPaper } from '@/lib/submissions';
 
 export const runtime = 'nodejs';
 
@@ -41,20 +40,16 @@ export const POST = withLogging(async function POST(req: Request) {
 
   await ensureUserRecord(userId);
 
-  const db = requireDb();
-  await db
-    .insert(paperSubmissions)
-    .values({
-      userId,
-      arxivId,
-      arxivUrl: `https://arxiv.org/abs/${arxivId}`,
-      title: metadata.title.slice(0, 500),
-      authors: metadata.authors.slice(0, 1000),
-      abstract: metadata.abstract || null,
-      justification,
-      relevanceArea,
-    })
-    .onConflictDoNothing();
+  await submitPaper({
+    userId,
+    arxivId,
+    arxivUrl: `https://arxiv.org/abs/${arxivId}`,
+    title: metadata.title.slice(0, 500),
+    authors: metadata.authors.slice(0, 1000),
+    abstract: metadata.abstract || null,
+    justification,
+    relevanceArea,
+  });
 
   return Response.json({
     ok: true,

--- a/app/api/pv/route.ts
+++ b/app/api/pv/route.ts
@@ -6,14 +6,13 @@
 
 import crypto from 'crypto';
 
-import { requireDb } from '@/db';
-import { pageViews } from '@/db/schema';
 import { sha256Hex } from '@/lib/hash';
 import { log } from '@/lib/logger';
 import { errorResponse, parseValidBody, API_ERRORS } from '@/lib/api-utils';
 import { pageViewSchema } from '@/lib/api-schemas';
 import { withLogging } from '@/lib/api-logging';
 import { serverTrack } from '@/lib/posthog-server';
+import { recordPageView } from '@/lib/submissions';
 
 export const runtime = 'nodejs';
 
@@ -25,7 +24,7 @@ function timingSafeCompare(a: string, b: string): boolean {
 }
 
 async function rawPOST(req: Request) {
-  // Verify internal secret — reject external callers
+  // Verify internal secret - reject external callers
   const secret = req.headers.get('x-pv-secret');
   const expected = process.env.PV_INTERNAL_SECRET ?? '';
   if (!secret || !expected || !timingSafeCompare(secret, expected)) {
@@ -38,7 +37,7 @@ async function rawPOST(req: Request) {
 
   const { path, sessionId } = payload;
 
-  // Parse UTM from cookie JSON — extract all 5 standard UTM params
+  // Parse UTM from cookie JSON - extract all 5 standard UTM params
   let utmSource: string | null = null;
   let utmMedium: string | null = null;
   let utmCampaign: string | null = null;
@@ -53,7 +52,7 @@ async function rawPOST(req: Request) {
       utmTerm = typeof utm.utm_term === 'string' ? utm.utm_term.slice(0, 128) : null;
       utmContent = typeof utm.utm_content === 'string' ? utm.utm_content.slice(0, 128) : null;
     } catch {
-      // Malformed cookie — ignore
+      // Malformed cookie - ignore
     }
   }
 
@@ -63,8 +62,7 @@ async function rawPOST(req: Request) {
   const ipHash = payload.clientIp ? await sha256Hex(payload.clientIp) : null;
 
   try {
-    const db = requireDb();
-    await db.insert(pageViews).values({
+    await recordPageView({
       path: path.slice(0, 512),
       userId,
       sessionId: sessionId.slice(0, 32),
@@ -81,7 +79,7 @@ async function rawPOST(req: Request) {
     });
     // --- Analytics: session_started (OCE-254) ---
     // Fire on the first page view of a new session to enable retention cohorts.
-    // serverTrack uses captureImmediate — completes HTTP request before returning.
+    // serverTrack uses captureImmediate - completes HTTP request before returning.
     if (payload.isNewSession) {
       const distinctId = userId ?? `anon_${sessionId}`;
       await serverTrack(distinctId, 'session_started', {
@@ -110,7 +108,7 @@ async function rawPOST(req: Request) {
       }
     }
   } catch (error) {
-    // Best-effort — don't fail the page load
+    // Best-effort - don't fail the page load
     log.error('page view insert failed', { error: error instanceof Error ? error.message : String(error), path, sessionId });
     return errorResponse(API_ERRORS.INTERNAL, 500);
   }

--- a/app/api/reactions/route.ts
+++ b/app/api/reactions/route.ts
@@ -1,8 +1,5 @@
 import { auth } from '@clerk/nextjs/server';
-import { and, eq, sql } from 'drizzle-orm';
 
-import { requireDb } from '@/db';
-import { bouts, reactions, type TranscriptEntry } from '@/db/schema';
 import { errorResponse, parseValidBody, rateLimitResponse } from '@/lib/api-utils';
 import { sha256Hex } from '@/lib/hash';
 import {
@@ -12,6 +9,7 @@ import {
 } from '@/lib/rate-limit';
 import { withLogging } from '@/lib/api-logging';
 import { reactionSchema } from '@/lib/api-schemas';
+import { toggleReaction } from '@/lib/reactions';
 
 export const runtime = 'nodejs';
 
@@ -36,23 +34,6 @@ export const POST = withLogging(async function POST(req: Request) {
 
   const { userId } = await auth();
   const ip = getClientIdentifier(req);
-  const db = requireDb();
-
-  // Verify bout exists and turnIndex is valid
-  const [bout] = await db
-    .select({ id: bouts.id, transcript: bouts.transcript })
-    .from(bouts)
-    .where(eq(bouts.id, boutId))
-    .limit(1);
-
-  if (!bout) {
-    return errorResponse('Bout not found.', 404);
-  }
-
-  const maxTurn = (bout.transcript as TranscriptEntry[])?.length ?? 0;
-  if (turnIndex < 0 || turnIndex >= maxTurn) {
-    return errorResponse('Invalid turn index.', 400);
-  }
 
   /*
    * Anonymous users: store userId as null (FK-safe) and use clientFingerprint
@@ -63,60 +44,22 @@ export const POST = withLogging(async function POST(req: Request) {
   const ipHash = await sha256Hex(ip);
   const fingerprint = userId ?? `anon:${ipHash}`;
 
-  // Toggle: check if reaction exists, then insert or delete
-  const [existing] = await db
-    .select({ id: reactions.id })
-    .from(reactions)
-    .where(
-      and(
-        eq(reactions.boutId, boutId),
-        eq(reactions.turnIndex, turnIndex),
-        eq(reactions.reactionType, reactionType),
-        eq(reactions.clientFingerprint, fingerprint),
-      ),
-    )
-    .limit(1);
+  const result = await toggleReaction({
+    boutId,
+    turnIndex,
+    reactionType,
+    userId: dbUserId,
+    clientFingerprint: fingerprint,
+  });
 
-  let action: 'added' | 'removed';
-
-  if (existing) {
-    // Remove existing reaction (toggle off)
-    await db.delete(reactions).where(eq(reactions.id, existing.id));
-    action = 'removed';
-  } else {
-    // Add new reaction (toggle on)
-    await db
-      .insert(reactions)
-      .values({
-        boutId,
-        turnIndex,
-        reactionType,
-        userId: dbUserId,
-        clientFingerprint: fingerprint,
-      })
-      .onConflictDoNothing();
-    action = 'added';
+  if (!result.ok) {
+    return errorResponse(result.error, result.status);
   }
-
-  // Return absolute counts for this turn so the client can reconcile
-  // without delta arithmetic. This eliminates optimistic update drift.
-  const [counts] = await db
-    .select({
-      heart: sql<number>`cast(count(*) filter (where ${reactions.reactionType} = 'heart') as int)`,
-      fire: sql<number>`cast(count(*) filter (where ${reactions.reactionType} = 'fire') as int)`,
-    })
-    .from(reactions)
-    .where(
-      and(
-        eq(reactions.boutId, boutId),
-        eq(reactions.turnIndex, turnIndex),
-      ),
-    );
 
   return Response.json({
     ok: true,
-    action,
-    counts: counts ?? { heart: 0, fire: 0 },
+    action: result.action,
+    counts: result.counts,
     turnIndex,
   }, {
     headers: { 'X-RateLimit-Remaining': String(rateLimit.remaining) },

--- a/app/api/winner-vote/route.ts
+++ b/app/api/winner-vote/route.ts
@@ -27,7 +27,7 @@ export const POST = withLogging(async function POST(req: Request) {
 
   const result = await castWinnerVote({ boutId, agentId, userId });
 
-  if ('error' in result) {
+  if (!result.ok) {
     return errorResponse(result.error, result.status);
   }
 

--- a/app/api/winner-vote/route.ts
+++ b/app/api/winner-vote/route.ts
@@ -1,12 +1,10 @@
 import { auth } from '@clerk/nextjs/server';
-import { eq } from 'drizzle-orm';
 
-import { requireDb } from '@/db';
-import { bouts, winnerVotes } from '@/db/schema';
 import { errorResponse, parseValidBody, rateLimitResponse, API_ERRORS } from '@/lib/api-utils';
 import { withLogging } from '@/lib/api-logging';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { winnerVoteSchema } from '@/lib/api-schemas';
+import { castWinnerVote } from '@/lib/winner-votes';
 
 export const runtime = 'nodejs';
 
@@ -27,36 +25,11 @@ export const POST = withLogging(async function POST(req: Request) {
     return rateLimitResponse(rateCheck);
   }
 
-  const db = requireDb();
+  const result = await castWinnerVote({ boutId, agentId, userId });
 
-  const [bout] = await db
-    .select({
-      id: bouts.id,
-      transcript: bouts.transcript,
-      agentLineup: bouts.agentLineup,
-    })
-    .from(bouts)
-    .where(eq(bouts.id, boutId))
-    .limit(1);
-
-  if (!bout) {
-    return errorResponse('Bout not found.', 404);
+  if ('error' in result) {
+    return errorResponse(result.error, result.status);
   }
-
-  // Verify the agent actually participated in this bout
-  const inTranscript = Array.isArray(bout.transcript)
-    && bout.transcript.some((t) => t.agentId === agentId);
-  const inLineup = Array.isArray(bout.agentLineup)
-    && bout.agentLineup.some((a) => a.id === agentId);
-
-  if (!inTranscript && !inLineup) {
-    return errorResponse('Agent was not a participant in this bout.', 403);
-  }
-
-  await db
-    .insert(winnerVotes)
-    .values({ boutId, agentId, userId })
-    .onConflictDoNothing();
 
   return Response.json({ ok: true });
 }, 'winner-vote');

--- a/components/arena.tsx
+++ b/components/arena.tsx
@@ -18,7 +18,7 @@ import { useBoutVoting } from '@/lib/use-bout-voting';
 import { useBoutSharing } from '@/lib/use-bout-sharing';
 import { useCopy } from '@/lib/copy-client';
 import { SharePanel } from '@/components/share-panel';
-import type { TranscriptEntry } from '@/db/schema';
+import type { TranscriptEntry } from '@/lib/bout-validation';
 import type { ReactionCountMap } from '@/lib/reactions';
 import type { WinnerVoteCounts } from '@/lib/winner-votes';
 import { PitButton } from '@/components/ui/button';

--- a/components/bout-hero.tsx
+++ b/components/bout-hero.tsx
@@ -1,4 +1,4 @@
-import type { TranscriptEntry } from '@/db/schema';
+import type { TranscriptEntry } from '@/lib/bout-validation';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/lib/feature-requests.ts
+++ b/lib/feature-requests.ts
@@ -88,7 +88,10 @@ export async function createFeatureRequest(
     })
     .returning({ id: featureRequests.id });
 
-  return { id: created!.id };
+  if (!created) {
+    throw new Error('Feature request insert returned no rows.');
+  }
+  return { id: created.id };
 }
 
 /**
@@ -132,6 +135,6 @@ export async function toggleFeatureRequestVote(
 
   return {
     voted: !existing,
-    voteCount: result!.count,
+    voteCount: result?.count ?? 0,
   };
 }

--- a/lib/feature-requests.ts
+++ b/lib/feature-requests.ts
@@ -1,0 +1,137 @@
+// Data access layer for feature requests and votes.
+// Encapsulates all DB queries so route handlers import only from lib/.
+
+import { eq, ne, and, sql, desc } from 'drizzle-orm';
+
+import { requireDb } from '@/db';
+import { featureRequests, featureRequestVotes, users } from '@/db/schema';
+
+/** Shape returned by listFeatureRequests for each row. */
+export type FeatureRequestView = {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  status: string;
+  createdAt: Date;
+  displayName: string;
+  voteCount: number;
+  userVoted: boolean;
+};
+
+/**
+ * List all non-declined feature requests with vote counts and
+ * whether the given user (if any) has voted on each.
+ */
+export async function listFeatureRequests(userId: string | null): Promise<FeatureRequestView[]> {
+  const db = requireDb();
+
+  const voteCount = sql<number>`(
+    select count(*)::int from feature_request_votes
+    where feature_request_votes.feature_request_id = ${featureRequests.id}
+  )`.as('vote_count');
+
+  const rows = await db
+    .select({
+      id: featureRequests.id,
+      title: featureRequests.title,
+      description: featureRequests.description,
+      category: featureRequests.category,
+      status: featureRequests.status,
+      createdAt: featureRequests.createdAt,
+      userId: featureRequests.userId,
+      displayName: users.displayName,
+      voteCount,
+    })
+    .from(featureRequests)
+    .leftJoin(users, eq(featureRequests.userId, users.id))
+    .where(ne(featureRequests.status, 'declined'))
+    .orderBy(desc(voteCount), desc(featureRequests.createdAt));
+
+  let votedIds: Set<number> = new Set();
+  if (userId) {
+    const userVotes = await db
+      .select({ featureRequestId: featureRequestVotes.featureRequestId })
+      .from(featureRequestVotes)
+      .where(eq(featureRequestVotes.userId, userId));
+    votedIds = new Set(userVotes.map((v) => v.featureRequestId));
+  }
+
+  return rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    description: r.description,
+    category: r.category,
+    status: r.status,
+    createdAt: r.createdAt,
+    displayName: r.displayName ?? 'Anonymous',
+    voteCount: r.voteCount,
+    userVoted: votedIds.has(r.id),
+  }));
+}
+
+/**
+ * Insert a new feature request. Returns the auto-generated id.
+ */
+export async function createFeatureRequest(
+  userId: string,
+  data: { title: string; description: string; category: string },
+): Promise<{ id: number }> {
+  const db = requireDb();
+  const [created] = await db
+    .insert(featureRequests)
+    .values({
+      userId,
+      title: data.title,
+      description: data.description,
+      category: data.category,
+    })
+    .returning({ id: featureRequests.id });
+
+  return { id: created!.id };
+}
+
+/**
+ * Toggle a vote on a feature request. Returns the new voted state
+ * and current vote count.
+ */
+export async function toggleFeatureRequestVote(
+  userId: string,
+  featureRequestId: number,
+): Promise<{ voted: boolean; voteCount: number }> {
+  const db = requireDb();
+
+  const [existing] = await db
+    .select({ id: featureRequestVotes.id })
+    .from(featureRequestVotes)
+    .where(
+      and(
+        eq(featureRequestVotes.featureRequestId, featureRequestId),
+        eq(featureRequestVotes.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  if (existing) {
+    await db
+      .delete(featureRequestVotes)
+      .where(eq(featureRequestVotes.id, existing.id));
+  } else {
+    await db
+      .insert(featureRequestVotes)
+      .values({ featureRequestId, userId })
+      .onConflictDoNothing();
+  }
+
+  const [result] = await db
+    .select({
+      count: sql<number>`count(*)::int`,
+    })
+    .from(featureRequestVotes)
+    .where(eq(featureRequestVotes.featureRequestId, featureRequestId));
+
+  return {
+    voted: !existing,
+    voteCount: result!.count,
+  };
+}

--- a/lib/reactions.ts
+++ b/lib/reactions.ts
@@ -4,7 +4,7 @@
 import { and, eq, sql, desc } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
-import { reactions } from '@/db/schema';
+import { bouts, reactions, type TranscriptEntry } from '@/db/schema';
 import { assertNever } from '@/lib/api-utils';
 
 /** Single source of truth for valid reaction types. Derive all other
@@ -91,4 +91,94 @@ export async function getMostReactedTurnIndex(boutId: string) {
     .limit(1);
 
   return top && top.totalCount > 0 ? top : null;
+}
+
+/** Result of a toggle operation returned to the route handler. */
+export type ToggleReactionResult =
+  | { ok: true; action: 'added' | 'removed'; counts: { heart: number; fire: number } }
+  | { ok: false; error: string; status: number };
+
+/**
+ * Toggle a reaction on a bout turn. Validates the bout and turn index,
+ * checks for an existing reaction, and inserts or deletes accordingly.
+ * Returns absolute counts so the client can reconcile without delta arithmetic.
+ */
+export async function toggleReaction(params: {
+  boutId: string;
+  turnIndex: number;
+  reactionType: ReactionType;
+  userId: string | null;
+  clientFingerprint: string;
+}): Promise<ToggleReactionResult> {
+  const { boutId, turnIndex, reactionType, userId, clientFingerprint } = params;
+  const db = requireDb();
+
+  // Verify bout exists and turnIndex is valid
+  const [bout] = await db
+    .select({ id: bouts.id, transcript: bouts.transcript })
+    .from(bouts)
+    .where(eq(bouts.id, boutId))
+    .limit(1);
+
+  if (!bout) {
+    return { ok: false, error: 'Bout not found.', status: 404 };
+  }
+
+  const maxTurn = (bout.transcript as TranscriptEntry[])?.length ?? 0;
+  if (turnIndex < 0 || turnIndex >= maxTurn) {
+    return { ok: false, error: 'Invalid turn index.', status: 400 };
+  }
+
+  // Toggle: check if reaction exists, then insert or delete
+  const [existing] = await db
+    .select({ id: reactions.id })
+    .from(reactions)
+    .where(
+      and(
+        eq(reactions.boutId, boutId),
+        eq(reactions.turnIndex, turnIndex),
+        eq(reactions.reactionType, reactionType),
+        eq(reactions.clientFingerprint, clientFingerprint),
+      ),
+    )
+    .limit(1);
+
+  let action: 'added' | 'removed';
+
+  if (existing) {
+    await db.delete(reactions).where(eq(reactions.id, existing.id));
+    action = 'removed';
+  } else {
+    await db
+      .insert(reactions)
+      .values({
+        boutId,
+        turnIndex,
+        reactionType,
+        userId,
+        clientFingerprint,
+      })
+      .onConflictDoNothing();
+    action = 'added';
+  }
+
+  // Return absolute counts for this turn
+  const [counts] = await db
+    .select({
+      heart: sql<number>`cast(count(*) filter (where ${reactions.reactionType} = 'heart') as int)`,
+      fire: sql<number>`cast(count(*) filter (where ${reactions.reactionType} = 'fire') as int)`,
+    })
+    .from(reactions)
+    .where(
+      and(
+        eq(reactions.boutId, boutId),
+        eq(reactions.turnIndex, turnIndex),
+      ),
+    );
+
+  return {
+    ok: true,
+    action,
+    counts: counts ?? { heart: 0, fire: 0 },
+  };
 }

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -1,0 +1,107 @@
+// Data access layer for simple form submissions and analytics inserts.
+// Groups newsletter signups, contact submissions, paper submissions,
+// and page view recording behind clean function boundaries so route
+// handlers do not import from @/db directly.
+
+import { requireDb } from '@/db';
+import {
+  newsletterSignups,
+  contactSubmissions,
+  paperSubmissions,
+  pageViews,
+} from '@/db/schema';
+
+/**
+ * Record a newsletter signup. Uses onConflictDoNothing to silently
+ * handle duplicate email addresses.
+ */
+export async function subscribeNewsletter(email: string): Promise<void> {
+  const db = requireDb();
+  await db
+    .insert(newsletterSignups)
+    .values({ email })
+    .onConflictDoNothing();
+}
+
+/**
+ * Persist a contact form submission to the database.
+ * Email delivery is handled separately in the route handler.
+ */
+export async function submitContact(data: {
+  name: string;
+  email: string;
+  message: string;
+}): Promise<void> {
+  const db = requireDb();
+  await db.insert(contactSubmissions).values({
+    name: data.name,
+    email: data.email,
+    message: data.message,
+  });
+}
+
+/**
+ * Record a paper submission. Uses onConflictDoNothing to handle
+ * duplicate (userId, arxivId) pairs gracefully.
+ */
+export async function submitPaper(data: {
+  userId: string;
+  arxivId: string;
+  arxivUrl: string;
+  title: string;
+  authors: string;
+  abstract: string | null;
+  justification: string;
+  relevanceArea: string;
+}): Promise<void> {
+  const db = requireDb();
+  await db
+    .insert(paperSubmissions)
+    .values({
+      userId: data.userId,
+      arxivId: data.arxivId,
+      arxivUrl: data.arxivUrl,
+      title: data.title,
+      authors: data.authors,
+      abstract: data.abstract,
+      justification: data.justification,
+      relevanceArea: data.relevanceArea,
+    })
+    .onConflictDoNothing();
+}
+
+/**
+ * Insert a page view record into the analytics table.
+ */
+export async function recordPageView(data: {
+  path: string;
+  userId: string | null;
+  sessionId: string;
+  referrer: string | null;
+  userAgent: string | null;
+  ipHash: string | null;
+  utmSource: string | null;
+  utmMedium: string | null;
+  utmCampaign: string | null;
+  utmTerm: string | null;
+  utmContent: string | null;
+  country: string | null;
+  copyVariant: string | null;
+}): Promise<void> {
+  const db = requireDb();
+  await db.insert(pageViews).values({
+    path: data.path,
+    userId: data.userId,
+    sessionId: data.sessionId,
+    referrer: data.referrer,
+    userAgent: data.userAgent,
+    ipHash: data.ipHash,
+    utmSource: data.utmSource,
+    utmMedium: data.utmMedium,
+    utmCampaign: data.utmCampaign,
+    utmTerm: data.utmTerm,
+    utmContent: data.utmContent,
+    country: data.country,
+    copyVariant: data.copyVariant,
+  });
+}

--- a/lib/winner-votes.ts
+++ b/lib/winner-votes.ts
@@ -49,7 +49,7 @@ export async function castWinnerVote(params: {
   boutId: string;
   agentId: string;
   userId: string;
-}): Promise<{ ok: true } | { error: string; status: number }> {
+}): Promise<{ ok: true } | { ok: false; error: string; status: number }> {
   const { boutId, agentId, userId } = params;
   const db = requireDb();
 
@@ -64,7 +64,7 @@ export async function castWinnerVote(params: {
     .limit(1);
 
   if (!bout) {
-    return { error: 'Bout not found.', status: 404 };
+    return { ok: false, error: 'Bout not found.', status: 404 };
   }
 
   // Verify the agent actually participated in this bout
@@ -74,7 +74,7 @@ export async function castWinnerVote(params: {
     && bout.agentLineup.some((a: { id?: string }) => a.id === agentId);
 
   if (!inTranscript && !inLineup) {
-    return { error: 'Agent was not a participant in this bout.', status: 403 };
+    return { ok: false, error: 'Agent was not a participant in this bout.', status: 403 };
   }
 
   await db

--- a/lib/winner-votes.ts
+++ b/lib/winner-votes.ts
@@ -5,7 +5,7 @@
 import { and, eq, sql } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
-import { winnerVotes } from '@/db/schema';
+import { bouts, winnerVotes } from '@/db/schema';
 
 export type WinnerVoteCounts = Record<string, number>;
 
@@ -39,4 +39,48 @@ export async function getUserWinnerVote(boutId: string, userId: string) {
     .limit(1);
 
   return existing?.agentId ?? null;
+}
+
+/**
+ * Cast a winner vote after validating the bout exists and the agent
+ * participated. Uses onConflictDoNothing for idempotent duplicate handling.
+ */
+export async function castWinnerVote(params: {
+  boutId: string;
+  agentId: string;
+  userId: string;
+}): Promise<{ ok: true } | { error: string; status: number }> {
+  const { boutId, agentId, userId } = params;
+  const db = requireDb();
+
+  const [bout] = await db
+    .select({
+      id: bouts.id,
+      transcript: bouts.transcript,
+      agentLineup: bouts.agentLineup,
+    })
+    .from(bouts)
+    .where(eq(bouts.id, boutId))
+    .limit(1);
+
+  if (!bout) {
+    return { error: 'Bout not found.', status: 404 };
+  }
+
+  // Verify the agent actually participated in this bout
+  const inTranscript = Array.isArray(bout.transcript)
+    && bout.transcript.some((t: { agentId?: string }) => t.agentId === agentId);
+  const inLineup = Array.isArray(bout.agentLineup)
+    && bout.agentLineup.some((a: { id?: string }) => a.id === agentId);
+
+  if (!inTranscript && !inLineup) {
+    return { error: 'Agent was not a participant in this bout.', status: 403 };
+  }
+
+  await db
+    .insert(winnerVotes)
+    .values({ boutId, agentId, userId })
+    .onConflictDoNothing();
+
+  return { ok: true };
 }

--- a/tests/unit/feature-requests-dal.test.ts
+++ b/tests/unit/feature-requests-dal.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => {
+  const db = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+  };
+  return { mockDb: db };
+});
+
+vi.mock('@/db', () => ({
+  requireDb: () => mockDb,
+}));
+
+vi.mock('@/db/schema', () => ({
+  featureRequests: {
+    id: Symbol('featureRequests.id'),
+    userId: Symbol('userId'),
+    title: Symbol('title'),
+    description: Symbol('description'),
+    category: Symbol('category'),
+    status: Symbol('status'),
+    createdAt: Symbol('createdAt'),
+  },
+  featureRequestVotes: {
+    id: Symbol('featureRequestVotes.id'),
+    featureRequestId: Symbol('featureRequestId'),
+    userId: Symbol('userId'),
+  },
+  users: {
+    id: Symbol('users.id'),
+    displayName: Symbol('displayName'),
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(),
+  ne: vi.fn(),
+  and: vi.fn(),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values, as: () => 'vote_count' }),
+    { raw: (s: string) => s },
+  ),
+  desc: vi.fn(),
+}));
+
+describe('lib/feature-requests', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockDb.select.mockReset();
+    mockDb.insert.mockReset();
+    mockDb.delete.mockReset();
+  });
+
+  describe('listFeatureRequests', () => {
+    it('returns formatted requests with vote status', async () => {
+      // First select: feature requests with joins
+      const mockOrderBy = vi.fn().mockResolvedValue([
+        {
+          id: 1,
+          title: 'Feature A',
+          description: 'Desc A',
+          category: 'ui',
+          status: 'pending',
+          createdAt: new Date('2026-01-01'),
+          userId: 'user_1',
+          displayName: 'Alice',
+          voteCount: 3,
+        },
+      ]);
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+      mockDb.select.mockReturnValueOnce({ from: mockFrom });
+
+      // Second select: user votes (authenticated)
+      const mockVoteWhere = vi.fn().mockResolvedValue([{ featureRequestId: 1 }]);
+      const mockVoteFrom = vi.fn().mockReturnValue({ where: mockVoteWhere });
+      mockDb.select.mockReturnValueOnce({ from: mockVoteFrom });
+
+      const { listFeatureRequests } = await import('@/lib/feature-requests');
+      const result = await listFeatureRequests('user_1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        id: 1,
+        title: 'Feature A',
+        description: 'Desc A',
+        category: 'ui',
+        status: 'pending',
+        createdAt: new Date('2026-01-01'),
+        displayName: 'Alice',
+        voteCount: 3,
+        userVoted: true,
+      });
+    });
+
+    it('returns Anonymous when displayName is null', async () => {
+      const mockOrderBy = vi.fn().mockResolvedValue([
+        {
+          id: 2,
+          title: 'Feature B',
+          description: 'Desc B',
+          category: 'agents',
+          status: 'pending',
+          createdAt: new Date('2026-01-02'),
+          userId: 'user_2',
+          displayName: null,
+          voteCount: 0,
+        },
+      ]);
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+      const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+      mockDb.select.mockReturnValueOnce({ from: mockFrom });
+
+      const { listFeatureRequests } = await import('@/lib/feature-requests');
+      const result = await listFeatureRequests(null);
+
+      expect(result[0]!.displayName).toBe('Anonymous');
+      expect(result[0]!.userVoted).toBe(false);
+    });
+  });
+
+  describe('createFeatureRequest', () => {
+    it('inserts and returns the generated id', async () => {
+      const mockReturning = vi.fn().mockResolvedValue([{ id: 42 }]);
+      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      mockDb.insert.mockReturnValue({ values: mockValues });
+
+      const { createFeatureRequest } = await import('@/lib/feature-requests');
+      const result = await createFeatureRequest('user_1', {
+        title: 'New Feature',
+        description: 'A long description',
+        category: 'ui',
+      });
+
+      expect(result).toEqual({ id: 42 });
+      expect(mockValues).toHaveBeenCalledWith({
+        userId: 'user_1',
+        title: 'New Feature',
+        description: 'A long description',
+        category: 'ui',
+      });
+    });
+  });
+
+  describe('toggleFeatureRequestVote', () => {
+    it('inserts vote when none exists and returns count', async () => {
+      // Existence check: no existing vote
+      const existLimit = vi.fn().mockResolvedValue([]);
+      const existWhere = vi.fn().mockReturnValue({ limit: existLimit });
+      const existFrom = vi.fn().mockReturnValue({ where: existWhere });
+      mockDb.select.mockReturnValueOnce({ from: existFrom });
+
+      // Insert
+      const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+      const mockInsertValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflict });
+      mockDb.insert.mockReturnValue({ values: mockInsertValues });
+
+      // Count
+      const countWhere = vi.fn().mockResolvedValue([{ count: 1 }]);
+      const countFrom = vi.fn().mockReturnValue({ where: countWhere });
+      mockDb.select.mockReturnValueOnce({ from: countFrom });
+
+      const { toggleFeatureRequestVote } = await import('@/lib/feature-requests');
+      const result = await toggleFeatureRequestVote('user_1', 1);
+
+      expect(result).toEqual({ voted: true, voteCount: 1 });
+    });
+
+    it('deletes vote when one exists and returns count', async () => {
+      // Existence check: found
+      const existLimit = vi.fn().mockResolvedValue([{ id: 99 }]);
+      const existWhere = vi.fn().mockReturnValue({ limit: existLimit });
+      const existFrom = vi.fn().mockReturnValue({ where: existWhere });
+      mockDb.select.mockReturnValueOnce({ from: existFrom });
+
+      // Delete
+      const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+      mockDb.delete.mockReturnValue({ where: mockDeleteWhere });
+
+      // Count
+      const countWhere = vi.fn().mockResolvedValue([{ count: 0 }]);
+      const countFrom = vi.fn().mockReturnValue({ where: countWhere });
+      mockDb.select.mockReturnValueOnce({ from: countFrom });
+
+      const { toggleFeatureRequestVote } = await import('@/lib/feature-requests');
+      const result = await toggleFeatureRequestVote('user_1', 1);
+
+      expect(result).toEqual({ voted: false, voteCount: 0 });
+    });
+  });
+});

--- a/tests/unit/reactions-toggle.test.ts
+++ b/tests/unit/reactions-toggle.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => {
+  const db = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+  };
+  return { mockDb: db };
+});
+
+vi.mock('@/db', () => ({
+  requireDb: () => mockDb,
+}));
+
+vi.mock('@/db/schema', () => ({
+  bouts: { id: 'bouts.id', transcript: 'bouts.transcript' },
+  reactions: {
+    id: 'reactions.id',
+    boutId: 'reactions.boutId',
+    turnIndex: 'reactions.turnIndex',
+    reactionType: 'reactions.reactionType',
+    clientFingerprint: 'reactions.clientFingerprint',
+    userId: 'reactions.userId',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((a: unknown, b: unknown) => [a, b]),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+    { raw: (s: string) => s },
+  ),
+  desc: vi.fn(),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  assertNever: (value: never, message: string) => { throw new Error(message); },
+}));
+
+describe('toggleReaction', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockDb.select.mockReset();
+    mockDb.insert.mockReset();
+    mockDb.delete.mockReset();
+  });
+
+  it('returns error when bout not found', async () => {
+    // Bout lookup returns empty
+    const boutLimit = vi.fn().mockResolvedValue([]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+    mockDb.select.mockReturnValueOnce({ from: boutFrom });
+
+    const { toggleReaction } = await import('@/lib/reactions');
+    const result = await toggleReaction({
+      boutId: 'ghost-bout',
+      turnIndex: 0,
+      reactionType: 'heart',
+      userId: null,
+      clientFingerprint: 'anon:hash',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'Bout not found.', status: 404 });
+  });
+
+  it('returns error when turn index is out of range', async () => {
+    const boutLimit = vi.fn().mockResolvedValue([{
+      id: 'bout-1',
+      transcript: [{ turn: 0, agentId: 'a1', text: 'hi' }],
+    }]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+    mockDb.select.mockReturnValueOnce({ from: boutFrom });
+
+    const { toggleReaction } = await import('@/lib/reactions');
+    const result = await toggleReaction({
+      boutId: 'bout-1',
+      turnIndex: 5,
+      reactionType: 'heart',
+      userId: null,
+      clientFingerprint: 'anon:hash',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'Invalid turn index.', status: 400 });
+  });
+
+  it('inserts new reaction when none exists (added)', async () => {
+    // Call 1: bout lookup
+    const boutLimit = vi.fn().mockResolvedValue([{
+      id: 'bout-1',
+      transcript: [{ turn: 0, agentId: 'a1', text: 'hi' }, { turn: 1, agentId: 'a2', text: 'yo' }],
+    }]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+
+    // Call 2: reaction existence check - empty
+    const existLimit = vi.fn().mockResolvedValue([]);
+    const existWhere = vi.fn().mockReturnValue({ limit: existLimit });
+    const existFrom = vi.fn().mockReturnValue({ where: existWhere });
+
+    // Call 3: counts query
+    const countsWhere = vi.fn().mockResolvedValue([{ heart: 1, fire: 0 }]);
+    const countsFrom = vi.fn().mockReturnValue({ where: countsWhere });
+
+    mockDb.select
+      .mockReturnValueOnce({ from: boutFrom })
+      .mockReturnValueOnce({ from: existFrom })
+      .mockReturnValueOnce({ from: countsFrom });
+
+    // Insert chain
+    const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+    const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflict });
+    mockDb.insert.mockReturnValue({ values: mockValues });
+
+    const { toggleReaction } = await import('@/lib/reactions');
+    const result = await toggleReaction({
+      boutId: 'bout-1',
+      turnIndex: 0,
+      reactionType: 'heart',
+      userId: 'user_abc',
+      clientFingerprint: 'user_abc',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      action: 'added',
+      counts: { heart: 1, fire: 0 },
+    });
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith({
+      boutId: 'bout-1',
+      turnIndex: 0,
+      reactionType: 'heart',
+      userId: 'user_abc',
+      clientFingerprint: 'user_abc',
+    });
+  });
+
+  it('deletes existing reaction (removed)', async () => {
+    // Call 1: bout lookup
+    const boutLimit = vi.fn().mockResolvedValue([{
+      id: 'bout-1',
+      transcript: [{ turn: 0, agentId: 'a1', text: 'hi' }],
+    }]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+
+    // Call 2: reaction existence check - found
+    const existLimit = vi.fn().mockResolvedValue([{ id: 42 }]);
+    const existWhere = vi.fn().mockReturnValue({ limit: existLimit });
+    const existFrom = vi.fn().mockReturnValue({ where: existWhere });
+
+    // Call 3: counts query
+    const countsWhere = vi.fn().mockResolvedValue([{ heart: 0, fire: 0 }]);
+    const countsFrom = vi.fn().mockReturnValue({ where: countsWhere });
+
+    mockDb.select
+      .mockReturnValueOnce({ from: boutFrom })
+      .mockReturnValueOnce({ from: existFrom })
+      .mockReturnValueOnce({ from: countsFrom });
+
+    // Delete chain
+    const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+    mockDb.delete.mockReturnValue({ where: mockDeleteWhere });
+
+    const { toggleReaction } = await import('@/lib/reactions');
+    const result = await toggleReaction({
+      boutId: 'bout-1',
+      turnIndex: 0,
+      reactionType: 'heart',
+      userId: null,
+      clientFingerprint: 'anon:hash',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      action: 'removed',
+      counts: { heart: 0, fire: 0 },
+    });
+    expect(mockDb.delete).toHaveBeenCalled();
+  });
+
+  it('returns correct counts after toggle', async () => {
+    // Bout exists with 2 turns
+    const boutLimit = vi.fn().mockResolvedValue([{
+      id: 'bout-1',
+      transcript: [{ turn: 0, agentId: 'a1', text: 'hi' }, { turn: 1, agentId: 'a2', text: 'yo' }],
+    }]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+
+    // No existing reaction
+    const existLimit = vi.fn().mockResolvedValue([]);
+    const existWhere = vi.fn().mockReturnValue({ limit: existLimit });
+    const existFrom = vi.fn().mockReturnValue({ where: existWhere });
+
+    // Counts: 3 hearts, 2 fires
+    const countsWhere = vi.fn().mockResolvedValue([{ heart: 3, fire: 2 }]);
+    const countsFrom = vi.fn().mockReturnValue({ where: countsWhere });
+
+    mockDb.select
+      .mockReturnValueOnce({ from: boutFrom })
+      .mockReturnValueOnce({ from: existFrom })
+      .mockReturnValueOnce({ from: countsFrom });
+
+    const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+    const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflict });
+    mockDb.insert.mockReturnValue({ values: mockValues });
+
+    const { toggleReaction } = await import('@/lib/reactions');
+    const result = await toggleReaction({
+      boutId: 'bout-1',
+      turnIndex: 1,
+      reactionType: 'fire',
+      userId: null,
+      clientFingerprint: 'anon:hash',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      action: 'added',
+      counts: { heart: 3, fire: 2 },
+    });
+  });
+});

--- a/tests/unit/submissions-dal.test.ts
+++ b/tests/unit/submissions-dal.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => {
+  const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+  const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflict });
+  const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
+  return {
+    mockDb: {
+      insert: mockInsert,
+      _values: mockValues,
+      _onConflict: mockOnConflict,
+    },
+  };
+});
+
+vi.mock('@/db', () => ({
+  requireDb: () => mockDb,
+}));
+
+vi.mock('@/db/schema', () => ({
+  newsletterSignups: Symbol('newsletterSignups'),
+  contactSubmissions: Symbol('contactSubmissions'),
+  paperSubmissions: Symbol('paperSubmissions'),
+  pageViews: Symbol('pageViews'),
+}));
+
+describe('lib/submissions', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockDb.insert.mockReset();
+    mockDb._values.mockReset();
+    mockDb._onConflict.mockReset();
+
+    // Re-establish chain
+    mockDb._onConflict.mockResolvedValue(undefined);
+    mockDb._values.mockReturnValue({ onConflictDoNothing: mockDb._onConflict });
+    mockDb.insert.mockReturnValue({ values: mockDb._values });
+  });
+
+  describe('subscribeNewsletter', () => {
+    it('inserts email with onConflictDoNothing', async () => {
+      const { subscribeNewsletter } = await import('@/lib/submissions');
+      await subscribeNewsletter('test@example.com');
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockDb._values).toHaveBeenCalledWith({ email: 'test@example.com' });
+      expect(mockDb._onConflict).toHaveBeenCalled();
+    });
+  });
+
+  describe('submitContact', () => {
+    it('inserts contact data', async () => {
+      // submitContact does not use onConflictDoNothing - plain insert
+      const mockPlainValues = vi.fn().mockResolvedValue(undefined);
+      mockDb.insert.mockReturnValue({ values: mockPlainValues });
+
+      const { submitContact } = await import('@/lib/submissions');
+      await submitContact({ name: 'Alice', email: 'a@b.com', message: 'Hello!' });
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockPlainValues).toHaveBeenCalledWith({
+        name: 'Alice',
+        email: 'a@b.com',
+        message: 'Hello!',
+      });
+    });
+  });
+
+  describe('submitPaper', () => {
+    it('inserts paper data with onConflictDoNothing', async () => {
+      const { submitPaper } = await import('@/lib/submissions');
+      await submitPaper({
+        userId: 'user_1',
+        arxivId: '2305.14325',
+        arxivUrl: 'https://arxiv.org/abs/2305.14325',
+        title: 'Test Paper',
+        authors: 'Author A',
+        abstract: 'Abstract text',
+        justification: 'Relevant because...',
+        relevanceArea: 'agent-interaction',
+      });
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockDb._values).toHaveBeenCalledWith({
+        userId: 'user_1',
+        arxivId: '2305.14325',
+        arxivUrl: 'https://arxiv.org/abs/2305.14325',
+        title: 'Test Paper',
+        authors: 'Author A',
+        abstract: 'Abstract text',
+        justification: 'Relevant because...',
+        relevanceArea: 'agent-interaction',
+      });
+      expect(mockDb._onConflict).toHaveBeenCalled();
+    });
+  });
+
+  describe('recordPageView', () => {
+    it('inserts page view data', async () => {
+      // recordPageView does not use onConflictDoNothing - plain insert
+      const mockPlainValues = vi.fn().mockResolvedValue(undefined);
+      mockDb.insert.mockReturnValue({ values: mockPlainValues });
+
+      const { recordPageView } = await import('@/lib/submissions');
+      await recordPageView({
+        path: '/bout/abc',
+        userId: 'user_1',
+        sessionId: 'sess123',
+        referrer: null,
+        userAgent: 'test-agent',
+        ipHash: 'hash123',
+        utmSource: null,
+        utmMedium: null,
+        utmCampaign: null,
+        utmTerm: null,
+        utmContent: null,
+        country: 'GB',
+        copyVariant: null,
+      });
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockPlainValues).toHaveBeenCalledWith({
+        path: '/bout/abc',
+        userId: 'user_1',
+        sessionId: 'sess123',
+        referrer: null,
+        userAgent: 'test-agent',
+        ipHash: 'hash123',
+        utmSource: null,
+        utmMedium: null,
+        utmCampaign: null,
+        utmTerm: null,
+        utmContent: null,
+        country: 'GB',
+        copyVariant: null,
+      });
+    });
+  });
+});

--- a/tests/unit/winner-votes-cast.test.ts
+++ b/tests/unit/winner-votes-cast.test.ts
@@ -51,7 +51,7 @@ describe('castWinnerVote', () => {
       userId: 'user_1',
     });
 
-    expect(result).toEqual({ error: 'Bout not found.', status: 404 });
+    expect(result).toEqual({ ok: false, error: 'Bout not found.', status: 404 });
   });
 
   it('returns error when agent did not participate', async () => {
@@ -73,7 +73,7 @@ describe('castWinnerVote', () => {
       userId: 'user_1',
     });
 
-    expect(result).toEqual({ error: 'Agent was not a participant in this bout.', status: 403 });
+    expect(result).toEqual({ ok: false, error: 'Agent was not a participant in this bout.', status: 403 });
   });
 
   it('succeeds when agent is in transcript', async () => {

--- a/tests/unit/winner-votes-cast.test.ts
+++ b/tests/unit/winner-votes-cast.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb } = vi.hoisted(() => {
+  const db = {
+    select: vi.fn(),
+    insert: vi.fn(),
+  };
+  return { mockDb: db };
+});
+
+vi.mock('@/db', () => ({
+  requireDb: () => mockDb,
+}));
+
+vi.mock('@/db/schema', () => ({
+  bouts: {
+    id: 'bouts.id',
+    transcript: 'bouts.transcript',
+    agentLineup: 'bouts.agentLineup',
+  },
+  winnerVotes: {
+    boutId: 'winnerVotes.boutId',
+    agentId: 'winnerVotes.agentId',
+    userId: 'winnerVotes.userId',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((a: unknown, b: unknown) => [a, b]),
+  sql: vi.fn(),
+}));
+
+describe('castWinnerVote', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockDb.select.mockReset();
+    mockDb.insert.mockReset();
+  });
+
+  it('returns error when bout not found', async () => {
+    const boutLimit = vi.fn().mockResolvedValue([]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+    mockDb.select.mockReturnValue({ from: boutFrom });
+
+    const { castWinnerVote } = await import('@/lib/winner-votes');
+    const result = await castWinnerVote({
+      boutId: 'ghost-bout',
+      agentId: 'agent-a',
+      userId: 'user_1',
+    });
+
+    expect(result).toEqual({ error: 'Bout not found.', status: 404 });
+  });
+
+  it('returns error when agent did not participate', async () => {
+    const boutLimit = vi.fn().mockResolvedValue([{
+      id: 'bout-1',
+      transcript: [
+        { turn: 0, agentId: 'agent-a', agentName: 'Alpha', text: 'Hello' },
+      ],
+      agentLineup: null,
+    }]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+    mockDb.select.mockReturnValue({ from: boutFrom });
+
+    const { castWinnerVote } = await import('@/lib/winner-votes');
+    const result = await castWinnerVote({
+      boutId: 'bout-1',
+      agentId: 'agent-x',
+      userId: 'user_1',
+    });
+
+    expect(result).toEqual({ error: 'Agent was not a participant in this bout.', status: 403 });
+  });
+
+  it('succeeds when agent is in transcript', async () => {
+    const boutLimit = vi.fn().mockResolvedValue([{
+      id: 'bout-1',
+      transcript: [
+        { turn: 0, agentId: 'agent-a', agentName: 'Alpha', text: 'Hello' },
+        { turn: 1, agentId: 'agent-b', agentName: 'Bravo', text: 'World' },
+      ],
+      agentLineup: null,
+    }]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+    mockDb.select.mockReturnValue({ from: boutFrom });
+
+    const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+    const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflict });
+    mockDb.insert.mockReturnValue({ values: mockValues });
+
+    const { castWinnerVote } = await import('@/lib/winner-votes');
+    const result = await castWinnerVote({
+      boutId: 'bout-1',
+      agentId: 'agent-a',
+      userId: 'user_1',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockValues).toHaveBeenCalledWith({
+      boutId: 'bout-1',
+      agentId: 'agent-a',
+      userId: 'user_1',
+    });
+    expect(mockOnConflict).toHaveBeenCalled();
+  });
+
+  it('succeeds when agent is in lineup but not transcript', async () => {
+    const boutLimit = vi.fn().mockResolvedValue([{
+      id: 'bout-1',
+      transcript: [],
+      agentLineup: [
+        { id: 'arena-1', name: 'Gladiator', systemPrompt: 'Fight!' },
+      ],
+    }]);
+    const boutWhere = vi.fn().mockReturnValue({ limit: boutLimit });
+    const boutFrom = vi.fn().mockReturnValue({ where: boutWhere });
+    mockDb.select.mockReturnValue({ from: boutFrom });
+
+    const mockOnConflict = vi.fn().mockResolvedValue(undefined);
+    const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflict });
+    mockDb.insert.mockReturnValue({ values: mockValues });
+
+    const { castWinnerVote } = await import('@/lib/winner-votes');
+    const result = await castWinnerVote({
+      boutId: 'bout-1',
+      agentId: 'arena-1',
+      userId: 'user_1',
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary

Completes the DAL boundary establishment by extracting all direct `@/db` and `@/db/schema` imports from 8 route handler files and 2 component files into corresponding lib/ modules. Also fixes RD-016 (component type imports from db/schema).

## What changed

**Route handlers cleaned (zero @/db imports):**
- `app/api/reactions/route.ts` - toggle logic extracted to `toggleReaction()` in lib/reactions.ts
- `app/api/winner-vote/route.ts` - vote logic extracted to `castWinnerVote()` in lib/winner-votes.ts
- `app/api/feature-requests/route.ts` - list + create extracted to lib/feature-requests.ts
- `app/api/feature-requests/vote/route.ts` - vote toggle extracted to lib/feature-requests.ts
- `app/api/newsletter/route.ts` - insert extracted to lib/submissions.ts
- `app/api/contact/route.ts` - insert extracted to lib/submissions.ts
- `app/api/paper-submissions/route.ts` - insert extracted to lib/submissions.ts
- `app/api/pv/route.ts` - page view insert extracted to lib/submissions.ts

**Components fixed (RD-016):**
- `components/arena.tsx` - imports TranscriptEntry from lib/bout-validation instead of db/schema
- `components/bout-hero.tsx` - same

**Lib files created/extended:**
- `lib/reactions.ts` - added `toggleReaction()` with bout validation and absolute count return
- `lib/winner-votes.ts` - added `castWinnerVote()` with participant validation
- `lib/feature-requests.ts` (new) - `listFeatureRequests`, `createFeatureRequest`, `toggleFeatureRequestVote`
- `lib/submissions.ts` (new) - `subscribeNewsletter`, `submitContact`, `submitPaper`, `recordPageView`

## Technical decisions

- **Consistent error result types**: All DAL functions use `{ ok: true } | { ok: false; error; status }` discriminated union (darkcat finding, fixed)
- **Non-null assertions replaced**: `created!.id` patterns replaced with explicit guards (darkcat finding, fixed)
- **TOCTOU in toggles**: Pre-existing race condition in select-then-insert/delete toggle patterns. Not a regression. Noted for future atomic CTE approach.
- **Health endpoint excluded**: `app/api/health/route.ts` does `db.execute(sql\`SELECT 1\`)` - infrastructure ping, not a domain query.

## What was tested

- 18 new tests across 4 files (reactions-toggle, winner-votes-cast, feature-requests-dal, submissions-dal)
- All 1466 existing tests pass
- Gate: typecheck + lint + test:unit + test:integration = green

## Reviewed by

- DC-1 (Claude): PASS WITH FINDINGS - non-null assertions (fixed), inconsistent return types (fixed), TOCTOU (pre-existing, noted)

Tests: 1466/1466 passed
Gate: typecheck + lint + test = green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted engagement and community DB queries from `app/` into `lib/` to complete the DAL boundary (RD-015b). Fixed component type imports to stop using `@/db/schema` (RD-016).

- **Refactors**
  - Extracted DB queries from 8 routes into `lib/` modules; added `reactions.toggleReaction`, `winner-votes.castWinnerVote`, `feature-requests` (list/create/toggle vote), and `submissions` (newsletter/contact/paper/page view).
  - Routes now import from `lib/*`; no `@/db` or `@/db/schema` imports remain in handlers.
  - Standardized DAL result types and removed non-null assertions; no API behavior changes.

- **Bug Fixes**
  - Components import `TranscriptEntry` from `lib/bout-validation` instead of `@/db/schema` (RD-016).

<sup>Written for commit dbb46c0516deaab3c343c4b83116aa6f8bd3c297. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized data submission and processing flows for improved consistency and reliability across contact forms, newsletter signups, paper submissions, and feature requests.
  * Consolidated reaction and voting mechanisms for enhanced stability.

* **Tests**
  * Added comprehensive unit test coverage for feature requests, reactions, submissions, and winner voting systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->