### PR TITLE
feat(run): M1.4 - execution engine, traces table, message builder

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -580,3 +580,46 @@ export type ContextBundleInput = {
     source?: string;
   }>;
 };
+
+// ---------------------------------------------------------------------------
+// Run model -- traces (M1.4)
+// ---------------------------------------------------------------------------
+
+export type TraceMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export const traces = pgTable('traces', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  runId: varchar('run_id', { length: 21 })
+    .notNull()
+    .references(() => runs.id, { onDelete: 'cascade' }),
+  contestantId: varchar('contestant_id', { length: 21 })
+    .notNull()
+    .references(() => contestants.id, { onDelete: 'cascade' }),
+  // Request
+  requestMessages: jsonb('request_messages').$type<TraceMessage[]>().notNull(),
+  requestModel: varchar('request_model', { length: 128 }).notNull(),
+  requestTemperature: real('request_temperature'),
+  // Response
+  responseContent: text('response_content'),
+  responseFinishReason: varchar('response_finish_reason', { length: 32 }),
+  // Metrics
+  inputTokens: integer('input_tokens'),
+  outputTokens: integer('output_tokens'),
+  totalTokens: integer('total_tokens'),
+  latencyMs: integer('latency_ms'),
+  // Status
+  status: varchar('status', { length: 16 }).notNull(),
+  error: text('error'),
+  // Timestamps
+  startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
+  completedAt: timestamp('completed_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  runIdIdx: index('traces_run_id_idx').on(table.runId),
+  contestantIdIdx: index('traces_contestant_id_idx').on(table.contestantId),
+}));

--- a/drizzle/0007_m1.4-traces.sql
+++ b/drizzle/0007_m1.4-traces.sql
@@ -1,0 +1,26 @@
+-- M1.4: traces table for the run model.
+-- Append-only record of each model call during run execution.
+-- Cascade delete: deleting a run deletes its traces.
+
+CREATE TABLE IF NOT EXISTS "traces" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "run_id" varchar(21) NOT NULL REFERENCES "runs"("id") ON DELETE CASCADE,
+  "contestant_id" varchar(21) NOT NULL REFERENCES "contestants"("id") ON DELETE CASCADE,
+  "request_messages" jsonb NOT NULL,
+  "request_model" varchar(128) NOT NULL,
+  "request_temperature" real,
+  "response_content" text,
+  "response_finish_reason" varchar(32),
+  "input_tokens" integer,
+  "output_tokens" integer,
+  "total_tokens" integer,
+  "latency_ms" integer,
+  "status" varchar(16) NOT NULL,
+  "error" text,
+  "started_at" timestamp with time zone NOT NULL,
+  "completed_at" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "traces_run_id_idx" ON "traces" USING btree ("run_id");
+CREATE INDEX IF NOT EXISTS "traces_contestant_id_idx" ON "traces" USING btree ("contestant_id");

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -46,6 +46,9 @@ export type RunId = Brand<string, 'RunId'>;
 /** Contestant identifier -- 21-char nanoid (M1.3). */
 export type ContestantId = Brand<string, 'ContestantId'>;
 
+/** Trace identifier -- 21-char nanoid (M1.4). */
+export type TraceId = Brand<string, 'TraceId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -91,6 +94,11 @@ export function asRunId(raw: string): RunId {
 /** Brand a raw string as a ContestantId. */
 export function asContestantId(raw: string): ContestantId {
   return raw as ContestantId;
+}
+
+/** Brand a raw string as a TraceId. */
+export function asTraceId(raw: string): TraceId {
+  return raw as TraceId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/run/contestants.ts
+++ b/lib/run/contestants.ts
@@ -38,7 +38,7 @@ export async function addContestant(
     })
     .returning();
 
-  return contestant;
+  return contestant!;
 }
 
 /** Retrieve all contestants for a run. */

--- a/lib/run/engine.ts
+++ b/lib/run/engine.ts
@@ -129,7 +129,7 @@ export async function executeRun(
           content: m.content,
         })),
         temperature: contestant.temperature ?? undefined,
-        maxTokens: contestant.maxTokens ?? undefined,
+        maxOutputTokens: contestant.maxTokens ?? undefined,
       });
       const latencyMs = Math.round(performance.now() - start);
       const completedAt = new Date();
