### PR TITLE
refactor(schema): drop dead tables free_bout_pool and agent_flags (RD-022, RD-023)

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -41,8 +41,6 @@ All modules that touch the database import `requireDb` from `@/db` and table/enu
 | `winner_votes` | `serial` | Per-bout winner votes (unique per user per bout) |
 | `newsletter_signups` | `serial` | Email collection with unique email index |
 | `agents` | `varchar(128)` | Agent definitions: personality fields, dual hashes, EAS attestation, lineage |
-| `free_bout_pool` | `serial` | Global daily free bout limit (unique per date) |
-| `agent_flags` | `serial` | User-submitted moderation flags (unique per agent per user) |
 | `paper_submissions` | `serial` | ArXiv paper submissions with moderation status |
 | `feature_requests` | `serial` | User feature request submissions with admin review |
 | `feature_request_votes` | `serial` | Votes on feature requests (unique per user per request) |
@@ -73,8 +71,6 @@ ArenaAgent = { id: string; name: string; systemPrompt: string; color?: string; a
 | `winner_votes` | `created_at` | btree |
 | `newsletter_signups` | `email` | unique |
 | `agents` | `(archived, created_at)` | composite |
-| `free_bout_pool` | `date` | unique |
-| `agent_flags` | `(agent_id, user_id)` | unique |
 | `paper_submissions` | `user_id` | btree |
 | `paper_submissions` | `(user_id, arxiv_id)` | unique |
 | `feature_requests` | `created_at` | btree |

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -295,41 +295,6 @@ export const agents = pgTable('agents', {
   }).onDelete('set null'),
 }));
 
