### PR TITLE
feat(run): M1.2 - runs table, status enum, domain module

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -513,3 +513,35 @@ export const tasks = pgTable('tasks', {
   domainIdx: index('tasks_domain_idx').on(table.domain),
   createdAtIdx: index('tasks_created_at_idx').on(table.createdAt),
 }));
+
+// ---------------------------------------------------------------------------
+// Run model -- runs (M1.2)
+// ---------------------------------------------------------------------------
+
+export const runStatus = pgEnum('run_status', [
+  'pending', 'running', 'completed', 'failed',
+]);
+
+export const runs = pgTable('runs', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  taskId: varchar('task_id', { length: 21 })
+    .notNull()
+    .references(() => tasks.id),
+  status: runStatus('status').default('pending').notNull(),
+  ownerId: varchar('owner_id', { length: 128 })
+    .references(() => users.id, { onDelete: 'set null' }),
+  startedAt: timestamp('started_at', { withTimezone: true }),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  error: text('error'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  taskIdIdx: index('runs_task_id_idx').on(table.taskId),
+  ownerIdIdx: index('runs_owner_id_idx').on(table.ownerId),
+  statusCreatedIdx: index('runs_status_created_idx').on(table.status, table.createdAt),
+}));

--- a/drizzle/0005_m1.2-runs.sql
+++ b/drizzle/0005_m1.2-runs.sql
@@ -1,0 +1,25 @@
+-- M1.2: runs table for the run model.
+-- Tracks execution lifecycle: pending -> running -> completed | failed.
+
+DO $$ BEGIN
+  CREATE TYPE "public"."run_status" AS ENUM('pending', 'running', 'completed', 'failed');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "runs" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "task_id" varchar(21) NOT NULL REFERENCES "tasks"("id"),
+  "status" "run_status" DEFAULT 'pending' NOT NULL,
+  "owner_id" varchar(128) REFERENCES "users"("id") ON DELETE SET NULL,
+  "started_at" timestamp with time zone,
+  "completed_at" timestamp with time zone,
+  "error" text,
+  "metadata" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "runs_task_id_idx" ON "runs" USING btree ("task_id");
+CREATE INDEX IF NOT EXISTS "runs_owner_id_idx" ON "runs" USING btree ("owner_id");
+CREATE INDEX IF NOT EXISTS "runs_status_created_idx" ON "runs" USING btree ("status", "created_at");

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -40,6 +40,9 @@ export type MicroCredits = Brand<number, 'MicroCredits'>;
 /** Task identifier -- 21-char nanoid (M1.1). */
 export type TaskId = Brand<string, 'TaskId'>;
 
