### PR TITLE
feat(run): M1.3 - contestants table, Zod schema, domain module

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -27,6 +27,7 @@ import {
   boolean,
   integer,
   foreignKey,
+  real,
 } from 'drizzle-orm/pg-core';
 
 export type TranscriptEntry = {
@@ -545,3 +546,37 @@ export const runs = pgTable('runs', {
   ownerIdIdx: index('runs_owner_id_idx').on(table.ownerId),
   statusCreatedIdx: index('runs_status_created_idx').on(table.status, table.createdAt),
 }));
+
+// ---------------------------------------------------------------------------
+// Run model -- contestants (M1.3)
+// ---------------------------------------------------------------------------
+
+export const contestants = pgTable('contestants', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  runId: varchar('run_id', { length: 21 })
+    .notNull()
+    .references(() => runs.id, { onDelete: 'cascade' }),
+  label: varchar('label', { length: 128 }).notNull(),
+  model: varchar('model', { length: 128 }).notNull(),
+  provider: varchar('provider', { length: 64 }),
+  systemPrompt: text('system_prompt'),
+  temperature: real('temperature'),
+  maxTokens: integer('max_tokens'),
+  toolAccess: jsonb('tool_access').$type<string[]>(),
+  contextBundle: jsonb('context_bundle').$type<ContextBundleInput>(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  runIdIdx: index('contestants_run_id_idx').on(table.runId),
+}));
+
+/** Inline context documents for MVP. Post-MVP context layer (Phase 4)
+ *  will introduce proper context bundle tables with provenance. */
+export type ContextBundleInput = {
+  documents?: Array<{
+    label: string;
+    content: string;
+    source?: string;
+  }>;
+};

--- a/drizzle/0006_m1.3-contestants.sql
+++ b/drizzle/0006_m1.3-contestants.sql
@@ -1,0 +1,19 @@
+-- M1.3: contestants table for the run model.
+-- Agent configurations that compete within a run.
+-- Cascade delete: deleting a run deletes its contestants.
+
+CREATE TABLE IF NOT EXISTS "contestants" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "run_id" varchar(21) NOT NULL REFERENCES "runs"("id") ON DELETE CASCADE,
+  "label" varchar(128) NOT NULL,
+  "model" varchar(128) NOT NULL,
+  "provider" varchar(64),
+  "system_prompt" text,
+  "temperature" real,
+  "max_tokens" integer,
+  "tool_access" jsonb,
+  "context_bundle" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "contestants_run_id_idx" ON "contestants" USING btree ("run_id");

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -200,3 +200,26 @@ export const createTaskSchema = z.object({
   domain: z.string().max(64, 'Domain must be 64 characters or fewer.').optional(),
 });
 export type CreateTaskBody = z.infer<typeof createTaskSchema>;
+
+// ---------------------------------------------------------------------------
+// Run model -- contestants (M1.3)
+// ---------------------------------------------------------------------------
+
+/** Validation for adding a contestant to a run. */
+export const addContestantSchema = z.object({
+  label: z.string().min(1, 'Contestant label is required.').max(128, 'Label must be 128 characters or fewer.'),
+  model: z.string().min(1, 'Model is required.').max(128, 'Model must be 128 characters or fewer.'),
+  provider: z.enum(['openai', 'anthropic', 'google', 'xai']).optional(),
+  systemPrompt: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  maxTokens: z.number().int().positive().optional(),
+  toolAccess: z.array(z.string()).optional(),
+  contextBundle: z.object({
+    documents: z.array(z.object({
+      label: z.string(),
+      content: z.string(),
+      source: z.string().optional(),
+    })).optional(),
+  }).optional(),
+});
+export type AddContestantBody = z.infer<typeof addContestantSchema>;

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -43,6 +43,9 @@ export type TaskId = Brand<string, 'TaskId'>;
 /** Run identifier -- 21-char nanoid (M1.2). */
 export type RunId = Brand<string, 'RunId'>;
 
