### PR TITLE
feat(rate-limit): distributed rate limiting with Upstash + in-memory fallback (RD-020)

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -155,7 +155,7 @@ export const POST = withLogging(async function POST(req: Request) {
     return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
   }
 
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'agent-creation', maxRequests: 10, windowMs: 60 * 60 * 1000 },
     userId,
   );

--- a/app/api/ask-the-pit/route.ts
+++ b/app/api/ask-the-pit/route.ts
@@ -68,7 +68,7 @@ async function rawPOST(req: Request) {
   }
 
   const clientId = getClientIdentifier(req);
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'ask-the-pit', maxRequests: 5, windowMs: 60 * 1000 },
     clientId,
   );

--- a/app/api/byok-stash/route.ts
+++ b/app/api/byok-stash/route.ts
@@ -38,7 +38,7 @@ export const POST = withLogging(async function POST(req: Request) {
     }
   }
 
-  const rateCheck = checkRateLimit(RATE_LIMIT, userId);
+  const rateCheck = await checkRateLimit(RATE_LIMIT, userId);
   if (!rateCheck.success) {
     return rateLimitResponse(rateCheck);
   }

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -18,7 +18,7 @@ function escapeHtml(str: string): string {
 
 export const POST = withLogging(async function POST(req: Request) {
   const clientId = getClientIdentifier(req);
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'contact', maxRequests: 5, windowMs: 60 * 60 * 1000 },
     clientId,
   );

--- a/app/api/feature-requests/route.ts
+++ b/app/api/feature-requests/route.ts
@@ -25,7 +25,7 @@ export const POST = withLogging(async function POST(req: Request) {
     return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
   }
 
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'feature-requests', maxRequests: 10, windowMs: 60 * 60 * 1000 },
     userId,
   );

--- a/app/api/feature-requests/vote/route.ts
+++ b/app/api/feature-requests/vote/route.ts
@@ -15,7 +15,7 @@ export const POST = withLogging(async function POST(req: Request) {
     return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
   }
 
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'feature-request-votes', maxRequests: 30, windowMs: 60 * 1000 },
     userId,
   );

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -8,7 +8,7 @@ export const runtime = 'nodejs';
 
 export const POST = withLogging(async function POST(req: Request) {
   const clientId = getClientIdentifier(req);
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'newsletter', maxRequests: 5, windowMs: 60 * 60 * 1000 },
     clientId,
   );

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -13,7 +13,7 @@ import { withLogging } from '@/lib/api-logging';
 const RATE_LIMIT = { name: 'openapi', maxRequests: 10, windowMs: 60_000 };
 
 async function rawGET(req: Request) {
-  const rateCheck = checkRateLimit(RATE_LIMIT, getClientIdentifier(req));
+  const rateCheck = await checkRateLimit(RATE_LIMIT, getClientIdentifier(req));
   if (!rateCheck.success) {
     return rateLimitResponse(rateCheck);
   }

--- a/app/api/paper-submissions/route.ts
+++ b/app/api/paper-submissions/route.ts
@@ -16,7 +16,7 @@ export const POST = withLogging(async function POST(req: Request) {
     return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
   }
 
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'paper-submissions', maxRequests: 5, windowMs: 60 * 60 * 1000 },
     userId,
   );

