### PR TITLE
feat(run): M1.1 - tasks table, branded type, domain module

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -482,3 +482,34 @@ export const researchExports = pgTable('research_exports', {
   agentCount: integer('agent_count').notNull(),
   payload: jsonb('payload').$type<Record<string, unknown>>().notNull(),
 });
+
+// ---------------------------------------------------------------------------
+// Run model -- tasks (M1.1)
+// ---------------------------------------------------------------------------
+// Coexists alongside the bout model. No FK between runs and bouts.
+// See docs/specs/phase-1-run-model.md for design decisions.
+
+/** Expected output shape for a task. */
+export const expectedOutputShape = pgEnum('expected_output_shape', [
+  'text', 'json', 'code',
+]);
+
+export const tasks = pgTable('tasks', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  name: varchar('name', { length: 256 }).notNull(),
+  description: text('description'),
+  prompt: text('prompt').notNull(),
+  constraints: jsonb('constraints').$type<string[]>(),
+  expectedOutputShape: expectedOutputShape('expected_output_shape'),
+  acceptanceCriteria: jsonb('acceptance_criteria').$type<string[]>(),
+  domain: varchar('domain', { length: 64 }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  domainIdx: index('tasks_domain_idx').on(table.domain),
+  createdAtIdx: index('tasks_created_at_idx').on(table.createdAt),
+}));

--- a/drizzle/0004_m1.1-tasks.sql
+++ b/drizzle/0004_m1.1-tasks.sql
@@ -1,0 +1,24 @@
+-- M1.1: tasks table for the run model.
+-- Coexists alongside the bout model (no FK between runs and bouts).
+
+DO $$ BEGIN
+  CREATE TYPE "public"."expected_output_shape" AS ENUM('text', 'json', 'code');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "tasks" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "name" varchar(256) NOT NULL,
+  "description" text,
+  "prompt" text NOT NULL,
+  "constraints" jsonb,
+  "expected_output_shape" "expected_output_shape",
+  "acceptance_criteria" jsonb,
+  "domain" varchar(64),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "tasks_domain_idx" ON "tasks" USING btree ("domain");
+CREATE INDEX IF NOT EXISTS "tasks_created_at_idx" ON "tasks" USING btree ("created_at");

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -184,3 +184,19 @@ export const agentCreateSchema = z.object({
   clientManifestHash: z.string().optional(),
 });
 export type AgentCreateBody = z.infer<typeof agentCreateSchema>;
+
+// ---------------------------------------------------------------------------
+// Run model -- tasks (M1.1)
+// ---------------------------------------------------------------------------
+
+/** POST /api/tasks (future M1.5) -- validated at domain layer for now. */
+export const createTaskSchema = z.object({
+  name: z.string().min(1, 'Task name is required.').max(256, 'Task name must be 256 characters or fewer.'),
+  description: z.string().optional(),
+  prompt: z.string().min(1, 'Task prompt is required.'),
+  constraints: z.array(z.string()).optional(),
+  expectedOutputShape: z.enum(['text', 'json', 'code']).optional(),
+  acceptanceCriteria: z.array(z.string()).optional(),
+  domain: z.string().max(64, 'Domain must be 64 characters or fewer.').optional(),
+});
+export type CreateTaskBody = z.infer<typeof createTaskSchema>;

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -34,8 +34,11 @@ export type UserId = Brand<string, 'UserId'>;
 /** Agent identifier — preset composite or custom nanoid. */
 export type AgentId = Brand<string, 'AgentId'>;
 
-/** Micro-credit amount — 1 credit = 100 micro. */
+/** Micro-credit amount -- 1 credit = 100 micro. */
 export type MicroCredits = Brand<number, 'MicroCredits'>;
