### PR TITLE
refactor(agents): remove dead exports findAgentById, createAgentWithSlotCheck, AgentLineageEntry (RD-024)

### DIFF
--- a/lib/agent-detail.ts
+++ b/lib/agent-detail.ts
@@ -8,7 +8,7 @@ import { eq } from 'drizzle-orm';
 import type { AgentSnapshot } from '@/lib/agent-registry';
 import { findPresetAgent, presetToSnapshot, rowToSnapshot } from '@/lib/agent-mapper';
 
-export type AgentLineageEntry = {
+type AgentLineageEntry = {
   id: string;
   name: string;
 };

--- a/lib/agent-registry.ts
+++ b/lib/agent-registry.ts
@@ -127,16 +127,6 @@ export const registerPresetAgent = async (params: {
   return { agentId, manifest, promptHash, manifestHash };
 };
 
-export const findAgentById = async (agentId: string) => {
-  const db = requireDb();
-  const [row] = await db
-    .select()
-    .from(agents)
-    .where(and(eq(agents.id, agentId), eq(agents.archived, false)))
-    .limit(1);
-  return row;
-};
-
 // ---------------------------------------------------------------------------
 // Data Access Layer functions (extracted from app/ route handlers)
 // ---------------------------------------------------------------------------
@@ -181,42 +171,6 @@ export async function countActiveUserAgents(userId: string): Promise<number> {
       ),
     );
   return result?.count ?? 0;
-}
-
-/**
- * Atomically check user agent slot availability and insert a new agent.
- *
- * Wraps the count query and insert in a transaction with FOR UPDATE
- * semantics to prevent race conditions where two concurrent requests
- * both pass the slot check before either insert completes (RD-017).
- *
- * TODO(RD-017): Wire into POST /api/agents route handler. Currently
- * the route uses separate countActiveUserAgents + insertAgent calls.
- * This function is tested and ready for integration.
- */
-export async function createAgentWithSlotCheck(
-  userId: string,
-  values: AgentInsertValues,
-  canCreateFn: (userId: string, count: number) => Promise<{ allowed: boolean; reason?: string }>,
-): Promise<void> {
-  const db = requireDb();
-  await db.transaction(async (tx) => {
-    const [countResult] = await tx
-      .select({ count: sql<number>`count(*)::int` })
-      .from(agents)
-      .where(
-        and(
-          eq(agents.ownerId, userId),
-          eq(agents.archived, false),
-        ),
-      );
-    const currentCount = countResult?.count ?? 0;
-    const slotCheck = await canCreateFn(userId, currentCount);
-    if (!slotCheck.allowed) {
-      throw new Error(slotCheck.reason ?? 'Agent slot limit reached.');
-    }
-    await tx.insert(agents).values(values);
-  });
 }
 
 /** Insert an agent row directly (no slot check). Used by seed-agents. */

--- a/tests/unit/agent-registry-dal.test.ts
+++ b/tests/unit/agent-registry-dal.test.ts
@@ -34,7 +34,6 @@ import {
   archiveAgent,
   restoreAgent,
   countActiveUserAgents,
-  createAgentWithSlotCheck,
   insertAgent,
   updateAgentAttestation,
 } from '@/lib/agent-registry';
@@ -151,48 +150,4 @@ describe('lib/agent-registry DAL functions', () => {
     });
   });
 
-  // ================================================================
-  // createAgentWithSlotCheck
-  // ================================================================
-  describe('createAgentWithSlotCheck', () => {
-    const baseValues = {
-      id: 'agent-slot',
-      name: 'Slot Agent',
-      systemPrompt: 'Be witty.',
-      presetId: null,
-      tier: 'custom' as const,
-      model: null,
-      responseLength: 'short',
-      responseFormat: 'spaced',
-      promptHash: 'hash1',
-      manifestHash: 'hash2',
-    };
-
-    it('inserts agent when slot check allows', async () => {
-      const canCreate = vi.fn().mockResolvedValue({ allowed: true });
-
-      await createAgentWithSlotCheck('user-1', baseValues, canCreate);
-
-      expect(mockDb.transaction).toHaveBeenCalledOnce();
-      expect(canCreate).toHaveBeenCalledWith('user-1', 0);
-      expect(mockDb.insert).toHaveBeenCalled();
-    });
-
-    it('throws when slot check denies', async () => {
-      const canCreate = vi.fn().mockResolvedValue({
-        allowed: false,
-        reason: 'Agent limit reached.',
-      });
-
-      await expect(
-        createAgentWithSlotCheck('user-1', baseValues, canCreate),
-      ).rejects.toThrow('Agent limit reached.');
-    });
-
-    it('uses transaction for atomicity', async () => {
-      const canCreate = vi.fn().mockResolvedValue({ allowed: true });
-      await createAgentWithSlotCheck('user-1', baseValues, canCreate);
-      expect(mockDb.transaction).toHaveBeenCalledOnce();
-    });
-  });
 });

--- a/tests/unit/agent-registry.test.ts
+++ b/tests/unit/agent-registry.test.ts
@@ -123,16 +123,6 @@ const setupSelect = (result: unknown[]) => {
   }));
 };
 
-const setupSelectWithLimit = (result: unknown[]) => {
-  mockDb.select.mockImplementation(() => ({
-    from: () => ({
-      where: () => ({
-        limit: async () => result,
-      }),
-    }),
-  }));
-};
-
 const loadRegistry = async () => import('@/lib/agent-registry');
 
 describe('agent-registry', () => {
@@ -278,26 +268,4 @@ describe('agent-registry', () => {
     });
   });
 
-  describe('findAgentById', () => {
-    it('returns agent when found (non-archived)', async () => {
-      const agentRow = {
-        id: 'preset:roast-battle:judge',
-        name: 'The Judge',
-        archived: false,
-      };
-      setupSelectWithLimit([agentRow]);
-
-      const { findAgentById } = await loadRegistry();
-      const result = await findAgentById('preset:roast-battle:judge');
-      expect(result).toEqual(agentRow);
-    });
-
-    it('returns undefined when not found', async () => {
-      setupSelectWithLimit([]);
-
-      const { findAgentById } = await loadRegistry();
-      const result = await findAgentById('nonexistent');
-      expect(result).toBeUndefined();
-    });
-  });
 });


### PR DESCRIPTION
## Summary

Removes 3 dead exports from the agent cluster that have zero consumers outside their defining files and tests.

## What changed

- **lib/agent-registry.ts** - Removed `findAgentById` (0 consumers) and `createAgentWithSlotCheck` (RD-017 prep, never wired)
- **lib/agent-detail.ts** - Un-exported `AgentLineageEntry` type (0 external consumers, used internally)
- **tests/unit/agent-registry.test.ts** - Removed `findAgentById` test block
- **tests/unit/agent-registry-dal.test.ts** - Removed `createAgentWithSlotCheck` test block

Net: -124 lines of dead code.

## Reviewed by

- DC-1 (Claude): PASS WITH FINDINGS - stale doc reference (minor)

Gate: typecheck + lint + test = green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes dead exports from the agents module to shrink the public API and clean up related tests. Addresses RD-024.

- **Refactors**
  - Removed `findAgentById` from `lib/agent-registry.ts` and its tests (0 consumers).
  - Removed `createAgentWithSlotCheck` from `lib/agent-registry.ts` and its tests (RD-017 prep, never wired).
  - Made `AgentLineageEntry` internal in `lib/agent-detail.ts`.
  - Deleted unused test helper `setupSelectWithLimit`.
  - Net change: -124 LOC.

<sup>Written for commit 0ca51d3120dd7150e356d9edaa8cb126a1753a20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