@@ -145,10 +145,10 @@ export async function executeRun(
           requestTemperature: contestant.temperature,
           responseContent: result.text,
           responseFinishReason: result.finishReason ?? null,
-          inputTokens: result.usage?.promptTokens ?? null,
-          outputTokens: result.usage?.completionTokens ?? null,
+          inputTokens: result.usage?.inputTokens ?? null,
+          outputTokens: result.usage?.outputTokens ?? null,
           totalTokens: result.usage
-            ? (result.usage.promptTokens ?? 0) + (result.usage.completionTokens ?? 0)
+            ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
             : null,
           latencyMs,
           status: 'success',
@@ -158,7 +158,7 @@ export async function executeRun(
         })
         .returning();
 
-      traceResults.push({ ...contestant, trace });
+      traceResults.push({ ...contestant, trace: trace ?? null });
     } catch (err) {
       failures++;
       const completedAt = new Date();
@@ -186,7 +186,7 @@ export async function executeRun(
         })
         .returning();
 
-      traceResults.push({ ...contestant, trace });
+      traceResults.push({ ...contestant, trace: trace ?? null });
     }
   }
 

--- a/lib/run/engine.ts
+++ b/lib/run/engine.ts
@@ -1,0 +1,266 @@
+// Run execution engine (M1.4).
+//
+// Orchestrates model calls for each contestant in a run,
+// captures full traces, and manages run lifecycle.
+// Sequential execution -- parallel is post-MVP.
+
+import { eq, and, lt } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { generateText } from 'ai';
+
+import { runs, contestants, traces, tasks } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { getModel } from '@/lib/ai';
+import { asTraceId } from '@/lib/domain-ids';
+import type { RunId } from '@/lib/domain-ids';
+import type {
+  Run, Task, Contestant, Trace, RunWithTraces, TraceMessage,
+} from './types';
+
+const STALE_RUN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// ---------------------------------------------------------------------------
+// Message building
+// ---------------------------------------------------------------------------
+
+/** Build the messages array from task + contestant config. */
+export function buildMessages(
+  task: Task,
+  contestant: Contestant,
+): TraceMessage[] {
+  const messages: TraceMessage[] = [];
+
+  if (contestant.systemPrompt) {
+    messages.push({ role: 'system', content: contestant.systemPrompt });
+  }
+
+  // Inject context bundle documents as user context
+  const docs = contestant.contextBundle?.documents;
+  if (docs && docs.length > 0) {
+    const contextBlock = docs
+      .map((d) => `--- ${d.label} ---\n${d.content}`)
+      .join('\n\n');
+    messages.push({ role: 'user', content: contextBlock });
+  }
+
+  // Task prompt with constraints and acceptance criteria
+  let taskContent = task.prompt;
+  if (task.constraints && task.constraints.length > 0) {
+    taskContent += '\n\nConstraints:\n' +
+      task.constraints.map((c) => `- ${c}`).join('\n');
+  }
+  if (task.acceptanceCriteria && task.acceptanceCriteria.length > 0) {
+    taskContent += '\n\nAcceptance criteria:\n' +
+      task.acceptanceCriteria.map((c) => `- ${c}`).join('\n');
+  }
+  messages.push({ role: 'user', content: taskContent });
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a run: call each contestant's model, capture traces,
+ * update run status. Returns the completed run with traces.
+ *
+ * Contestants are executed sequentially for deterministic ordering
+ * and simpler error handling. Parallel execution is post-MVP.
+ */
+export async function executeRun(
+  db: DbOrTx,
+  runId: RunId,
+): Promise<RunWithTraces> {
+  // 1. Load run, validate status is 'pending'
+  const [run] = await db
+    .select()
+    .from(runs)
+    .where(eq(runs.id, runId))
+    .limit(1);
+
+  if (!run) {
+    throw new Error(`Run not found: ${runId}`);
+  }
+  if (run.status !== 'pending') {
+    throw new Error(`Run ${runId} is ${run.status}, expected pending`);
+  }
+
+  // 2. Set status to 'running'
+  const now = new Date();
+  await db
+    .update(runs)
+    .set({ status: 'running', startedAt: now, updatedAt: now })
+    .where(eq(runs.id, runId));
+
+  // 3. Load task and contestants
+  const [task] = await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.id, run.taskId))
+    .limit(1);
+
+  if (!task) {
+    throw new Error(`Task not found: ${run.taskId}`);
+  }
+
+  const contestantRows = await db
+    .select()
+    .from(contestants)
+    .where(eq(contestants.runId, runId));
+
+  // 4. Execute each contestant
+  const traceResults: (Contestant & { trace: Trace | null })[] = [];
+  let failures = 0;
+
+  for (const contestant of contestantRows) {
+    const messages = buildMessages(task, contestant);
+    const traceId = asTraceId(nanoid());
+    const startedAt = new Date();
+
+    try {
+      const model = getModel(contestant.model);
+      const start = performance.now();
+      const result = await generateText({
+        model,
+        messages: messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        })),
+        temperature: contestant.temperature ?? undefined,
+        maxTokens: contestant.maxTokens ?? undefined,
+      });
+      const latencyMs = Math.round(performance.now() - start);
+      const completedAt = new Date();
+
+      const [trace] = await db
+        .insert(traces)
+        .values({
+          id: traceId,
+          runId,
+          contestantId: contestant.id,
+          requestMessages: messages,
+          requestModel: contestant.model,
+          requestTemperature: contestant.temperature,
+          responseContent: result.text,
+          responseFinishReason: result.finishReason ?? null,
+          inputTokens: result.usage?.promptTokens ?? null,
+          outputTokens: result.usage?.completionTokens ?? null,
+          totalTokens: result.usage
+            ? (result.usage.promptTokens ?? 0) + (result.usage.completionTokens ?? 0)
+            : null,
+          latencyMs,
+          status: 'success',
+          error: null,
+          startedAt,
+          completedAt,
+        })
+        .returning();
+
+      traceResults.push({ ...contestant, trace });
+    } catch (err) {
+      failures++;
+      const completedAt = new Date();
+      const errorMsg = err instanceof Error ? err.message : String(err);
+
+      const [trace] = await db
+        .insert(traces)
+        .values({
+          id: traceId,
+          runId,
+          contestantId: contestant.id,
+          requestMessages: messages,
+          requestModel: contestant.model,
+          requestTemperature: contestant.temperature,
+          responseContent: null,
+          responseFinishReason: null,
+          inputTokens: null,
+          outputTokens: null,
+          totalTokens: null,
+          latencyMs: null,
+          status: 'error',
+          error: errorMsg,
+          startedAt,
+          completedAt,
+        })
+        .returning();
+
+      traceResults.push({ ...contestant, trace });
+    }
+  }
+
+  // 5. Set final status
+  const completedAt = new Date();
+  const allFailed = failures === contestantRows.length && contestantRows.length > 0;
+  const finalStatus = allFailed ? 'failed' : 'completed';
+  const errorSummary = failures > 0
+    ? `${failures}/${contestantRows.length} contestants failed`
+    : null;
+
+  await db
+    .update(runs)
+    .set({
+      status: finalStatus,
+      completedAt,
+      error: errorSummary,
+      updatedAt: completedAt,
+    })
+    .where(eq(runs.id, runId));
+
+  // 6. Return run with traces
+  const updatedRun: Run = {
+    ...run,
+    status: finalStatus,
+    startedAt: now,
+    completedAt,
+    error: errorSummary,
+    updatedAt: completedAt,
+  };
+
+  return {
+    ...updatedRun,
+    task,
+    contestants: traceResults,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Zombie sweep
+// ---------------------------------------------------------------------------
+
+/**
+ * Find runs stuck in 'running' past the timeout and mark them failed.
+ * Returns the number of runs swept. Call on startup or via admin endpoint.
+ */
+export async function sweepStaleRuns(
+  db: DbOrTx,
+  timeoutMs: number = STALE_RUN_TIMEOUT_MS,
+): Promise<number> {
+  const cutoff = new Date(Date.now() - timeoutMs);
+  const now = new Date();
+
+  const staleRuns = await db
+    .select()
+    .from(runs)
+    .where(and(
+      eq(runs.status, 'running'),
+      lt(runs.startedAt, cutoff),
+    ));
+
+  if (staleRuns.length === 0) return 0;
+
+  for (const run of staleRuns) {
+    await db
+      .update(runs)
+      .set({
+        status: 'failed',
+        error: 'Execution timed out or process died',
+        completedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(runs.id, run.id));
+  }
+
+  return staleRuns.length;
+}

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -6,4 +6,6 @@ export type { Task, NewTask, ListTasksOptions } from './types';
 export type { Run, NewRun, RunStatus, ListRunsOptions } from './types';
 export type { CreateRunInput } from './runs';
 export { addContestant, getContestantsForRun } from './contestants';
+export { executeRun, sweepStaleRuns, buildMessages } from './engine';
 export type { Contestant, NewContestant, ContextBundleInput } from './types';
+export type { Trace, NewTrace, TraceMessage, RunWithTraces } from './types';

--- a/lib/run/runs.ts
+++ b/lib/run/runs.ts
@@ -36,7 +36,7 @@ export async function createRun(
     })
     .returning();
 
-  return run;
+  return run!;
 }
 
 /** Retrieve a single run by ID. Returns null if not found. */