-export const freeBoutPool = pgTable('free_bout_pool', {
-  id: serial('id').primaryKey(),
-  date: varchar('date', { length: 10 }).notNull(),
-  used: integer('used').notNull().default(0),
-  maxDaily: integer('max_daily').notNull(),
-  /** Cumulative platform spend (micro-credits) on free-tier bouts today. */
-  spendMicro: bigint('spend_micro', { mode: 'number' }).notNull().default(0),
-  /** Daily spend cap (micro-credits). Default £20 = 200,000 micro. */
-  spendCapMicro: bigint('spend_cap_micro', { mode: 'number' }).notNull().default(200_000),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-}, (table) => ({
-  dateIdx: uniqueIndex('free_bout_pool_date_idx').on(table.date),
-}));
-
-export const agentFlags = pgTable(
-  'agent_flags',
-  {
-    id: serial('id').primaryKey(),
-    agentId: varchar('agent_id', { length: 128 }).notNull().references(() => agents.id, { onDelete: 'cascade' }),
-    userId: varchar('user_id', { length: 128 }).notNull().references(() => users.id, { onDelete: 'cascade' }),
-    reason: varchar('reason', { length: 32 }).notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .defaultNow()
-      .notNull(),
-  },
-  (table) => ({
-    uniqueFlag: uniqueIndex('agent_flags_unique').on(
-      table.agentId,
-      table.userId,
-    ),
-  }),
-);
-
 export const paperSubmissions = pgTable(
   'paper_submissions',
   {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,6 @@ Client parsing happens in `lib/use-bout.ts` with `parseJsonEventStream`.
 - `reactions` + `winner_votes` — audience engagement (deduped)
 - `users` — Clerk user mirror, subscription tier, stripe customer
 - `newsletter_signups` — email list
-- `free_bout_pool` — daily free bout cap
-- `agent_flags` — community moderation
 - `paper_submissions` — arXiv paper submissions for research curation
 - `feature_requests` + `feature_request_votes` — community feature voting
 - `page_views` — server-side analytics (path, session, UTM, geo)

--- a/drizzle/0003_drop_dead_tables.sql
+++ b/drizzle/0003_drop_dead_tables.sql
@@ -1,0 +1,4 @@
+-- Drop dead tables: free_bout_pool (replaced by intro_pool) and agent_flags
+-- (created but never used). See RD-022 and RD-023.
+DROP TABLE IF EXISTS "free_bout_pool";
+DROP TABLE IF EXISTS "agent_flags";

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -202,26 +202,6 @@ export const contactSubmissions = pgTable("contact_submissions", {
 	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
 });
 
-export const agentFlags = pgTable("agent_flags", {
-	id: serial().primaryKey().notNull(),
-	agentId: varchar("agent_id", { length: 128 }).notNull(),
-	userId: varchar("user_id", { length: 128 }).notNull(),
-	reason: varchar({ length: 32 }).notNull(),
-	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	uniqueIndex("agent_flags_unique").using("btree", table.agentId.asc().nullsLast().op("text_ops"), table.userId.asc().nullsLast().op("text_ops")),
-]);
-
-export const freeBoutPool = pgTable("free_bout_pool", {
-	id: serial().primaryKey().notNull(),
-	date: varchar({ length: 10 }).notNull(),
-	used: integer().default(0).notNull(),
-	maxDaily: integer("max_daily").notNull(),
-	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
-}, (table) => [
-	uniqueIndex("free_bout_pool_date_idx").using("btree", table.date.asc().nullsLast().op("text_ops")),
-]);
-
 export const bouts = pgTable("bouts", {
 	id: varchar({ length: 21 }).primaryKey().notNull(),
 	presetId: varchar("preset_id", { length: 64 }).notNull(),

--- a/pitctl/cmd/agents.go
+++ b/pitctl/cmd/agents.go
@@ -18,7 +18,6 @@ import (
 // AgentsListOpts configures the agents list command.
 type AgentsListOpts struct {
 	Archived bool
-	Flagged  bool
 	Limit    int
 }
 
@@ -40,28 +39,15 @@ func RunAgentsList(cfg *config.Config, opts AgentsListOpts) error {
 	var query string
 	var args []interface{}
 
-	if opts.Flagged {
+	if opts.Archived {
 		query = `
-			SELECT a.id, a.name, a.tier, a.archived, COUNT(f.id) as flags, a.created_at
-			FROM agents a
-			INNER JOIN agent_flags f ON f.agent_id = a.id
-			GROUP BY a.id, a.name, a.tier, a.archived, a.created_at
-			ORDER BY flags DESC
-			LIMIT $1`
-		args = []interface{}{opts.Limit}
-	} else if opts.Archived {
-		query = `
-			SELECT a.id, a.name, a.tier, a.archived,
-			       (SELECT COUNT(*) FROM agent_flags f WHERE f.agent_id = a.id) as flags,
-			       a.created_at
+			SELECT a.id, a.name, a.tier, a.archived, a.created_at
 			FROM agents a WHERE a.archived = true
 			ORDER BY a.created_at DESC LIMIT $1`
 		args = []interface{}{opts.Limit}
 	} else {
 		query = `
-			SELECT a.id, a.name, a.tier, a.archived,
-			       (SELECT COUNT(*) FROM agent_flags f WHERE f.agent_id = a.id) as flags,
-			       a.created_at
+			SELECT a.id, a.name, a.tier, a.archived, a.created_at
 			FROM agents a WHERE a.archived = false
 			ORDER BY a.created_at DESC LIMIT $1`
 		args = []interface{}{opts.Limit}
@@ -74,9 +60,7 @@ func RunAgentsList(cfg *config.Config, opts AgentsListOpts) error {
 	defer rows.Close()
 
 	heading := "agents"
-	if opts.Flagged {
-		heading = "flagged agents"
-	} else if opts.Archived {
+	if opts.Archived {
 		heading = "archived agents"
 	}
 
@@ -88,10 +72,9 @@ func RunAgentsList(cfg *config.Config, opts AgentsListOpts) error {
 	for rows.Next() {
 		var id, name, tier string
 		var archived bool
-		var flags int64
 		var createdAt time.Time
 
-		if err := rows.Scan(&id, &name, &tier, &archived, &flags, &createdAt); err != nil {
+		if err := rows.Scan(&id, &name, &tier, &archived, &createdAt); err != nil {
 			return err
 		}
 
@@ -105,7 +88,6 @@ func RunAgentsList(cfg *config.Config, opts AgentsListOpts) error {
 			truncStr(name, 20),
 			tier,
 			archStr,
-			fmt.Sprintf("%d", flags),
 			format.Date(createdAt),
 		})
 	}
@@ -119,7 +101,7 @@ func RunAgentsList(cfg *config.Config, opts AgentsListOpts) error {
 	t := table.New().
 		Border(lipgloss.RoundedBorder()).
 		BorderStyle(theme.BorderStyle()).
-		Headers("ID", "Name", "Tier", "Archived", "Flags", "Created").
+		Headers("ID", "Name", "Tier", "Archived", "Created").
 		Rows(tableRows...).
 		StyleFunc(func(row, col int) lipgloss.Style {
 			base := lipgloss.NewStyle().Padding(0, 1)
@@ -133,8 +115,6 @@ func RunAgentsList(cfg *config.Config, opts AgentsListOpts) error {
 				return base.Foreground(theme.ColorCyan)
 			case 2:
 				return base.Foreground(theme.ColorPurple)
-			case 4:
-				return base.Foreground(theme.ColorFg).Align(lipgloss.Right)
 			default:
 				return base.Foreground(theme.ColorFg)
 			}
@@ -175,10 +155,6 @@ func RunAgentsInspect(cfg *config.Config, agentID string) error {
 		return err
 	}
 
-	// Flag count.
-	var flagCount int64
-	conn.QueryVal(ctx, &flagCount, `SELECT COUNT(*) FROM agent_flags WHERE agent_id = $1`, agentID)
-
 	// Bout appearances.
 	var boutCount int64
 	conn.QueryVal(ctx, &boutCount,
@@ -199,7 +175,6 @@ func RunAgentsInspect(cfg *config.Config, agentID string) error {
 	kv("Owner", nullStr(ownerID))
 	kv("Parent", nullStr(parentID))
 	kv("Archived", fmt.Sprintf("%v", archived))
-	kv("Flags", format.Num(flagCount))
 	kv("Bout Appearances", format.Num(boutCount))
 	kv("Prompt Hash", promptHash)
 	kv("Manifest Hash", manifestHash)

--- a/pitctl/cmd/alerts.go
+++ b/pitctl/cmd/alerts.go
@@ -178,34 +178,7 @@ func checkStuckBouts(cfg *config.Config) alert.Check {
 	return alert.Check{Name: "Stuck Bouts", Level: alert.LevelOK, Message: "none"}
 }
 
-func checkFreeBoutPool(cfg *config.Config) alert.Check {
-	conn, err := db.Connect(cfg.DatabaseURL)
-	if err != nil {
-		return alert.Check{Name: "Free Bout Pool", Level: alert.LevelCrit, Message: "db unavailable"}
-	}
-	defer conn.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	today := time.Now().Format("2006-01-02")
-	var poolUsed, poolMax int64
-	err = conn.DB.QueryRowContext(ctx,
-		`SELECT COALESCE(used, 0), COALESCE(max_daily, 500) FROM free_bout_pool WHERE date = $1`, today).Scan(&poolUsed, &poolMax)
-	if err != nil {
-		poolMax = 500
-		poolUsed = 0
-	}
-
-	remaining := poolMax - poolUsed
-	pctRemaining := float64(remaining) / float64(poolMax) * 100
-
-	msg := fmt.Sprintf("%d/%d remaining (%.0f%%)", remaining, poolMax, pctRemaining)
-	if pctRemaining < 5 {
-		return alert.Check{Name: "Free Bout Pool", Level: alert.LevelCrit, Message: msg}
-	}
-	if pctRemaining < 15 {
-		return alert.Check{Name: "Free Bout Pool", Level: alert.LevelWarn, Message: msg}
-	}
-	return alert.Check{Name: "Free Bout Pool", Level: alert.LevelOK, Message: msg}
+func checkFreeBoutPool(_ *config.Config) alert.Check {
+	// Free bout pool table was removed (RD-022). Always OK.
+	return alert.Check{Name: "Free Bout Pool", Level: alert.LevelOK, Message: "removed"}
 }

--- a/pitctl/cmd/status.go
+++ b/pitctl/cmd/status.go
@@ -52,24 +52,6 @@ func RunStatus(cfg *config.Config) error {
 		fmt.Sprintf("  %-20s %s", theme.Muted.Render("BYOK"), enabledStr(cfg.IsEnabled("BYOK_ENABLED"))),
 	}
 
-	// Free bout pool.
-	var poolUsed, poolMax int64
-	today := time.Now().Format("2006-01-02")
-	err = conn.DB.QueryRowContext(ctx,
-		`SELECT COALESCE(used, 0), COALESCE(max_daily, 500) FROM free_bout_pool WHERE date = $1`, today).Scan(&poolUsed, &poolMax)
-	if err != nil {
-		// No pool entry for today — show full pool.
-		poolMax = 500
-		if m := cfg.Get("FREE_BOUT_POOL_MAX"); m != "" {
-			fmt.Sscanf(m, "%d", &poolMax)
-		}
-		poolUsed = 0
-	}
-	remaining := poolMax - poolUsed
-	lines = append(lines, fmt.Sprintf("  %-20s %s",
-		theme.Muted.Render("Free Bout Pool"),
-		theme.Value.Render(fmt.Sprintf("%s / %s remaining today", format.Num(remaining), format.Num(poolMax)))))
-
 	for _, l := range lines {
 		fmt.Println(l)
 	}
@@ -114,15 +96,13 @@ func RunStatus(cfg *config.Config) error {
 	}
 
 	// Agent stats.
-	var totalAgents, freeAgents, premiumAgents, customAgents, archivedAgents, flaggedAgents int64
+	var totalAgents, freeAgents, premiumAgents, customAgents, archivedAgents int64
 
 	queryWarn(ctx, conn, &totalAgents, `SELECT COUNT(*) FROM agents`)
 	queryWarn(ctx, conn, &freeAgents, `SELECT COUNT(*) FROM agents WHERE tier = 'free' AND NOT archived`)
 	queryWarn(ctx, conn, &premiumAgents, `SELECT COUNT(*) FROM agents WHERE tier = 'premium' AND NOT archived`)
 	queryWarn(ctx, conn, &customAgents, `SELECT COUNT(*) FROM agents WHERE tier = 'custom' AND NOT archived`)
 	queryWarn(ctx, conn, &archivedAgents, `SELECT COUNT(*) FROM agents WHERE archived`)
-	queryWarn(ctx, conn, &flaggedAgents,
-		`SELECT COUNT(DISTINCT agent_id) FROM agent_flags`)
 
 	agentRows := [][]string{
 		{"Total", format.Num(totalAgents)},
@@ -130,7 +110,6 @@ func RunStatus(cfg *config.Config) error {
 		{"Premium", format.Num(premiumAgents)},
 		{"Custom", format.Num(customAgents)},
 		{"Archived", format.Num(archivedAgents)},
-		{"Flagged", format.Num(flaggedAgents)},
 	}
 
 	// Render tables side by side.

--- a/pitctl/main.go
+++ b/pitctl/main.go
@@ -207,7 +207,6 @@ func runAgents(cfg *config.Config, args []string, confirmed bool) {
 	default:
 		opts := cmd.AgentsListOpts{
 			Archived: hasFlag(args, "--archived"),
-			Flagged:  hasFlag(args, "--flagged"),
 		}
 		if l := flagVal(args, "--limit"); l != "" {
 			opts.Limit, _ = strconv.Atoi(l)

--- a/scripts/reset-prod-data.ts
+++ b/scripts/reset-prod-data.ts
@@ -50,7 +50,6 @@ async function main() {
     'remix_events',
     'research_exports',
     'credit_transactions',
-    'free_bout_pool',
   ];
 
   console.log('Tables to TRUNCATE:');
@@ -114,9 +113,6 @@ async function main() {
 
   await db.execute(sql`TRUNCATE TABLE credit_transactions CASCADE`);
   console.log('  ✓ credit_transactions');
-
-  await db.execute(sql`TRUNCATE TABLE free_bout_pool CASCADE`);
-  console.log('  ✓ free_bout_pool');
 
   console.log('');
 


### PR DESCRIPTION
## Summary

Removes two dead database tables that have no runtime readers or writers. Reduces schema surface area for future reviewers.

## What changed

- **db/schema.ts** - Removed `freeBoutPool` and `agentFlags` table definitions
- **drizzle/0003_drop_dead_tables.sql** - Migration: `DROP TABLE IF EXISTS` for both tables
- **drizzle/schema.ts** - Removed generated entries for both tables
- **scripts/reset-prod-data.ts** - Removed free_bout_pool from truncation list
- **pitctl/** - Removed free_bout_pool queries and agent_flags references from Go CLI

## Technical decisions

- Migration uses `DROP TABLE IF EXISTS` for safety
- Migration not added to drizzle journal (follows established convention - hand-written migrations 0001, 0002 also not journaled)
- pitctl `checkFreeBoutPool` body replaced with immediate OK return (preserves function signature)

## Reviewed by

- DC-1 (Claude): PASS WITH FINDINGS - journal convention (established), stub retention (acceptable)

Gate: typecheck + lint + test = green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops dead tables `free_bout_pool` and `agent_flags` per RD-022 and RD-023. Reduces schema surface and removes unused `pitctl` paths.

- **Refactors**
  - Removed table definitions from `db/schema.ts` and generated entries from `drizzle/schema.ts`.
  - Deleted `agent_flags` and `free_bout_pool` queries from `pitctl` (agents list/inspect, alerts, status); removed `--flagged` option and “Flags” column.
  - Updated `db/README.md`, `docs/architecture.md`, and `scripts/reset-prod-data.ts` to drop references.

- **Migration**
  - Added `drizzle/0003_drop_dead_tables.sql` with `DROP TABLE IF EXISTS` for both tables.
  - Kept out of the Drizzle journal to match prior hand-written migrations.
  - Stubbed `checkFreeBoutPool` to return OK to preserve the interface.

<sup>Written for commit fd6fe07c31803ddbabba4e859e2ae8a563c98c2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed free bout pool management feature and related monitoring
  * Removed agent flagging and community moderation system
  * Updated database schema and migrations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->