--- a/app/api/reactions/route.ts
+++ b/app/api/reactions/route.ts
@@ -22,7 +22,7 @@ const RATE_LIMIT_CONFIG: RateLimitConfig = {
 
 export const POST = withLogging(async function POST(req: Request) {
   const clientId = getClientIdentifier(req);
-  const rateLimit = checkRateLimit(RATE_LIMIT_CONFIG, clientId);
+  const rateLimit = await checkRateLimit(RATE_LIMIT_CONFIG, clientId);
 
   if (!rateLimit.success) {
     return rateLimitResponse(rateLimit);

--- a/app/api/research/export/route.ts
+++ b/app/api/research/export/route.ts
@@ -16,7 +16,7 @@ export const runtime = 'nodejs';
 const RATE_LIMIT = { name: 'research-export', maxRequests: 5, windowMs: 60 * 60 * 1000 };
 
 export const GET = withLogging(async function GET(req: Request) {
-  const rateCheck = checkRateLimit(RATE_LIMIT, getClientIdentifier(req));
+  const rateCheck = await checkRateLimit(RATE_LIMIT, getClientIdentifier(req));
   if (!rateCheck.success) {
     return rateLimitResponse(rateCheck);
   }

--- a/app/api/short-links/route.ts
+++ b/app/api/short-links/route.ts
@@ -8,7 +8,7 @@ import { shortLinkSchema } from '@/lib/api-schemas';
 export const runtime = 'nodejs';
 
 export const POST = withLogging(async function POST(req: Request) {
-  const rateCheck = checkRateLimit(
+  const rateCheck = await checkRateLimit(
     { name: 'short-links', maxRequests: 30, windowMs: 60 * 1000 },
     getClientIdentifier(req),
   );

--- a/app/api/winner-vote/route.ts
+++ b/app/api/winner-vote/route.ts
@@ -20,7 +20,7 @@ export const POST = withLogging(async function POST(req: Request) {
     return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
   }
 
-  const rateCheck = checkRateLimit(RATE_LIMIT, userId);
+  const rateCheck = await checkRateLimit(RATE_LIMIT, userId);
   if (!rateCheck.success) {
     return rateLimitResponse(rateCheck);
   }

--- a/docs/internal/captain/bout-engine-annotated.ts
+++ b/docs/internal/captain/bout-engine-annotated.ts
@@ -400,7 +400,7 @@ export async function validateBoutRequest(
 
   if (boutMaxRequests !== undefined) {
     const rateLimitId = userId ?? getClientIdentifier(req);
-    const boutRateCheck = checkRateLimit(
+    const boutRateCheck = await checkRateLimit(
       { name: 'bout-creation', maxRequests: boutMaxRequests, windowMs: 60 * 60 * 1000 },
       rateLimitId,
     );

--- a/lib/bout-validation.ts
+++ b/lib/bout-validation.ts
@@ -336,7 +336,7 @@ export async function validateBoutRequest(
 
   if (boutMaxRequests !== undefined) {
     const rateLimitId = userId ?? getClientIdentifier(req);
-    const boutRateCheck = checkRateLimit(
+    const boutRateCheck = await checkRateLimit(
       { name: 'bout-creation', maxRequests: boutMaxRequests, windowMs: 60 * 60 * 1000 },
       rateLimitId,
     );

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -21,37 +21,48 @@ import { resolveClientIp } from '@/lib/ip';
 // Distributed (Upstash Redis) rate limiter
 // ---------------------------------------------------------------------------
 
-/** One Ratelimit instance per config name, each with its own window/limit. */
+/**
+ * One Ratelimit instance per unique (name, maxRequests, windowMs) tuple.
+ * The cache key includes limit parameters because the same config name
+ * (e.g. 'bout-creation') may be called with different maxRequests per
+ * tier (anonymous: 2, free: 5, pass: 15). Caching by name alone would
+ * lock in the first-seen limit for all subsequent tiers.
+ */
 const distributedLimiters = new Map<string, Ratelimit>();
 
-let redisAvailable: boolean | null = null;
+/** Shared Redis instance for all limiters. Created once on first use. */
+let sharedRedis: Redis | null = null;
 let redisWarningLogged = false;
+
+function getSharedRedis(): Redis | null {
+  if (sharedRedis) return sharedRedis;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  sharedRedis = new Redis({ url, token });
+  return sharedRedis;
+}
 
 /**
  * Return an Upstash Ratelimit instance for the given config, or null when
- * Redis env vars are missing. Instances are created lazily and cached.
+ * Redis env vars are missing. Instances are created lazily and cached by
+ * the full config signature (name + maxRequests + windowMs).
  */
 function getDistributedLimiter(config: RateLimitConfig): Ratelimit | null {
-  if (redisAvailable === false) return null;
+  const redis = getSharedRedis();
+  if (!redis) return null;
 
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) {
-    redisAvailable = false;
-    return null;
-  }
-  redisAvailable = true;
-
-  const existing = distributedLimiters.get(config.name);
+  const cacheKey = `${config.name}:${config.maxRequests}:${config.windowMs}`;
+  const existing = distributedLimiters.get(cacheKey);
   if (existing) return existing;
 
   const limiter = new Ratelimit({
-    redis: new Redis({ url, token }),
+    redis,
     limiter: Ratelimit.slidingWindow(config.maxRequests, `${config.windowMs} ms`),
-    prefix: `ratelimit:${config.name}`,
+    prefix: `ratelimit:${config.name}:${config.maxRequests}`,
   });
 
-  distributedLimiters.set(config.name, limiter);
+  distributedLimiters.set(cacheKey, limiter);
   return limiter;
 }
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,19 +1,63 @@
 /**
- * Simple in-memory rate limiter for serverless environments.
- * Uses a sliding window approach with automatic cleanup.
+ * Distributed rate limiter with in-memory fallback.
  *
- * LIMITATION: In-memory only — each serverless instance has independent
- * state. A determined attacker hitting different instances can bypass
- * limits. For strict production enforcement, migrate to a shared store
- * (e.g. Upstash Redis).
+ * When UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are set, uses
+ * @upstash/ratelimit for distributed sliding-window rate limiting across
+ * all serverless instances. Falls back to per-instance in-memory rate
+ * limiting when Redis is unavailable (local dev, tests, Redis failure).
  *
- * Current mitigations: DB-level constraints (unique indexes, atomic
- * conditional updates, preauthorization) serve as the authoritative
- * enforcement layer. This rate limiter provides best-effort throttling
- * to reduce load on those DB checks.
+ * DB-level constraints (unique indexes, atomic conditional updates,
+ * preauthorization) remain the authoritative enforcement layer. This
+ * rate limiter provides best-effort throttling to reduce load on those
+ * DB checks.
  */
 
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
 import { resolveClientIp } from '@/lib/ip';
+
+// ---------------------------------------------------------------------------
+// Distributed (Upstash Redis) rate limiter
+// ---------------------------------------------------------------------------
+
+/** One Ratelimit instance per config name, each with its own window/limit. */
+const distributedLimiters = new Map<string, Ratelimit>();
+
+let redisAvailable: boolean | null = null;
+let redisWarningLogged = false;
+
+/**
+ * Return an Upstash Ratelimit instance for the given config, or null when
+ * Redis env vars are missing. Instances are created lazily and cached.
+ */
+function getDistributedLimiter(config: RateLimitConfig): Ratelimit | null {
+  if (redisAvailable === false) return null;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    redisAvailable = false;
+    return null;
+  }
+  redisAvailable = true;
+
+  const existing = distributedLimiters.get(config.name);
+  if (existing) return existing;
+
+  const limiter = new Ratelimit({
+    redis: new Redis({ url, token }),
+    limiter: Ratelimit.slidingWindow(config.maxRequests, `${config.windowMs} ms`),
+    prefix: `ratelimit:${config.name}`,
+  });
+
+  distributedLimiters.set(config.name, limiter);
+  return limiter;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory fallback rate limiter
+// ---------------------------------------------------------------------------
 
 type RateLimitEntry = {
   count: number;
@@ -38,6 +82,53 @@ const cleanup = (store: Map<string, RateLimitEntry>, windowMs: number) => {
   }
 };
 
+/** In-memory sliding window check (original implementation). */
+function checkRateLimitInMemory(
+  config: RateLimitConfig,
+  identifier: string,
+): RateLimitResult {
+  const { name, maxRequests, windowMs } = config;
+
+  let store = stores.get(name);
+  if (!store) {
+    store = new Map();
+    stores.set(name, store);
+  }
+
+  cleanup(store, windowMs);
+
+  const now = Date.now();
+  const entry = store.get(identifier);
+
+  if (!entry || now - entry.windowStart > windowMs) {
+    store.set(identifier, { count: 1, windowStart: now });
+    return {
+      success: true,
+      remaining: maxRequests - 1,
+      resetAt: now + windowMs,
+    };
+  }
+
+  if (entry.count >= maxRequests) {
+    return {
+      success: false,
+      remaining: 0,
+      resetAt: entry.windowStart + windowMs,
+    };
+  }
+
+  entry.count += 1;
+  return {
+    success: true,
+    remaining: maxRequests - entry.count,
+    resetAt: entry.windowStart + windowMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 export type RateLimitConfig = {
   /** Unique identifier for this rate limiter (e.g., 'reactions') */
   name: string;
@@ -56,53 +147,36 @@ export type RateLimitResult = {
 /**
  * Check if a request should be rate limited.
  *
+ * Uses distributed (Upstash Redis) rate limiting when Redis env vars are
+ * set. Falls back to in-memory rate limiting otherwise, or when Redis
+ * is unreachable at runtime.
+ *
  * @param config - Rate limit configuration
  * @param identifier - Unique identifier for the client (IP, userId, etc.)
  * @returns Object with success boolean, remaining requests, and reset timestamp
  */
-export function checkRateLimit(
+export async function checkRateLimit(
   config: RateLimitConfig,
   identifier: string,
-): RateLimitResult {
-  const { name, maxRequests, windowMs } = config;
-
-  let store = stores.get(name);
-  if (!store) {
-    store = new Map();
-    stores.set(name, store);
+): Promise<RateLimitResult> {
+  const distributed = getDistributedLimiter(config);
+  if (distributed) {
+    try {
+      const result = await distributed.limit(identifier);
+      return {
+        success: result.success,
+        remaining: result.remaining,
+        resetAt: result.reset,
+      };
+    } catch (err) {
+      if (!redisWarningLogged) {
+        redisWarningLogged = true;
+        console.warn('[rate-limit] Redis unavailable, falling back to in-memory:', err);
+      }
+    }
   }
 
-  cleanup(store, windowMs);
-
-  const now = Date.now();
-  const entry = store.get(identifier);
-
-  if (!entry || now - entry.windowStart > windowMs) {
-    // New window
-    store.set(identifier, { count: 1, windowStart: now });
-    return {
-      success: true,
-      remaining: maxRequests - 1,
-      resetAt: now + windowMs,
-    };
-  }
-
-  if (entry.count >= maxRequests) {
-    // Rate limited
-    return {
-      success: false,
-      remaining: 0,
-      resetAt: entry.windowStart + windowMs,
-    };
-  }
-
-  // Increment and allow
-  entry.count += 1;
-  return {
-    success: true,
-    remaining: maxRequests - entry.count,
-    resetAt: entry.windowStart + windowMs,
-  };
+  return checkRateLimitInMemory(config, identifier);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "@scalar/nextjs-api-reference": "^0.9.18",
     "@sentry/nextjs": "^10.38.0",
+    "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^1.6.1",
     "ai": "^6.0.73",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.38.0
         version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.1(esbuild@0.25.12))
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.37.0)
       '@upstash/redis':
         specifier: ^1.37.0
         version: 1.37.0
@@ -2340,6 +2343,15 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
 
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
@@ -7355,6 +7367,15 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.37.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.37.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.37.0
 
   '@upstash/redis@1.37.0':
     dependencies:

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
 import { checkRateLimit, getClientIdentifier, type RateLimitConfig } from '@/lib/rate-limit';
 
-describe('rate-limit', () => {
+describe('rate-limit (in-memory fallback)', () => {
   const config: RateLimitConfig = {
     name: 'test-limiter',
     maxRequests: 3,
@@ -12,78 +12,197 @@ describe('rate-limit', () => {
     vi.useFakeTimers();
   });
 
-  it('allows requests within limit', () => {
-    const result1 = checkRateLimit(config, 'client-1');
+  it('allows requests within limit', async () => {
+    const result1 = await checkRateLimit(config, 'client-1');
     expect(result1.success).toBe(true);
     expect(result1.remaining).toBe(2);
 
-    const result2 = checkRateLimit(config, 'client-1');
+    const result2 = await checkRateLimit(config, 'client-1');
     expect(result2.success).toBe(true);
     expect(result2.remaining).toBe(1);
 
-    const result3 = checkRateLimit(config, 'client-1');
+    const result3 = await checkRateLimit(config, 'client-1');
     expect(result3.success).toBe(true);
     expect(result3.remaining).toBe(0);
   });
 
-  it('blocks requests over limit', () => {
-    checkRateLimit(config, 'client-2');
-    checkRateLimit(config, 'client-2');
-    checkRateLimit(config, 'client-2');
+  it('blocks requests over limit', async () => {
+    await checkRateLimit(config, 'client-2');
+    await checkRateLimit(config, 'client-2');
+    await checkRateLimit(config, 'client-2');
 
-    const result = checkRateLimit(config, 'client-2');
+    const result = await checkRateLimit(config, 'client-2');
     expect(result.success).toBe(false);
     expect(result.remaining).toBe(0);
   });
 
-  it('resets after window expires', () => {
-    checkRateLimit(config, 'client-3');
-    checkRateLimit(config, 'client-3');
-    checkRateLimit(config, 'client-3');
+  it('resets after window expires', async () => {
+    await checkRateLimit(config, 'client-3');
+    await checkRateLimit(config, 'client-3');
+    await checkRateLimit(config, 'client-3');
 
     // Should be blocked
-    expect(checkRateLimit(config, 'client-3').success).toBe(false);
+    expect((await checkRateLimit(config, 'client-3')).success).toBe(false);
 
     // Advance time past window
     vi.advanceTimersByTime(1001);
 
     // Should be allowed again
-    const result = checkRateLimit(config, 'client-3');
+    const result = await checkRateLimit(config, 'client-3');
     expect(result.success).toBe(true);
     expect(result.remaining).toBe(2);
   });
 
-  it('tracks different clients separately', () => {
-    checkRateLimit(config, 'client-a');
-    checkRateLimit(config, 'client-a');
-    checkRateLimit(config, 'client-a');
+  it('tracks different clients separately', async () => {
+    await checkRateLimit(config, 'client-a');
+    await checkRateLimit(config, 'client-a');
+    await checkRateLimit(config, 'client-a');
 
     // Client A is blocked
-    expect(checkRateLimit(config, 'client-a').success).toBe(false);
+    expect((await checkRateLimit(config, 'client-a')).success).toBe(false);
 
     // Client B has full quota
-    const result = checkRateLimit(config, 'client-b');
+    const result = await checkRateLimit(config, 'client-b');
     expect(result.success).toBe(true);
     expect(result.remaining).toBe(2);
   });
 
-  it('tracks different rate limiters separately', () => {
+  it('tracks different rate limiters separately', async () => {
     const configA: RateLimitConfig = { name: 'limiter-a', maxRequests: 1, windowMs: 1000 };
     const configB: RateLimitConfig = { name: 'limiter-b', maxRequests: 1, windowMs: 1000 };
 
-    checkRateLimit(configA, 'client-x');
-    expect(checkRateLimit(configA, 'client-x').success).toBe(false);
+    await checkRateLimit(configA, 'client-x');
+    expect((await checkRateLimit(configA, 'client-x')).success).toBe(false);
 
     // Different limiter should allow
-    expect(checkRateLimit(configB, 'client-x').success).toBe(true);
+    expect((await checkRateLimit(configB, 'client-x')).success).toBe(true);
   });
 
-  it('provides reset timestamp', () => {
+  it('provides reset timestamp', async () => {
     const now = Date.now();
     vi.setSystemTime(now);
 
-    const result = checkRateLimit(config, 'client-reset');
+    const result = await checkRateLimit(config, 'client-reset');
     expect(result.resetAt).toBe(now + config.windowMs);
+  });
+});
+
+describe('rate-limit (distributed)', () => {
+  const config: RateLimitConfig = {
+    name: 'dist-test',
+    maxRequests: 5,
+    windowMs: 60_000,
+  };
+
+  const mockLimit = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockLimit.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses distributed limiter when Redis env vars are set', async () => {
+    mockLimit.mockResolvedValue({
+      success: true,
+      remaining: 4,
+      reset: Date.now() + 60_000,
+      limit: 5,
+    });
+
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://fake.upstash.io');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'fake-token');
+
+    vi.doMock('@upstash/ratelimit', () => ({
+      Ratelimit: class MockRatelimit {
+        limit = mockLimit;
+        static slidingWindow() {
+          return { type: 'slidingWindow' };
+        }
+      },
+    }));
+    vi.doMock('@upstash/redis', () => ({
+      Redis: class MockRedis {
+        constructor() {}
+      },
+    }));
+
+    const mod = await import('@/lib/rate-limit');
+    const result = await mod.checkRateLimit(config, 'user-1');
+
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(4);
+    expect(mockLimit).toHaveBeenCalledWith('user-1');
+  });
+
+  it('falls back to in-memory when distributed limiter throws', async () => {
+    mockLimit.mockRejectedValue(new Error('Redis connection failed'));
+
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://fake.upstash.io');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'fake-token');
+
+    vi.doMock('@upstash/ratelimit', () => ({
+      Ratelimit: class MockRatelimit {
+        limit = mockLimit;
+        static slidingWindow() {
+          return { type: 'slidingWindow' };
+        }
+      },
+    }));
+    vi.doMock('@upstash/redis', () => ({
+      Redis: class MockRedis {
+        constructor() {}
+      },
+    }));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mod = await import('@/lib/rate-limit');
+    const result = await mod.checkRateLimit(config, 'user-fallback');
+
+    // Should succeed via in-memory fallback
+    expect(result.success).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[rate-limit] Redis unavailable'),
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('maps distributed result fields correctly', async () => {
+    const resetTime = Date.now() + 30_000;
+    mockLimit.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: resetTime,
+      limit: 5,
+    });
+
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://fake.upstash.io');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'fake-token');
+
+    vi.doMock('@upstash/ratelimit', () => ({
+      Ratelimit: class MockRatelimit {
+        limit = mockLimit;
+        static slidingWindow() {
+          return { type: 'slidingWindow' };
+        }
+      },
+    }));
+    vi.doMock('@upstash/redis', () => ({
+      Redis: class MockRedis {
+        constructor() {}
+      },
+    }));
+
+    const mod = await import('@/lib/rate-limit');
+    const result = await mod.checkRateLimit(config, 'user-blocked');
+
+    expect(result.success).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.resetAt).toBe(resetTime);
   });
 });
 


### PR DESCRIPTION
## Summary

Replaces the per-serverless-instance in-memory rate limiter with a hybrid distributed/in-memory implementation using `@upstash/ratelimit`. When Upstash Redis is configured, rate limits are shared across all instances. Falls back to the existing in-memory implementation for dev/test or Redis failures.

## What changed

- **lib/rate-limit.ts** - `checkRateLimit` is now async. Uses `@upstash/ratelimit` sliding window when Redis is available, falls back to existing in-memory logic. One Ratelimit instance per unique (name, maxRequests, windowMs) tuple. Shared Redis client across all limiters.
- **14 callers updated** - Added `await` to every `checkRateLimit(...)` call across route handlers and bout-validation.
- **package.json** - Added `@upstash/ratelimit` dependency.
- **tests/unit/rate-limit.test.ts** - Updated existing tests to async, added 3 new tests for distributed path.

## Technical decisions

- **Cache key includes limit params**: `bout-creation` is called with different `maxRequests` per tier (anonymous: 2, free: 5, pass: 15). Caching by name alone would lock in the first-seen limit. Cache key is `name:maxRequests:windowMs`.
- **Shared Redis instance**: Single `Redis` client shared across all limiters (Upstash REST clients are lightweight but no need for multiples).
- **No redisAvailable latch**: Env vars checked on every call (cheap) to avoid cold-start race permanently disabling Redis.
- **Async conversion**: All callers are in async functions, so adding `await` is safe. TypeScript enforces correctness.

## What was tested

- 3 new tests for distributed path (mock @upstash/ratelimit)
- All 1500 existing tests pass
- Gate: typecheck + lint + test = green

## Reviewed by

- DC-1 (Claude): FAIL -> fixed critical (tiered limit collision), fixed major (shared Redis, removed latch)

Tests: 1500/1500 passed
Gate: typecheck + lint + test = green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds distributed rate limiting across serverless instances using `@upstash/ratelimit`, with a safe in-memory fallback. `checkRateLimit` is now async and all call sites are updated. Implements Linear RD-020.

- **New Features**
  - Uses Upstash sliding window when `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are set; shared Redis client across limiters.
  - Caches one limiter per `name:maxRequests:windowMs` to support tiered limits.
  - Falls back to in-memory when Redis is missing or errors (logs once).

- **Migration**
  - To enable distributed limits, set the Upstash env vars; otherwise behavior stays in-memory.
  - `checkRateLimit(...)` is async; ensure new usages await it.

<sup>Written for commit c8ce0637ca39343ba4eb997d957770317fd7679d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure Improvements**
  * Upgraded rate limiting system to use distributed enforcement with automatic fallback to local protection when external services are unavailable, ensuring consistent request throttling across the platform with enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->