### PR TITLE
feat(cache): distributed cache with Upstash Redis + in-memory fallback (RD-018, RD-019)

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,135 @@
+// Distributed cache abstraction with graceful in-memory fallback.
+//
+// Uses Upstash Redis when UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN
+// are set. Falls back to an in-memory Map when env vars are missing (local dev,
+// tests) or when Redis is unreachable at runtime.
+//
+// Reads process.env directly to avoid circular dependency with lib/env.ts.
+// The env.ts schema includes these vars for startup-time validation, but the
+// cache module initializes lazily on first access.
+
+import { Redis } from '@upstash/redis';
+
+let redis: Redis | null = null;
+let redisWarningLogged = false;
+
+function getRedis(): Redis | null {
+  if (redis) return redis;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (url && token) {
+    redis = new Redis({ url, token });
+  }
+  return redis;
+}
+
+// In-memory fallback for dev/test or Redis failure.
+const localCache = new Map<string, { value: string; expiresAt: number }>();
+
+function logRedisWarning(err: unknown) {
+  if (!redisWarningLogged) {
+    redisWarningLogged = true;
+    console.warn('[cache] Redis unavailable, falling back to in-memory:', err);
+  }
+}
+
+function localGet(key: string): string | null {
+  const entry = localCache.get(key);
+  if (!entry) return null;
+  if (Date.now() >= entry.expiresAt) {
+    localCache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+/**
+ * Retrieve a cached value by key. Returns null on cache miss or error.
+ * Deserializes JSON automatically.
+ */
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  const client = getRedis();
+  if (client) {
+    try {
+      const raw = await client.get<string>(key);
+      if (raw === null || raw === undefined) return null;
+      // Upstash auto-deserializes JSON, so raw may already be an object
+      if (typeof raw === 'string') {
+        return JSON.parse(raw) as T;
+      }
+      return raw as T;
+    } catch (err) {
+      logRedisWarning(err);
+    }
+  }
+  const raw = localGet(key);
+  if (raw === null) return null;
+  return JSON.parse(raw) as T;
+}
+
+/**
+ * Store a value in cache with a TTL in seconds.
+ * Serializes to JSON automatically.
+ */
+export async function cacheSet<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+  const json = JSON.stringify(value);
+  const client = getRedis();
+  if (client) {
+    try {
+      await client.set(key, json, { ex: ttlSeconds });
+      return;
+    } catch (err) {
+      logRedisWarning(err);
+    }
+  }
+  localCache.set(key, {
+    value: json,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  });
+}
+
+/**
+ * Delete a cached entry by key.
+ */
+export async function cacheDel(key: string): Promise<void> {
+  const client = getRedis();
+  if (client) {
+    try {
+      await client.del(key);
+      return;
+    } catch (err) {
+      logRedisWarning(err);
+    }
+  }
+  localCache.delete(key);
+}
+
+/**
+ * Check whether a key exists in the cache and has not expired.
+ */
+export async function cacheExists(key: string): Promise<boolean> {
+  const client = getRedis();
+  if (client) {
+    try {
+      const result = await client.exists(key);
+      return result === 1;
+    } catch (err) {
+      logRedisWarning(err);
+    }
+  }
+  const entry = localCache.get(key);
+  if (!entry) return false;
+  if (Date.now() >= entry.expiresAt) {
+    localCache.delete(key);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Clear the in-memory fallback cache. Useful in tests.
+ * Does not affect Redis.
+ */
+export function clearLocalCache(): void {
+  localCache.clear();
+}

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -45,19 +45,19 @@ function localGet(key: string): string | null {
 
 /**
  * Retrieve a cached value by key. Returns null on cache miss or error.
- * Deserializes JSON automatically.
+ *
+ * Redis path: Upstash auto-deserializes JSON, so we use get<T> directly.
+ * Local path: values are stored as JSON strings and parsed on retrieval.
  */
 export async function cacheGet<T>(key: string): Promise<T | null> {
   const client = getRedis();
   if (client) {
     try {
-      const raw = await client.get<string>(key);
-      if (raw === null || raw === undefined) return null;
-      // Upstash auto-deserializes JSON, so raw may already be an object
-      if (typeof raw === 'string') {
-        return JSON.parse(raw) as T;
-      }
-      return raw as T;
+      // Upstash auto-deserializes JSON stored via set(). Using get<T>()
+      // lets Upstash return the deserialized value directly, avoiding
+      // double-parse bugs with string values.
+      const result = await client.get<T>(key);
+      return result ?? null;
     } catch (err) {
       logRedisWarning(err);
     }
@@ -69,21 +69,25 @@ export async function cacheGet<T>(key: string): Promise<T | null> {
 
 /**
  * Store a value in cache with a TTL in seconds.
- * Serializes to JSON automatically.
+ *
+ * Redis path: Upstash handles serialization natively.
+ * Local path: values are JSON-stringified for storage.
  */
 export async function cacheSet<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
-  const json = JSON.stringify(value);
   const client = getRedis();
   if (client) {
     try {
-      await client.set(key, json, { ex: ttlSeconds });
+      // Let Upstash handle serialization. Passing the value directly
+      // avoids double-serialization (JSON.stringify then Upstash's
+      // internal serialize) which causes parse failures for string values.
+      await client.set(key, value, { ex: ttlSeconds });
       return;
     } catch (err) {
       logRedisWarning(err);
     }
   }
   localCache.set(key, {
-    value: json,
+    value: JSON.stringify(value),
     expiresAt: Date.now() + ttlSeconds * 1000,
   });
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -163,6 +163,13 @@ const serverEnvSchema = z.object({
 
   // --- Analytics ---
   PV_INTERNAL_SECRET: z.string().optional(),
+
+  // --- Distributed cache (Upstash Redis) ---
+  // Optional: when missing, lib/cache.ts falls back to in-memory Map.
+  // Read directly by lib/cache.ts via process.env (not via env.*) to
+  // avoid circular dependency. Validated here for startup-time schema check.
+  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+  UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
 });
 
 export type ServerEnv = z.infer<typeof serverEnvSchema>;

--- a/lib/leaderboard.ts
+++ b/lib/leaderboard.ts
@@ -9,6 +9,7 @@ import { and, eq, gte } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
 import { agents, bouts, referrals, users, winnerVotes } from '@/db/schema';
+import { cacheGet, cacheSet } from '@/lib/cache';
 import { ALL_PRESETS, ARENA_PRESET_ID } from '@/lib/presets';
 import {
   buildPresetAgentId,
@@ -79,16 +80,12 @@ const getRangeStart = (range: LeaderboardRange) => {
   return new Date(Date.now() - RANGE_MS[range]);
 };
 
-// In-memory cache to avoid repeated full-table scans. The leaderboard is
-// read-heavy and tolerant of 5-minute staleness. At scale this should be
-// replaced with SQL aggregation queries and/or a dedicated cache layer.
-let leaderboardCache: { data: LeaderboardData; timestamp: number } | null = null;
-const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_KEY = 'leaderboard:data';
+const CACHE_TTL_SECONDS = 5 * 60; // 5 minutes
 
 export async function getLeaderboardData(): Promise<LeaderboardData> {
-  if (leaderboardCache && Date.now() - leaderboardCache.timestamp < CACHE_TTL_MS) {
-    return leaderboardCache.data;
-  }
+  const cached = await cacheGet<LeaderboardData>(CACHE_KEY);
+  if (cached) return cached;
 
   const db = requireDb();
   const snapshots = await getAgentSnapshots();
@@ -322,6 +319,6 @@ export async function getLeaderboardData(): Promise<LeaderboardData> {
     result[range] = { pit: pitEntries, players: playerEntries };
   }
 
-  leaderboardCache = { data: result, timestamp: Date.now() };
+  await cacheSet(CACHE_KEY, result, CACHE_TTL_SECONDS);
   return result;
 }

--- a/lib/onboarding.ts
+++ b/lib/onboarding.ts
@@ -61,7 +61,7 @@ export async function initializeUserSession(params: {
 }) {
   const cacheKey = `onboarding:init:${params.userId}`;
   const cached = await cacheGet<number>(cacheKey);
-  if (cached) return;
+  if (cached !== null) return;
 
   // Check DB for existing user BEFORE ensureUserRecord creates one.
   // This provides a durable new-user signal that survives deploys/restarts,

--- a/lib/onboarding.ts
+++ b/lib/onboarding.ts
@@ -7,6 +7,7 @@ import { eq, and } from 'drizzle-orm';
 
 import { requireDb } from '@/db';
 import { creditTransactions } from '@/db/schema';
+import { cacheGet, cacheSet } from '@/lib/cache';
 import { CREDITS_ENABLED, ensureCreditAccount } from '@/lib/credits';
 import {
   claimIntroCredits,
@@ -49,11 +50,7 @@ export async function applySignupBonus(userId: string) {
   };
 }
 
-// In-memory set of recently initialized users. Prevents the 5+ DB queries
-// in initializeUserSession from running on every single page load for the
-// same authenticated user. Entries expire after 1 hour.
-const recentlyInitialized = new Map<string, number>();
-const INIT_CACHE_TTL_MS = 60 * 60 * 1000;
+const INIT_CACHE_TTL_SECONDS = 60 * 60; // 1 hour
 
 export async function initializeUserSession(params: {
   userId: string;
@@ -62,11 +59,9 @@ export async function initializeUserSession(params: {
   utmMedium?: string | null;
   utmCampaign?: string | null;
 }) {
-  const now = Date.now();
-  const lastInit = recentlyInitialized.get(params.userId);
-  if (lastInit && now - lastInit < INIT_CACHE_TTL_MS) {
-    return;
-  }
+  const cacheKey = `onboarding:init:${params.userId}`;
+  const cached = await cacheGet<number>(cacheKey);
+  if (cached) return;
 
   // Check DB for existing user BEFORE ensureUserRecord creates one.
   // This provides a durable new-user signal that survives deploys/restarts,
@@ -141,14 +136,5 @@ export async function initializeUserSession(params: {
     }
   }
 
-  recentlyInitialized.set(params.userId, now);
-
-  // Periodic cleanup: remove stale entries to prevent unbounded growth
-  if (recentlyInitialized.size > 1000) {
-    for (const [uid, ts] of recentlyInitialized) {
-      if (now - ts > INIT_CACHE_TTL_MS) {
-        recentlyInitialized.delete(uid);
-      }
-    }
-  }
+  await cacheSet(cacheKey, Date.now(), INIT_CACHE_TTL_SECONDS);
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "@scalar/nextjs-api-reference": "^0.9.18",
     "@sentry/nextjs": "^10.38.0",
+    "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^1.6.1",
     "ai": "^6.0.73",
     "canonicalize": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.38.0
         version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.1(esbuild@0.25.12))
+      '@upstash/redis':
+        specifier: ^1.37.0
+        version: 1.37.0
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -58,7 +61,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)
+        version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0)
       ethers:
         specifier: ^6.16.0
         version: 6.16.0
@@ -2337,6 +2340,9 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/redis@1.37.0':
+    resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -4925,6 +4931,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
@@ -7347,6 +7356,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@upstash/redis@1.37.0':
+    dependencies:
+      uncrypto: 0.1.3
+
   '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -7981,11 +7994,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0):
+  drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.37.0):
     optionalDependencies:
       '@neondatabase/serverless': 1.0.2
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.16.0
+      '@upstash/redis': 1.37.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -10284,6 +10298,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.19.8: {}
 

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// No Redis env vars in test - all operations use in-memory fallback.
+
+describe('lib/cache (in-memory fallback)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const loadCache = async () => import('@/lib/cache');
+
+  it('cacheGet returns null for missing key', async () => {
+    const { cacheGet, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    const result = await cacheGet('nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('cacheSet + cacheGet round-trips a value', async () => {
+    const { cacheGet, cacheSet, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    await cacheSet('hello', 'world', 60);
+    const result = await cacheGet<string>('hello');
+    expect(result).toBe('world');
+  });
+
+  it('cacheSet + cacheGet round-trips an object with JSON serialization', async () => {
+    const { cacheGet, cacheSet, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    const obj = { name: 'Darwin', wins: 42, nested: { score: 0.95 } };
+    await cacheSet('agent:1', obj, 300);
+    const result = await cacheGet<typeof obj>('agent:1');
+    expect(result).toEqual(obj);
+  });
+
+  it('TTL expiry returns null after elapsed time', async () => {
+    const { cacheGet, cacheSet, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    await cacheSet('ephemeral', 'data', 10);
+
+    // Still valid at 9 seconds
+    vi.advanceTimersByTime(9_000);
+    expect(await cacheGet('ephemeral')).toBe('data');
+
+    // Expired at 10 seconds
+    vi.advanceTimersByTime(1_000);
+    expect(await cacheGet('ephemeral')).toBeNull();
+  });
+
+  it('cacheDel removes an entry', async () => {
+    const { cacheGet, cacheSet, cacheDel, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    await cacheSet('to-delete', 'value', 60);
+    expect(await cacheGet('to-delete')).toBe('value');
+    await cacheDel('to-delete');
+    expect(await cacheGet('to-delete')).toBeNull();
+  });
+
+  it('cacheExists returns true for existing key and false for missing', async () => {
+    const { cacheSet, cacheExists, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    expect(await cacheExists('nope')).toBe(false);
+    await cacheSet('yep', 1, 60);
+    expect(await cacheExists('yep')).toBe(true);
+  });
+
+  it('cacheExists returns false after TTL expiry', async () => {
+    const { cacheSet, cacheExists, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    await cacheSet('expiring', true, 5);
+    expect(await cacheExists('expiring')).toBe(true);
+    vi.advanceTimersByTime(5_000);
+    expect(await cacheExists('expiring')).toBe(false);
+  });
+
+  it('clearLocalCache clears all entries', async () => {
+    const { cacheGet, cacheSet, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    await cacheSet('a', 1, 60);
+    await cacheSet('b', 2, 60);
+    clearLocalCache();
+    expect(await cacheGet('a')).toBeNull();
+    expect(await cacheGet('b')).toBeNull();
+  });
+
+  it('handles number values', async () => {
+    const { cacheGet, cacheSet, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    await cacheSet('count', 42, 60);
+    expect(await cacheGet<number>('count')).toBe(42);
+  });
+
+  it('handles null-ish stored values correctly', async () => {
+    const { cacheGet, cacheSet, clearLocalCache } = await loadCache();
+    clearLocalCache();
+    // Storing 0 should be retrievable (not confused with cache miss)
+    await cacheSet('zero', 0, 60);
+    const result = await cacheGet<number>('zero');
+    expect(result).toBe(0);
+  });
+});

--- a/tests/unit/leaderboard.test.ts
+++ b/tests/unit/leaderboard.test.ts
@@ -179,7 +179,7 @@ describe('lib/leaderboard', () => {
     mockDb.select.mockReset();
 
     const second = await getLeaderboardData();
-    expect(second).toBe(first); // Same reference (cached)
+    expect(second).toEqual(first); // Cached (serialized round-trip)
     expect(mockDb.select).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Introduces a distributed cache abstraction (`lib/cache.ts`) backed by Upstash Redis with graceful in-memory fallback. Migrates two in-memory caches to the new infrastructure, preparing the application for horizontal scaling.

## What changed

- **lib/cache.ts** (new) - `cacheGet<T>`, `cacheSet<T>`, `cacheDel`, `cacheExists`, `clearLocalCache`. Uses Upstash Redis when env vars are set, falls back to in-memory Map for dev/test. Redis errors logged once then silently degraded.
- **lib/leaderboard.ts** - Removed module-level `leaderboardCache` variable. Now uses `cacheGet`/`cacheSet` with key `leaderboard:data` and 5-minute TTL.
- **lib/onboarding.ts** - Removed module-level `recentlyInitialized` Map and manual cleanup. Now uses `cacheGet`/`cacheSet` with key `onboarding:init:{userId}` and 1-hour TTL.
- **lib/env.ts** - Added optional `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` to Zod schema.
- **package.json** - Added `@upstash/redis` dependency.

## Technical decisions

- **Lazy Redis init**: Redis client created on first cache access, not at module load. Avoids startup failures when env vars are missing.
- **Upstash native serialization**: Values passed to `client.set()` directly (not JSON.stringify'd first) because Upstash auto-serializes/deserializes. Prevents double-parse bugs with string values.
- **process.env in cache.ts**: Reads env vars directly to avoid circular dependency with lib/env.ts. Documented in header comment.
- **Write-through gap**: Known limitation - if Redis write succeeds but later Redis read fails, local cache won't have the value. Acceptable because cache misses are safe (just recompute). Noted for future if Redis instability is observed.

## What was tested

- 10 new tests in cache.test.ts (miss, hit, TTL expiry, delete, exists, objects, numbers, zero values)
- All 1497 existing tests pass
- Gate: typecheck + lint + test = green

## Reviewed by

- DC-1 (Claude): PASS WITH FINDINGS - double JSON parse (fixed), truthy cache check (fixed), write-through gap (noted)

Tests: 1497/1497 passed
Gate: typecheck + lint + test = green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a distributed cache backed by Upstash Redis with a safe in-memory fallback, and migrates leaderboard and onboarding to it. Prepares the app for horizontal scaling and aligns with RD-018 and RD-019.

- **New Features**
  - New `lib/cache.ts`: `cacheGet`, `cacheSet`, `cacheDel`, `cacheExists`, `clearLocalCache`; lazy Redis init; Upstash auto-serialization; logs once then degrades to memory.
  - Leaderboard uses `leaderboard:data` with 5-minute TTL.
  - Onboarding uses `onboarding:init:{userId}` with 1-hour TTL.
  - Env schema: optional `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`.

- **Dependencies**
  - Add `@upstash/redis`.

<sup>Written for commit a7e5514b72330519e912ecb59bc760595610553e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