+/** Run identifier -- 21-char nanoid (M1.2). */
+export type RunId = Brand<string, 'RunId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -75,6 +78,11 @@ export function asMicroCredits(raw: number): MicroCredits {
 /** Brand a raw string as a TaskId. */
 export function asTaskId(raw: string): TaskId {
   return raw as TaskId;
+}
+
+/** Brand a raw string as a RunId. */
+export function asRunId(raw: string): RunId {
+  return raw as RunId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -1,4 +1,7 @@
 // Barrel export for the run domain module.
 
 export { createTask, getTask, listTasks } from './tasks';
+export { createRun, getRun, listRuns } from './runs';
 export type { Task, NewTask, ListTasksOptions } from './types';
+export type { Run, NewRun, RunStatus, ListRunsOptions } from './types';
+export type { CreateRunInput } from './runs';

--- a/lib/run/runs.ts
+++ b/lib/run/runs.ts
@@ -1,0 +1,84 @@
+// Run CRUD -- domain module for the runs table (M1.2).
+//
+// Creation and query only. Execution logic is M1.4.
+// Pure persistence layer. No HTTP awareness.
+
+import { eq, and, desc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { runs } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asRunId, type RunId } from '@/lib/domain-ids';
+import type { TaskId } from '@/lib/domain-ids';
+import type { Run, RunStatus, ListRunsOptions } from './types';
+
+/** Input for creating a new run. */
+export type CreateRunInput = {
+  taskId: TaskId;
+  ownerId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** Create a new run in pending status. */
+export async function createRun(
+  db: DbOrTx,
+  input: CreateRunInput,
+): Promise<Run> {
+  const id = asRunId(nanoid());
+
+  const [run] = await db
+    .insert(runs)
+    .values({
+      id,
+      taskId: input.taskId,
+      ownerId: input.ownerId ?? null,
+      metadata: input.metadata ?? null,
+    })
+    .returning();
+
+  return run;
+}
+
+/** Retrieve a single run by ID. Returns null if not found. */
+export async function getRun(
+  db: DbOrTx,
+  id: RunId,
+): Promise<Run | null> {
+  const [run] = await db
+    .select()
+    .from(runs)
+    .where(eq(runs.id, id))
+    .limit(1);
+
+  return run ?? null;
+}
+
+/** List runs with optional filters and pagination. */
+export async function listRuns(
+  db: DbOrTx,
+  opts: ListRunsOptions = {},
+): Promise<Run[]> {
+  const { taskId, status, ownerId, limit = 50, offset = 0 } = opts;
+
+  const conditions = [];
+  if (taskId) conditions.push(eq(runs.taskId, taskId));
+  if (status) conditions.push(eq(runs.status, status));
+  if (ownerId) conditions.push(eq(runs.ownerId, ownerId));
+
+  if (conditions.length > 0) {
+    return db
+      .select()
+      .from(runs)
+      .where(and(...conditions))
+      .orderBy(desc(runs.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  return db
+    .select()
+    .from(runs)
+    .orderBy(desc(runs.createdAt))
+    .limit(limit)
+    .offset(offset);
+}

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -5,7 +5,7 @@
 // over manual type definitions where possible.
 
 import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import type { tasks } from '@/db/schema';
+import type { tasks, runs } from '@/db/schema';
 
 /** A task as stored in the database. */
 export type Task = InferSelectModel<typeof tasks>;
@@ -16,6 +16,24 @@ export type NewTask = InferInsertModel<typeof tasks>;
 /** Options for listing tasks with filtering and pagination. */
 export type ListTasksOptions = {
   domain?: string;
+  limit?: number;
+  offset?: number;
+};
+
+/** A run as stored in the database. */
+export type Run = InferSelectModel<typeof runs>;
+
+/** Input shape for creating a run (Drizzle insert). */
+export type NewRun = InferInsertModel<typeof runs>;
+
+/** Run status enum values. */
+export type RunStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+/** Options for listing runs with filtering and pagination. */
+export type ListRunsOptions = {
+  taskId?: string;
+  status?: RunStatus;
+  ownerId?: string;
   limit?: number;
   offset?: number;
 };

--- a/tests/unit/run/runs.test.ts
+++ b/tests/unit/run/runs.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning, mockSelectLimit } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({
+            offset: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockSelectLimit };
+});
+
+vi.mock('@/db/schema', () => ({
+  runs: {
+    id: 'id',
+    taskId: 'task_id',
+    status: 'status',
+    ownerId: 'owner_id',
+    createdAt: 'created_at',
+  },
+  runStatus: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  desc: vi.fn((col: unknown) => ({ _desc: col })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'run-nanoid-000000000'),
+}));
+
+import { createRun, getRun, listRuns } from '@/lib/run/runs';
+import type { DbOrTx } from '@/db';
+import type { TaskId } from '@/lib/domain-ids';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeTaskId = 'task-abc-000000000000' as TaskId;
+
+const fakeRun = {
+  id: 'run-nanoid-000000000',
+  taskId: fakeTaskId,
+  status: 'pending',
+  ownerId: null,
+  startedAt: null,
+  completedAt: null,
+  error: null,
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  const mockOffset = vi.fn().mockResolvedValue([]);
+  const mockLimitList = vi.fn().mockReturnValue({ offset: mockOffset });
+  const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimitList });
+  const mockWhere = vi.fn().mockReturnValue({
+    limit: mockSelectLimit,
+    orderBy: mockOrderBy,
+  });
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+    orderBy: mockOrderBy,
+  });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+
+  return { mockFrom, mockWhere, mockOrderBy, mockLimitList, mockOffset };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeRun]);
+    mockSelectLimit.mockResolvedValue([]);
+  });
+
+  // ── createRun ───────────────────────────────────────────────────────────
+
+  describe('createRun', () => {
+    it('persists a run with pending status and generated id', async () => {
+      const result = await createRun(mockDb as unknown as DbOrTx, {
+        taskId: fakeTaskId,
+      });
+      expect(result).toEqual(fakeRun);
+      expect(result.status).toBe('pending');
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts optional ownerId', async () => {
+      const runWithOwner = { ...fakeRun, ownerId: 'user-123' };
+      mockReturning.mockResolvedValue([runWithOwner]);
+
+      const result = await createRun(mockDb as unknown as DbOrTx, {
+        taskId: fakeTaskId,
+        ownerId: 'user-123',
+      });
+      expect(result.ownerId).toBe('user-123');
+    });
+
+    it('accepts optional metadata', async () => {
+      const meta = { source: 'test', priority: 1 };
+      const runWithMeta = { ...fakeRun, metadata: meta };
+      mockReturning.mockResolvedValue([runWithMeta]);
+
+      const result = await createRun(mockDb as unknown as DbOrTx, {
+        taskId: fakeTaskId,
+        metadata: meta,
+      });
+      expect(result.metadata).toEqual(meta);
+    });
+  });
+
+  // ── getRun ──────────────────────────────────────────────────────────────
+
+  describe('getRun', () => {
+    it('returns null for missing id', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+      const result = await getRun(
+        mockDb as unknown as DbOrTx,
+        'nonexistent' as any,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns the run when found', async () => {
+      mockSelectLimit.mockResolvedValue([fakeRun]);
+      const result = await getRun(
+        mockDb as unknown as DbOrTx,
+        fakeRun.id as any,
+      );
+      expect(result).toEqual(fakeRun);
+    });
+  });
+
+  // ── listRuns ────────────────────────────────────────────────────────────
+
+  describe('listRuns', () => {
+    it('returns empty array when no runs exist', async () => {
+      const result = await listRuns(mockDb as unknown as DbOrTx);
+      expect(result).toEqual([]);
+    });
+
+    it('calls select with default limit and offset', async () => {
+      await listRuns(mockDb as unknown as DbOrTx);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes status filter when specified', async () => {
+      const { mockWhere } = resetMockChains();
+
+      // For filtered queries with conditions, chain goes:
+      // select().from().where(and(...)).orderBy().limit().offset()
+      const mockOffset = vi.fn().mockResolvedValue([fakeRun]);
+      const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      mockWhere.mockReturnValue({
+        orderBy: mockOrderBy,
+      });
+
+      await listRuns(mockDb as unknown as DbOrTx, { status: 'pending' });
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Second milestone of Phase 1 (Run Model). Adds the runs table -- the central entity that binds a task to contestants and tracks execution lifecycle.

Depends on: #101 (M1.1 - tasks table)

### Schema
- `run_status` enum: pending, running, completed, failed
- `runs` table: id (varchar 21 nanoid PK), taskId (FK to tasks), status (default pending), ownerId (FK to users, on delete set null), startedAt, completedAt, error, metadata (jsonb), timestamps
- Indexes on taskId, ownerId, status+createdAt
- Migration: `drizzle/0005_m1.2-runs.sql`

### Domain layer
- `RunId` branded type + `asRunId` constructor
- `createRun`, `getRun`, `listRuns` in `lib/run/runs.ts`
- `listRuns` supports composable filters (taskId, status, ownerId) via `and()`
- Types: Run, NewRun, RunStatus, ListRunsOptions

### What was tested
- 8 new unit tests: createRun (pending default, ownerId, metadata), getRun (null/found), listRuns (empty, defaults, status filter)
- All 1521 tests pass (138 files, 0 failures)

### Scope boundary
- Creation and query only -- no execution logic (M1.4)
- No API routes (M1.5)

### Follow-up
- M1.3: contestants table
- M1.4: execution engine with traces
- M1.5: API routes

Closes #102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `runs` model and `run_status` enum to track task execution (pending → running → completed/failed) and link runs to tasks and owners. Includes domain APIs to create and query runs with simple filters.

- **New Features**
  - Schema: `runs` table (id, taskId FK, status default pending, ownerId nullable, startedAt/completedAt, error, metadata, timestamps) and indexes on taskId, ownerId, status+createdAt.
  - Domain: `RunId` type; `createRun`, `getRun`, `listRuns` with filters (taskId, status, ownerId); types `Run`, `NewRun`, `RunStatus`, `ListRunsOptions`.
  - Tests: 8 unit tests covering create (defaults, ownerId, metadata), get (null/found), list (empty, defaults, status).
  - Scope: creation and query only; no execution logic or API routes.

- **Migration**
  - Run database migrations to apply `drizzle/0005_m1.2-runs.sql`.

<sup>Written for commit 637cf0b7880af0afdd231a48b6b177677265f45f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