+/** Contestant identifier -- 21-char nanoid (M1.3). */
+export type ContestantId = Brand<string, 'ContestantId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -83,6 +86,11 @@ export function asTaskId(raw: string): TaskId {
 /** Brand a raw string as a RunId. */
 export function asRunId(raw: string): RunId {
   return raw as RunId;
+}
+
+/** Brand a raw string as a ContestantId. */
+export function asContestantId(raw: string): ContestantId {
+  return raw as ContestantId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/run/contestants.ts
+++ b/lib/run/contestants.ts
@@ -1,0 +1,53 @@
+// Contestant CRUD -- domain module for the contestants table (M1.3).
+//
+// Pure persistence layer. Validates via Zod at the boundary,
+// persists via Drizzle. No HTTP awareness.
+
+import { eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { contestants } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asContestantId } from '@/lib/domain-ids';
+import type { RunId } from '@/lib/domain-ids';
+import { addContestantSchema, type AddContestantBody } from '@/lib/api-schemas';
+import type { Contestant } from './types';
+
+/** Add a contestant to a run. Validates input, generates nanoid, persists. */
+export async function addContestant(
+  db: DbOrTx,
+  runId: RunId,
+  input: AddContestantBody,
+): Promise<Contestant> {
+  const validated = addContestantSchema.parse(input);
+  const id = asContestantId(nanoid());
+
+  const [contestant] = await db
+    .insert(contestants)
+    .values({
+      id,
+      runId,
+      label: validated.label,
+      model: validated.model,
+      provider: validated.provider ?? null,
+      systemPrompt: validated.systemPrompt ?? null,
+      temperature: validated.temperature ?? null,
+      maxTokens: validated.maxTokens ?? null,
+      toolAccess: validated.toolAccess ?? null,
+      contextBundle: validated.contextBundle ?? null,
+    })
+    .returning();
+
+  return contestant;
+}
+
+/** Retrieve all contestants for a run. */
+export async function getContestantsForRun(
+  db: DbOrTx,
+  runId: RunId,
+): Promise<Contestant[]> {
+  return db
+    .select()
+    .from(contestants)
+    .where(eq(contestants.runId, runId));
+}

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -5,3 +5,5 @@ export { createRun, getRun, listRuns } from './runs';
 export type { Task, NewTask, ListTasksOptions } from './types';
 export type { Run, NewRun, RunStatus, ListRunsOptions } from './types';
 export type { CreateRunInput } from './runs';
+export { addContestant, getContestantsForRun } from './contestants';
+export type { Contestant, NewContestant, ContextBundleInput } from './types';

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -5,7 +5,8 @@
 // over manual type definitions where possible.
 
 import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import type { tasks, runs } from '@/db/schema';
+import type { tasks, runs, contestants } from '@/db/schema';
+import type { ContextBundleInput } from '@/db/schema';
 
 /** A task as stored in the database. */
 export type Task = InferSelectModel<typeof tasks>;
@@ -37,3 +38,12 @@ export type ListRunsOptions = {
   limit?: number;
   offset?: number;
 };
+
+/** A contestant as stored in the database. */
+export type Contestant = InferSelectModel<typeof contestants>;
+
+/** Input shape for creating a contestant (Drizzle insert). */
+export type NewContestant = InferInsertModel<typeof contestants>;
+
+// Re-export for consumers
+export type { ContextBundleInput };

--- a/tests/unit/run/contestants.test.ts
+++ b/tests/unit/run/contestants.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning, mockWhere } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockWhere = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockWhere,
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockWhere };
+});
+
+vi.mock('@/db/schema', () => ({
+  contestants: {
+    id: 'id',
+    runId: 'run_id',
+    label: 'label',
+    model: 'model',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'cont-nanoid-00000000'),
+}));
+
+import { addContestant, getContestantsForRun } from '@/lib/run/contestants';
+import type { DbOrTx } from '@/db';
+import type { RunId } from '@/lib/domain-ids';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeRunId = 'run-abc-000000000000' as RunId;
+
+const validInput = {
+  label: 'GPT-4o baseline',
+  model: 'gpt-4o',
+};
+
+const fullInput = {
+  label: 'Claude Sonnet tuned',
+  model: 'claude-sonnet-4-20250514',
+  provider: 'anthropic' as const,
+  systemPrompt: 'You are an expert evaluator.',
+  temperature: 0.7,
+  maxTokens: 4096,
+  toolAccess: ['web_search'],
+  contextBundle: {
+    documents: [
+      { label: 'CV', content: 'Senior engineer with 10 years...', source: 'upload' },
+    ],
+  },
+};
+
+const fakeContestant = {
+  id: 'cont-nanoid-00000000',
+  runId: fakeRunId,
+  label: 'GPT-4o baseline',
+  model: 'gpt-4o',
+  provider: null,
+  systemPrompt: null,
+  temperature: null,
+  maxTokens: null,
+  toolAccess: null,
+  contextBundle: null,
+  createdAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+  mockDb.select.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: mockWhere,
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/contestants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeContestant]);
+    mockWhere.mockResolvedValue([]);
+  });
+
+  // ── addContestant ───────────────────────────────────────────────────────
+
+  describe('addContestant', () => {
+    it('persists a contestant with generated id and runId', async () => {
+      const result = await addContestant(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+        validInput,
+      );
+      expect(result).toEqual(fakeContestant);
+      expect(result.runId).toBe(fakeRunId);
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts all optional fields', async () => {
+      const fullContestant = {
+        ...fakeContestant,
+        ...fullInput,
+        id: 'cont-nanoid-00000000',
+        runId: fakeRunId,
+        createdAt: fakeContestant.createdAt,
+      };
+      mockReturning.mockResolvedValue([fullContestant]);
+
+      const result = await addContestant(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+        fullInput,
+      );
+      expect(result.model).toBe('claude-sonnet-4-20250514');
+      expect(result.temperature).toBe(0.7);
+      expect(result.contextBundle).toBeDefined();
+    });
+
+    it('rejects empty label', async () => {
+      await expect(
+        addContestant(mockDb as unknown as DbOrTx, fakeRunId, {
+          ...validInput,
+          label: '',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects empty model', async () => {
+      await expect(
+        addContestant(mockDb as unknown as DbOrTx, fakeRunId, {
+          ...validInput,
+          model: '',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects temperature above 2', async () => {
+      await expect(
+        addContestant(mockDb as unknown as DbOrTx, fakeRunId, {
+          ...validInput,
+          temperature: 2.5,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── getContestantsForRun ────────────────────────────────────────────────
+
+  describe('getContestantsForRun', () => {
+    it('returns empty array when no contestants exist', async () => {
+      mockWhere.mockResolvedValue([]);
+      const result = await getContestantsForRun(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('returns all contestants for a run', async () => {
+      const contestants = [
+        fakeContestant,
+        { ...fakeContestant, id: 'cont-2', label: 'Claude baseline' },
+      ];
+      mockWhere.mockResolvedValue(contestants);
+
+      const result = await getContestantsForRun(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+      );
+      expect(result).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Third milestone of Phase 1 (Run Model). Adds the contestants table -- agent configurations that compete within a run.

Depends on: #103 (M1.2 - runs table)

### Schema
- `contestants` table: id, runId (FK cascade), label, model, provider, systemPrompt, temperature (real), maxTokens, toolAccess (jsonb), contextBundle (jsonb), createdAt
- ContextBundleInput type for inline MVP context (documents with label, content, source)
- Index on runId
- Migration: `drizzle/0006_m1.3-contestants.sql`

### Domain layer
- `ContestantId` branded type + `asContestantId` constructor
- `addContestantSchema` Zod validation
- `addContestant`, `getContestantsForRun` in `lib/run/contestants.ts`

### What was tested
- 7 new unit tests: addContestant (persist, full fields, empty label/model rejection, temperature validation), getContestantsForRun (empty, multiple)
- All 1528 tests pass (139 files, 0 failures)

### Scope boundary
- Contestants only -- traces and execution are M1.4
- No API routes (M1.5)

Closes #104

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `contestants` table and domain module for the Run model (M1.3), so a run can store competing agent configs. Validates input with `zod`, uses branded IDs, and provides insert/list helpers; closes #104.

- **New Features**
  - Schema: `contestants` table with cascade on run delete, `runId` index, and fields for label, model, provider, systemPrompt, temperature, maxTokens, toolAccess (jsonb), contextBundle (jsonb), createdAt.
  - Domain: `ContestantId` brand + `asContestantId`, `addContestantSchema`, and helpers `addContestant` and `getContestantsForRun` (uses `nanoid` and `drizzle-orm`).
  - Types: `ContextBundleInput` for MVP inline documents.
  - Tests: 7 unit tests covering validation and queries.

- **Migration**
  - Apply `drizzle/0006_m1.3-contestants.sql`.

<sup>Written for commit 2aebaeff72e09bfce1c0e14fee27619350edfc23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