--- a/lib/run/tasks.ts
+++ b/lib/run/tasks.ts
@@ -34,7 +34,7 @@ export async function createTask(
     })
     .returning();
 
-  return task;
+  return task!;
 }
 
 /** Retrieve a single task by ID. Returns null if not found. */

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -5,8 +5,8 @@
 // over manual type definitions where possible.
 
 import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import type { tasks, runs, contestants } from '@/db/schema';
-import type { ContextBundleInput } from '@/db/schema';
+import type { tasks, runs, contestants, traces } from '@/db/schema';
+import type { ContextBundleInput, TraceMessage } from '@/db/schema';
 
 /** A task as stored in the database. */
 export type Task = InferSelectModel<typeof tasks>;
@@ -47,3 +47,16 @@ export type NewContestant = InferInsertModel<typeof contestants>;
 
 // Re-export for consumers
 export type { ContextBundleInput };
+export type { TraceMessage };
+
+/** A trace as stored in the database. */
+export type Trace = InferSelectModel<typeof traces>;
+
+/** Input shape for creating a trace (Drizzle insert). */
+export type NewTrace = InferInsertModel<typeof traces>;
+
+/** A run with its task, contestants, and traces. */
+export type RunWithTraces = Run & {
+  task: Task;
+  contestants: (Contestant & { trace: Trace | null })[];
+};