+
+/** Task identifier -- 21-char nanoid (M1.1). */
+export type TaskId = Brand<string, 'TaskId'>;
 
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
@@ -67,6 +70,11 @@ export function asAgentId(raw: string): AgentId {
 /** Brand a raw number as MicroCredits. */
 export function asMicroCredits(raw: number): MicroCredits {
   return raw as MicroCredits;
+}
+
+/** Brand a raw string as a TaskId. */
+export function asTaskId(raw: string): TaskId {
+  return raw as TaskId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -1,0 +1,4 @@
+// Barrel export for the run domain module.
+
+export { createTask, getTask, listTasks } from './tasks';
+export type { Task, NewTask, ListTasksOptions } from './types';

--- a/lib/run/tasks.ts
+++ b/lib/run/tasks.ts
@@ -1,0 +1,77 @@
+// Task CRUD -- domain module for the tasks table (M1.1).
+//
+// Pure persistence layer. Validates via Zod at the boundary,
+// persists via Drizzle. No HTTP awareness.
+
+import { eq, desc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { tasks } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asTaskId, type TaskId } from '@/lib/domain-ids';
+import { createTaskSchema, type CreateTaskBody } from '@/lib/api-schemas';
+import type { Task, ListTasksOptions } from './types';
+
+/** Create a new task. Validates input, generates nanoid, persists. */
+export async function createTask(
+  db: DbOrTx,
+  input: CreateTaskBody,
+): Promise<Task> {
+  const validated = createTaskSchema.parse(input);
+  const id = asTaskId(nanoid());
+
+  const [task] = await db
+    .insert(tasks)
+    .values({
+      id,
+      name: validated.name,
+      description: validated.description ?? null,
+      prompt: validated.prompt,
+      constraints: validated.constraints ?? null,
+      expectedOutputShape: validated.expectedOutputShape ?? null,
+      acceptanceCriteria: validated.acceptanceCriteria ?? null,
+      domain: validated.domain ?? null,
+    })
+    .returning();
+
+  return task;
+}
+
+/** Retrieve a single task by ID. Returns null if not found. */
+export async function getTask(
+  db: DbOrTx,
+  id: TaskId,
+): Promise<Task | null> {
+  const [task] = await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.id, id))
+    .limit(1);
+
+  return task ?? null;
+}
+
+/** List tasks with optional domain filter and pagination. */
+export async function listTasks(
+  db: DbOrTx,
+  opts: ListTasksOptions = {},
+): Promise<Task[]> {
+  const { domain, limit = 50, offset = 0 } = opts;
+
+  if (domain) {
+    return db
+      .select()
+      .from(tasks)
+      .where(eq(tasks.domain, domain))
+      .orderBy(desc(tasks.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  return db
+    .select()
+    .from(tasks)
+    .orderBy(desc(tasks.createdAt))
+    .limit(limit)
+    .offset(offset);
+}

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -1,0 +1,21 @@
+// Shared types and enums for the run model.
+//
+// This module defines types used across run domain modules.
+// Schema-derived types (from Drizzle InferSelect) are preferred
+// over manual type definitions where possible.
+
+import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
+import type { tasks } from '@/db/schema';
+
+/** A task as stored in the database. */
+export type Task = InferSelectModel<typeof tasks>;
+
+/** Input shape for creating a task (Drizzle insert). */
+export type NewTask = InferInsertModel<typeof tasks>;
+
+/** Options for listing tasks with filtering and pagination. */
+export type ListTasksOptions = {
+  domain?: string;
+  limit?: number;
+  offset?: number;
+};

--- a/tests/unit/run/tasks.test.ts
+++ b/tests/unit/run/tasks.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning, mockSelectLimit } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({
+            offset: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockSelectLimit };
+});
+
+vi.mock('@/db/schema', () => ({
+  tasks: {
+    id: 'id',
+    name: 'name',
+    domain: 'domain',
+    createdAt: 'created_at',
+  },
+  expectedOutputShape: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  desc: vi.fn((col: unknown) => ({ _desc: col })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'test-nanoid-00000000'),
+}));
+
+import { createTask, getTask, listTasks } from '@/lib/run/tasks';
+import type { DbOrTx } from '@/db';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validInput = {
+  name: 'Evaluate CV bullet',
+  prompt: 'Score this CV bullet against the role requirement.',
+  domain: 'job-application',
+};
+
+const fullInput = {
+  name: 'Full task',
+  description: 'A thorough task definition',
+  prompt: 'Do the thing.',
+  constraints: ['No hallucination', 'Stay on topic'],
+  expectedOutputShape: 'json' as const,
+  acceptanceCriteria: ['Correct answer', 'Well structured'],
+  domain: 'evaluation',
+};
+
+const fakeTask = {
+  id: 'test-nanoid-00000000',
+  name: 'Evaluate CV bullet',
+  description: null,
+  prompt: 'Score this CV bullet against the role requirement.',
+  constraints: null,
+  expectedOutputShape: null,
+  acceptanceCriteria: null,
+  domain: 'job-application',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  const mockOffset = vi.fn().mockResolvedValue([]);
+  const mockLimitList = vi.fn().mockReturnValue({ offset: mockOffset });
+  const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimitList });
+  const mockWhere = vi.fn().mockReturnValue({ limit: mockSelectLimit });
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+    orderBy: mockOrderBy,
+  });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+
+  return { mockFrom, mockWhere, mockOrderBy, mockLimitList, mockOffset };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/tasks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeTask]);
+    mockSelectLimit.mockResolvedValue([]);
+  });
+
+  // ── createTask ──────────────────────────────────────────────────────────
+
+  describe('createTask', () => {
+    it('persists and returns a task with generated id', async () => {
+      const result = await createTask(mockDb as unknown as DbOrTx, validInput);
+      expect(result).toEqual(fakeTask);
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes all fields including optional ones', async () => {
+      const fullTask = { ...fakeTask, ...fullInput, id: 'test-nanoid-00000000' };
+      mockReturning.mockResolvedValue([fullTask]);
+
+      const result = await createTask(mockDb as unknown as DbOrTx, fullInput);
+      expect(result.name).toBe('Full task');
+      expect(result.constraints).toEqual(['No hallucination', 'Stay on topic']);
+    });
+
+    it('rejects empty name', async () => {
+      await expect(
+        createTask(mockDb as unknown as DbOrTx, { ...validInput, name: '' }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects empty prompt', async () => {
+      await expect(
+        createTask(mockDb as unknown as DbOrTx, { ...validInput, prompt: '' }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects name over 256 characters', async () => {
+      await expect(
+        createTask(mockDb as unknown as DbOrTx, {
+          ...validInput,
+          name: 'x'.repeat(257),
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── getTask ─────────────────────────────────────────────────────────────
+
+  describe('getTask', () => {
+    it('returns null for missing id', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+      const result = await getTask(
+        mockDb as unknown as DbOrTx,
+        'nonexistent' as any,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns the task when found', async () => {
+      mockSelectLimit.mockResolvedValue([fakeTask]);
+      const result = await getTask(
+        mockDb as unknown as DbOrTx,
+        fakeTask.id as any,
+      );
+      expect(result).toEqual(fakeTask);
+    });
+  });
+
+  // ── listTasks ───────────────────────────────────────────────────────────
+
+  describe('listTasks', () => {
+    it('returns empty array when no tasks exist', async () => {
+      const result = await listTasks(mockDb as unknown as DbOrTx);
+      expect(result).toEqual([]);
+    });
+
+    it('calls with default limit and offset', async () => {
+      await listTasks(mockDb as unknown as DbOrTx);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes domain filter when specified', async () => {
+      const { mockFrom } = resetMockChains();
+
+      // For domain-filtered queries, the chain goes:
+      // select().from(tasks).where(eq(domain, val)).orderBy().limit().offset()
+      const mockOffset = vi.fn().mockResolvedValue([fakeTask]);
+      const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockWhere = vi.fn().mockReturnValue({
+        orderBy: mockOrderBy,
+      });
+      mockFrom.mockReturnValue({
+        where: mockWhere,
+        orderBy: mockOrderBy,
+      });
+
+      const result = await listTasks(mockDb as unknown as DbOrTx, {
+        domain: 'job-application',
+      });
+
+      // The domain filter should have been applied
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## What changed

First milestone of Phase 1 (Run Model). Adds the tasks table as the foundation for structured agent evaluation runs.

### Schema
- `tasks` table: varchar(21) nanoid PK, name, prompt, constraints (jsonb), expectedOutputShape (enum: text/json/code), acceptanceCriteria (jsonb), domain, timestamps (with timezone)
- Indexes on domain and created_at
- Drizzle migration: `drizzle/0004_m1.1-tasks.sql`

### Domain layer
- `TaskId` branded type + `asTaskId` constructor in `lib/domain-ids.ts`
- `createTaskSchema` Zod validation in `lib/api-schemas.ts`
- `lib/run/` directory: types.ts, tasks.ts (createTask, getTask, listTasks), index.ts barrel

### Why
Everything else in the run model (runs, contestants, traces, evaluation, scoring) operates on tasks. Without a task definition, there is nothing to run.

### What was tested
- 10 new unit tests: createTask (persist, optional fields, validation for empty name/prompt/name length), getTask (null for missing, return on found), listTasks (empty, default params, domain filter)
- All 1513 existing tests pass (137 files, 0 failures)

### Scope boundary
- Tasks table only -- runs, contestants, traces are M1.2-M1.4
- Domain module only -- no HTTP routes (deferred to M1.5)
- Coexists alongside existing bout tables (no FK between runs and bouts)

### Follow-up
- M1.2: runs table and run lifecycle
- M1.3: contestants table
- M1.4: execution engine with traces
- M1.5: API routes

Closes #100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements M1.1 of the Run model (issue #100) by adding the `tasks` table and a domain module for creating, fetching, and listing tasks. This lays the groundwork for structured agent evaluation runs; no HTTP routes yet.

- **New Features**
  - `tasks` table: `id` (nanoid 21), `name`, `description`, `prompt`, `constraints` (jsonb), `expected_output_shape` (enum: text/json/code), `acceptance_criteria` (jsonb), `domain`, timestamps; indexes on `domain` and `created_at`.
  - Domain layer: `TaskId` branded type + `asTaskId`, Zod `createTaskSchema`, and `createTask`, `getTask`, `listTasks` in `lib/run/` (barrel export in `lib/run/index.ts`).

- **Migration**
  - Adds `drizzle/0004_m1.1-tasks.sql` to create enum, table, and indexes.
  - Coexists with the bout model; no foreign keys. Future phases will add runs/contestants/traces.

<sup>Written for commit 5b6adb85aefaebcaba90e3bb3f62a54aa8841386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced comprehensive task management system with create, retrieve, and list operations.
  * Tasks support domain-based filtering and pagination capabilities.
  * Added configurable output shape specification (text, json, or code format).
  * Tasks include acceptance criteria and constraint definitions.

* **Chores**
  * Added database schema and migration for task storage with audit timestamps.

* **Tests**
  * Added unit tests covering task creation, retrieval, and listing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->