--- a/tests/unit/run/engine.test.ts
+++ b/tests/unit/run/engine.test.ts
@@ -217,7 +217,7 @@ describe('lib/run/engine', () => {
     it('omits system prompt when absent', () => {
       const noPrompt = { ...fakeContestant1, systemPrompt: null };
       const msgs = buildMessages(fakeTask, noPrompt);
-      expect(msgs[0].role).toBe('user');
+      expect(msgs[0]!.role).toBe('user');
     });
 
     it('includes context bundle documents', () => {
@@ -239,7 +239,7 @@ describe('lib/run/engine', () => {
       const simpleTask = { ...fakeTask, constraints: null, acceptanceCriteria: null };
       const msgs = buildMessages(simpleTask, { ...fakeContestant1, systemPrompt: null });
       expect(msgs).toHaveLength(1);
-      expect(msgs[0].content).toBe('Score this answer.');
+      expect(msgs[0]!.content).toBe('Score this answer.');
     });
   });
 
@@ -255,7 +255,7 @@ describe('lib/run/engine', () => {
       const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
       expect(result.task).toBeDefined();
       expect(result.contestants).toHaveLength(2);
-      expect(result.contestants[0].trace).toBeDefined();
+      expect(result.contestants[0]!.trace).toBeDefined();
     });
 
     it('updates run status to running then completed', async () => {

--- a/tests/unit/run/engine.test.ts
+++ b/tests/unit/run/engine.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockDb, mockReturning, mockSelectWhere, mockUpdateSet, mockGenerateText,
+} = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockSelectWhere = vi.fn();
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockSelectWhere,
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: mockUpdateSet,
+    }),
+  };
+
+  const mockGenerateText = vi.fn().mockResolvedValue({
+    text: 'Generated response',
+    finishReason: 'stop',
+    usage: { promptTokens: 100, completionTokens: 50 },
+  });
+
+  return { mockDb, mockReturning, mockSelectWhere, mockUpdateSet, mockGenerateText };
+});
+
+vi.mock('@/db/schema', () => ({
+  runs: { id: 'id', taskId: 'task_id', status: 'status', startedAt: 'started_at' },
+  tasks: { id: 'id' },
+  contestants: { runId: 'run_id' },
+  traces: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  lt: vi.fn((_col: unknown, val: unknown) => ({ _lt: val })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'trace-nanoid-0000000'),
+}));
+
+vi.mock('ai', () => ({
+  generateText: mockGenerateText,
+}));
+
+vi.mock('@/lib/ai', () => ({
+  getModel: vi.fn(() => 'mocked-model-instance'),
+}));
+
+import { executeRun, sweepStaleRuns, buildMessages } from '@/lib/run/engine';
+import type { DbOrTx } from '@/db';
+import type { RunId } from '@/lib/domain-ids';
+import type { Task, Contestant } from '@/lib/run/types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeRunId = 'run-abc-000000000000' as RunId;
+
+const fakeRun = {
+  id: fakeRunId,
+  taskId: 'task-abc-00000000000',
+  status: 'pending' as const,
+  ownerId: null,
+  startedAt: null,
+  completedAt: null,
+  error: null,
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeTask: Task = {
+  id: 'task-abc-00000000000',
+  name: 'Test task',
+  description: null,
+  prompt: 'Score this answer.',
+  constraints: ['Be concise'],
+  expectedOutputShape: 'text',
+  acceptanceCriteria: ['Correct score'],
+  domain: 'evaluation',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeContestant1: Contestant = {
+  id: 'cont-1-00000000000',
+  runId: fakeRunId,
+  label: 'GPT-4o',
+  model: 'gpt-4o',
+  provider: 'openai',
+  systemPrompt: 'You are an expert.',
+  temperature: 0.5,
+  maxTokens: 1000,
+  toolAccess: null,
+  contextBundle: null,
+  createdAt: new Date(),
+};
+
+const fakeContestant2: Contestant = {
+  id: 'cont-2-00000000000',
+  runId: fakeRunId,
+  label: 'Claude Sonnet',
+  model: 'claude-sonnet-4-20250514',
+  provider: 'anthropic',
+  systemPrompt: null,
+  temperature: null,
+  maxTokens: null,
+  toolAccess: null,
+  contextBundle: {
+    documents: [{ label: 'CV', content: 'Senior engineer...' }],
+  },
+  createdAt: new Date(),
+};
+
+const fakeTrace = {
+  id: 'trace-nanoid-0000000',
+  runId: fakeRunId,
+  contestantId: 'cont-1-00000000000',
+  requestMessages: [{ role: 'user', content: 'Score this answer.' }],
+  requestModel: 'gpt-4o',
+  requestTemperature: 0.5,
+  responseContent: 'Generated response',
+  responseFinishReason: 'stop',
+  inputTokens: 100,
+  outputTokens: 50,
+  totalTokens: 150,
+  latencyMs: 500,
+  status: 'success',
+  error: null,
+  startedAt: new Date(),
+  completedAt: new Date(),
+  createdAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let selectCallCount = 0;
+
+function resetMocks() {
+  selectCallCount = 0;
+
+  // insert chain
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  // update chain
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+  mockDb.update.mockReturnValue({ set: mockUpdateSet });
+
+  // select chain -- sequential: run, task, contestants
+  mockSelectWhere.mockImplementation(() => {
+    selectCallCount++;
+    if (selectCallCount === 1) {
+      // getRun -- returns .limit()
+      return { limit: vi.fn().mockResolvedValue([fakeRun]) };
+    }
+    if (selectCallCount === 2) {
+      // getTask -- returns .limit()
+      return { limit: vi.fn().mockResolvedValue([fakeTask]) };
+    }
+    // getContestants -- returns array directly
+    return Promise.resolve([fakeContestant1, fakeContestant2]);
+  });
+
+  // generateText mock
+  mockGenerateText.mockResolvedValue({
+    text: 'Generated response',
+    finishReason: 'stop',
+    usage: { promptTokens: 100, completionTokens: 50 },
+  });
+
+  // trace insert
+  mockReturning.mockResolvedValue([fakeTrace]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/engine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMocks();
+  });
+
+  // ── buildMessages ──────────────────────────────────────────────────────
+
+  describe('buildMessages', () => {
+    it('includes system prompt when present', () => {
+      const msgs = buildMessages(fakeTask, fakeContestant1);
+      expect(msgs[0]).toEqual({ role: 'system', content: 'You are an expert.' });
+    });
+
+    it('omits system prompt when absent', () => {
+      const noPrompt = { ...fakeContestant1, systemPrompt: null };
+      const msgs = buildMessages(fakeTask, noPrompt);
+      expect(msgs[0].role).toBe('user');
+    });
+
+    it('includes context bundle documents', () => {
+      const msgs = buildMessages(fakeTask, fakeContestant2);
+      const contextMsg = msgs.find((m) => m.content.includes('--- CV ---'));
+      expect(contextMsg).toBeDefined();
+      expect(contextMsg!.content).toContain('Senior engineer...');
+    });
+
+    it('includes constraints and acceptance criteria', () => {
+      const msgs = buildMessages(fakeTask, fakeContestant1);
+      const taskMsg = msgs.find((m) => m.content.includes('Constraints:'));
+      expect(taskMsg).toBeDefined();
+      expect(taskMsg!.content).toContain('Be concise');
+      expect(taskMsg!.content).toContain('Correct score');
+    });
+
+    it('handles task with no constraints or criteria', () => {
+      const simpleTask = { ...fakeTask, constraints: null, acceptanceCriteria: null };
+      const msgs = buildMessages(simpleTask, { ...fakeContestant1, systemPrompt: null });
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].content).toBe('Score this answer.');
+    });
+  });
+
+  // ── executeRun ─────────────────────────────────────────────────────────
+
+  describe('executeRun', () => {
+    it('calls generateText for each contestant', async () => {
+      await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns run with traces', async () => {
+      const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      expect(result.task).toBeDefined();
+      expect(result.contestants).toHaveLength(2);
+      expect(result.contestants[0].trace).toBeDefined();
+    });
+
+    it('updates run status to running then completed', async () => {
+      await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      // update called at least twice: running + completed
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it('rejects non-pending runs', async () => {
+      selectCallCount = 0;
+      mockSelectWhere.mockImplementation(() => {
+        selectCallCount++;
+        return { limit: vi.fn().mockResolvedValue([{ ...fakeRun, status: 'completed' }]) };
+      });
+
+      await expect(
+        executeRun(mockDb as unknown as DbOrTx, fakeRunId),
+      ).rejects.toThrow('expected pending');
+    });
+
+    it('rejects missing run', async () => {
+      selectCallCount = 0;
+      mockSelectWhere.mockImplementation(() => {
+        selectCallCount++;
+        return { limit: vi.fn().mockResolvedValue([]) };
+      });
+
+      await expect(
+        executeRun(mockDb as unknown as DbOrTx, fakeRunId),
+      ).rejects.toThrow('Run not found');
+    });
+
+    it('handles single contestant failure gracefully', async () => {
+      let genCallCount = 0;
+      mockGenerateText.mockImplementation(() => {
+        genCallCount++;
+        if (genCallCount === 1) throw new Error('Model unavailable');
+        return {
+          text: 'OK',
+          finishReason: 'stop',
+          usage: { promptTokens: 50, completionTokens: 20 },
+        };
+      });
+
+      const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      // Should complete (not fail) because one contestant succeeded
+      expect(result.status).toBe('completed');
+    });
+
+    it('marks run as failed when all contestants error', async () => {
+      mockGenerateText.mockRejectedValue(new Error('All broken'));
+
+      const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      expect(result.status).toBe('failed');
+    });
+  });
+
+  // ── sweepStaleRuns ─────────────────────────────────────────────────────
+
+  describe('sweepStaleRuns', () => {
+    it('returns 0 when no stale runs exist', async () => {
+      selectCallCount = 0;
+      mockSelectWhere.mockResolvedValue([]);
+
+      const count = await sweepStaleRuns(mockDb as unknown as DbOrTx);
+      expect(count).toBe(0);
+    });
+
+    it('marks stale runs as failed', async () => {
+      const staleRun = {
+        ...fakeRun,
+        status: 'running',
+        startedAt: new Date(Date.now() - 10 * 60 * 1000),
+      };
+      selectCallCount = 0;
+      mockSelectWhere.mockResolvedValue([staleRun]);
+
+      const count = await sweepStaleRuns(mockDb as unknown as DbOrTx);
+      expect(count).toBe(1);
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/run/runs.test.ts
+++ b/tests/unit/run/runs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { RunId } from '@/lib/domain-ids';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks -- Drizzle query chain
@@ -156,7 +157,7 @@ describe('lib/run/runs', () => {
       mockSelectLimit.mockResolvedValue([]);
       const result = await getRun(
         mockDb as unknown as DbOrTx,
-        'nonexistent' as any,
+        'nonexistent' as unknown as RunId,
       );
       expect(result).toBeNull();
     });
@@ -165,7 +166,7 @@ describe('lib/run/runs', () => {
       mockSelectLimit.mockResolvedValue([fakeRun]);
       const result = await getRun(
         mockDb as unknown as DbOrTx,
-        fakeRun.id as any,
+        fakeRun.id as unknown as RunId,
       );
       expect(result).toEqual(fakeRun);
     });

--- a/tests/unit/run/tasks.test.ts
+++ b/tests/unit/run/tasks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { TaskId } from '@/lib/domain-ids';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks -- Drizzle query chain
@@ -168,7 +169,7 @@ describe('lib/run/tasks', () => {
       mockSelectLimit.mockResolvedValue([]);
       const result = await getTask(
         mockDb as unknown as DbOrTx,
-        'nonexistent' as any,
+        'nonexistent' as unknown as TaskId,
       );
       expect(result).toBeNull();
     });
@@ -177,7 +178,7 @@ describe('lib/run/tasks', () => {
       mockSelectLimit.mockResolvedValue([fakeTask]);
       const result = await getTask(
         mockDb as unknown as DbOrTx,
-        fakeTask.id as any,
+        fakeTask.id as unknown as TaskId,
       );
       expect(result).toEqual(fakeTask);
     });
@@ -212,7 +213,7 @@ describe('lib/run/tasks', () => {
         orderBy: mockOrderBy,
       });
 
-      const result = await listTasks(mockDb as unknown as DbOrTx, {
+      await listTasks(mockDb as unknown as DbOrTx, {
         domain: 'job-application',
       });
 


### PR DESCRIPTION
## What changed

Fourth milestone of Phase 1 (Run Model). The execution engine -- most complex milestone. Orchestrates model calls, captures full traces, manages run lifecycle.

Depends on: #105 (M1.3 - contestants table)

### Schema
- `traces` table: id, runId (FK cascade), contestantId (FK cascade), requestMessages (jsonb), requestModel, requestTemperature, responseContent, responseFinishReason, token counts (input/output/total), latencyMs, status, error, timestamps
- `TraceMessage` type (role + content)
- Migration: `drizzle/0007_m1.4-traces.sql`

### Engine
- `executeRun`: validates pending, loads task + contestants, calls models via AI SDK `generateText`, captures traces with tokens + latency, lifecycle: pending -> running -> completed/failed
- `buildMessages`: system prompt + context bundle docs + task prompt + constraints + acceptance criteria
- `sweepStaleRuns`: marks runs stuck in running past 5min timeout as failed

### Error handling
- Single contestant failure: error trace recorded, run continues to next
- All contestants fail: run marked failed with summary
- Non-pending/missing run: rejected with descriptive error

### What was tested
- 14 new unit tests: buildMessages (5), executeRun (6), sweepStaleRuns (2), edge cases
- All 1542 tests pass (140 files, 0 failures)

### Scope boundary
- Engine logic only -- no HTTP routes (M1.5)
- Sequential execution (parallel post-MVP)

Closes #106

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the run execution engine (M1.4) with full trace capture via a new `traces` table, closing #106. Includes migration `drizzle/0007_m1.4-traces.sql`.

- **New Features**
  - `executeRun`: sequentially calls each contestant via `ai` `generateText`, records tokens/latency, and updates status (pending → running → completed/failed); partial failures allowed, fails if all fail.
  - `buildMessages`: merges system prompt, context docs, task prompt, constraints, and acceptance criteria.
  - `sweepStaleRuns`: marks runs stuck >5 minutes as failed.
  - Schema: `traces` table with request/response fields, token counts, latency, status, error; FKs + indexes on `runId` and `contestantId`.
  - Types/exports: `TraceMessage`, `Trace`, `RunWithTraces`, branded `TraceId`.

- **Bug Fixes**
  - Align with AI SDK v6: use `inputTokens`/`outputTokens` and `maxOutputTokens`.
  - Safer Drizzle `.returning()` handling; return non-null rows via `!`.
  - Replaced loose casts with branded IDs across code/tests.

<sup>Written for commit 5ad04d2e49fc7c62d6e3da4a4070896c9fa740d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

