### PR TITLE
feat(run): Phase 1 - Run model, execution engine, and API (M1.1-M1.5)

### DIFF
--- a/app/api/runs/[id]/execute/route.ts
+++ b/app/api/runs/[id]/execute/route.ts
@@ -1,0 +1,46 @@
+// POST /api/runs/:id/execute -- execute a pending run (M1.5).
+//
+// Separated from creation to avoid timeout on long model calls.
+// Sequential contestant execution can take 30s-2min+.
+// For MVP this is synchronous; post-MVP converts to async job.
+
+import { auth } from '@clerk/nextjs/server';
+import { requireDb } from '@/db';
+import { asRunId } from '@/lib/domain-ids';
+import { errorResponse, API_ERRORS } from '@/lib/api-utils';
+import { log } from '@/lib/logger';
+import { executeRun } from '@/lib/run/engine';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
+  }
+
+  const { id } = await params;
+
+  try {
+    const db = requireDb();
+    const result = await executeRun(db, asRunId(id));
+    return Response.json(result);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+
+    // Expected errors from executeRun validation
+    if (msg.includes('not found')) {
+      return errorResponse('Run not found', 404);
+    }
+    if (msg.includes('expected pending')) {
+      return errorResponse(`Run is not in pending status`, 409);
+    }
+
+    log.error('POST /api/runs/[id]/execute failed', error instanceof Error ? error : new Error(msg));
+    return errorResponse(API_ERRORS.INTERNAL, 500);
+  }
+}

--- a/app/api/runs/[id]/route.ts
+++ b/app/api/runs/[id]/route.ts
@@ -1,0 +1,32 @@
+// GET /api/runs/:id -- get a single run with task, contestants, and traces (M1.5).
+//
+// HTTP layer only. Composite query lives in lib/run/queries.ts.
+
+import { requireDb } from '@/db';
+import { asRunId } from '@/lib/domain-ids';
+import { errorResponse, API_ERRORS } from '@/lib/api-utils';
+import { log } from '@/lib/logger';
+import { getRunWithTraces } from '@/lib/run/queries';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  try {
+    const db = requireDb();
+    const run = await getRunWithTraces(db, asRunId(id));
+
+    if (!run) {
+      return errorResponse('Run not found', 404);
+    }
+
+    return Response.json(run);
+  } catch (error) {
+    log.error('GET /api/runs/[id] failed', error instanceof Error ? error : new Error(String(error)));
+    return errorResponse(API_ERRORS.INTERNAL, 500);
+  }
+}

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -1,0 +1,80 @@
+// POST /api/runs -- create a run with task + contestants (M1.5).
+// GET  /api/runs -- list runs with optional filters.
+//
+// HTTP layer only. Business logic lives in lib/run/.
+
+import { auth } from '@clerk/nextjs/server';
+import { withLogging } from '@/lib/api-logging';
+import { parseValidBody, errorResponse, API_ERRORS } from '@/lib/api-utils';
+import { requireDb } from '@/db';
+import { createRunSchema } from '@/lib/api-schemas';
+import { createTask } from '@/lib/run/tasks';
+import { createRun } from '@/lib/run/runs';
+import { addContestant } from '@/lib/run/contestants';
+import { listRuns } from '@/lib/run/runs';
+import { asTaskId, asRunId, type TaskId } from '@/lib/domain-ids';
+import type { RunStatus } from '@/lib/run/types';
+
+export const runtime = 'nodejs';
+
+async function rawPOST(req: Request) {
+  const { userId } = await auth();
+  if (!userId) {
+    return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
+  }
+
+  const parsed = await parseValidBody(req, createRunSchema);
+  if (parsed.error) return parsed.error;
+
+  const { task: taskInput, contestants: contestantInputs, metadata } = parsed.data;
+
+  const db = requireDb();
+
+  // Resolve task: inline creation or reference
+  let taskId: TaskId;
+  if ('taskId' in taskInput) {
+    taskId = asTaskId(taskInput.taskId);
+  } else {
+    const task = await createTask(db, taskInput);
+    taskId = asTaskId(task.id);
+  }
+
+  // Create run
+  const run = await createRun(db, { taskId, ownerId: userId, metadata });
+
+  // Add contestants
+  const contestantResults = [];
+  for (const input of contestantInputs) {
+    const contestant = await addContestant(db, asRunId(run.id), input);
+    contestantResults.push(contestant);
+  }
+
+  return Response.json(
+    { ...run, contestants: contestantResults },
+    { status: 201 },
+  );
+}
+
+async function rawGET(req: Request) {
+  const { userId } = await auth();
+  const url = new URL(req.url);
+
+  const status = url.searchParams.get('status') as RunStatus | null;
+  const taskId = url.searchParams.get('taskId');
+  const limit = parseInt(url.searchParams.get('limit') ?? '50', 10);
+  const offset = parseInt(url.searchParams.get('offset') ?? '0', 10);
+
+  const db = requireDb();
+  const runs = await listRuns(db, {
+    status: status ?? undefined,
+    taskId: taskId ?? undefined,
+    ownerId: userId ?? undefined,
+    limit: Math.min(limit, 100),
+    offset: Math.max(offset, 0),
+  });
+
+  return Response.json(runs);
+}
+
+export const POST = withLogging(rawPOST, 'create-run');
+export const GET = withLogging(rawGET, 'list-runs');

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -482,3 +482,34 @@ export const researchExports = pgTable('research_exports', {
   agentCount: integer('agent_count').notNull(),
   payload: jsonb('payload').$type<Record<string, unknown>>().notNull(),
 });
+
+// ---------------------------------------------------------------------------
+// Run model -- tasks (M1.1)
+// ---------------------------------------------------------------------------
+// Coexists alongside the bout model. No FK between runs and bouts.
+// See docs/specs/phase-1-run-model.md for design decisions.
+
+/** Expected output shape for a task. */
+export const expectedOutputShape = pgEnum('expected_output_shape', [
+  'text', 'json', 'code',
+]);
+
+export const tasks = pgTable('tasks', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  name: varchar('name', { length: 256 }).notNull(),
+  description: text('description'),
+  prompt: text('prompt').notNull(),
+  constraints: jsonb('constraints').$type<string[]>(),
+  expectedOutputShape: expectedOutputShape('expected_output_shape'),
+  acceptanceCriteria: jsonb('acceptance_criteria').$type<string[]>(),
+  domain: varchar('domain', { length: 64 }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  domainIdx: index('tasks_domain_idx').on(table.domain),
+  createdAtIdx: index('tasks_created_at_idx').on(table.createdAt),
+}));

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -27,6 +27,7 @@ import {
   boolean,
   integer,
   foreignKey,
+  real,
 } from 'drizzle-orm/pg-core';
 
 export type TranscriptEntry = {
@@ -545,3 +546,37 @@ export const runs = pgTable('runs', {
   ownerIdIdx: index('runs_owner_id_idx').on(table.ownerId),
   statusCreatedIdx: index('runs_status_created_idx').on(table.status, table.createdAt),
 }));
+
+// ---------------------------------------------------------------------------
+// Run model -- contestants (M1.3)
+// ---------------------------------------------------------------------------
+
+export const contestants = pgTable('contestants', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  runId: varchar('run_id', { length: 21 })
+    .notNull()
+    .references(() => runs.id, { onDelete: 'cascade' }),
+  label: varchar('label', { length: 128 }).notNull(),
+  model: varchar('model', { length: 128 }).notNull(),
+  provider: varchar('provider', { length: 64 }),
+  systemPrompt: text('system_prompt'),
+  temperature: real('temperature'),
+  maxTokens: integer('max_tokens'),
+  toolAccess: jsonb('tool_access').$type<string[]>(),
+  contextBundle: jsonb('context_bundle').$type<ContextBundleInput>(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  runIdIdx: index('contestants_run_id_idx').on(table.runId),
+}));
+
+/** Inline context documents for MVP. Post-MVP context layer (Phase 4)
+ *  will introduce proper context bundle tables with provenance. */
+export type ContextBundleInput = {
+  documents?: Array<{
+    label: string;
+    content: string;
+    source?: string;
+  }>;
+};

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -580,3 +580,46 @@ export type ContextBundleInput = {
     source?: string;
   }>;
 };
+
+// ---------------------------------------------------------------------------
+// Run model -- traces (M1.4)
+// ---------------------------------------------------------------------------
+
+export type TraceMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
+export const traces = pgTable('traces', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  runId: varchar('run_id', { length: 21 })
+    .notNull()
+    .references(() => runs.id, { onDelete: 'cascade' }),
+  contestantId: varchar('contestant_id', { length: 21 })
+    .notNull()
+    .references(() => contestants.id, { onDelete: 'cascade' }),
+  // Request
+  requestMessages: jsonb('request_messages').$type<TraceMessage[]>().notNull(),
+  requestModel: varchar('request_model', { length: 128 }).notNull(),
+  requestTemperature: real('request_temperature'),
+  // Response
+  responseContent: text('response_content'),
+  responseFinishReason: varchar('response_finish_reason', { length: 32 }),
+  // Metrics
+  inputTokens: integer('input_tokens'),
+  outputTokens: integer('output_tokens'),
+  totalTokens: integer('total_tokens'),
+  latencyMs: integer('latency_ms'),
+  // Status
+  status: varchar('status', { length: 16 }).notNull(),
+  error: text('error'),
+  // Timestamps
+  startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
+  completedAt: timestamp('completed_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  runIdIdx: index('traces_run_id_idx').on(table.runId),
+  contestantIdIdx: index('traces_contestant_id_idx').on(table.contestantId),
+}));

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -513,3 +513,35 @@ export const tasks = pgTable('tasks', {
   domainIdx: index('tasks_domain_idx').on(table.domain),
   createdAtIdx: index('tasks_created_at_idx').on(table.createdAt),
 }));
+
+// ---------------------------------------------------------------------------
+// Run model -- runs (M1.2)
+// ---------------------------------------------------------------------------
+
+export const runStatus = pgEnum('run_status', [
+  'pending', 'running', 'completed', 'failed',
+]);
+
+export const runs = pgTable('runs', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  taskId: varchar('task_id', { length: 21 })
+    .notNull()
+    .references(() => tasks.id),
+  status: runStatus('status').default('pending').notNull(),
+  ownerId: varchar('owner_id', { length: 128 })
+    .references(() => users.id, { onDelete: 'set null' }),
+  startedAt: timestamp('started_at', { withTimezone: true }),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  error: text('error'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => ({
+  taskIdIdx: index('runs_task_id_idx').on(table.taskId),
+  ownerIdIdx: index('runs_owner_id_idx').on(table.ownerId),
+  statusCreatedIdx: index('runs_status_created_idx').on(table.status, table.createdAt),
+}));

--- a/docs/internal/events.yaml
+++ b/docs/internal/events.yaml
@@ -137,3 +137,21 @@ events:
     ref: docs/specs/on-product-governance.md
     summary: "Adversarial review tiered by risk surface. Gate-only for schema/CRUD (6 milestones), single-model for API/UI (7 milestones), full 3-model triangulation for engine milestones (M1.4, M2.2). Evidence: git history shows 0% finding rate on schema PRs, 40%+ on integration code (c8ce063 rate limiter bypass, 2805384 double-refund race + SQL injection, a7e5514 serialization bugs). Tiered spend is itself a demonstration of token cost economics (skill 7) applied to the development process - calibrating verification cost against defect probability rather than applying uniform overhead."
     backrefs: [docs/specs/on-product-governance.md, SD-329]
+
+  - date: "2026-03-30"
+    time: "12:00"
+    type: review
+    agent: Codex
+    commit: null
+    ref: docs/internal/triangulation/pr-110-adversarial-review-2026-03-30.md
+    summary: "Adversarial review of PR #110 completed. 1 major finding: hotfix introduced a Next.js 16 config compilation failure via fileURLToPath(import.meta.url) in next.config.ts. Review also records that the PR message claimed middleware restoration, but the patch diff only changed next.config.ts."
+    backrefs: [84ad955, 6c4e11f, a14753e, docs/internal/triangulation/pr-110-adversarial-review-2026-03-30.md]
+
+  - date: "2026-03-30"
+    time: "12:15"
+    type: review-response
+    agent: Claude
+    commit: null
+    ref: docs/internal/triangulation/pr-110-adversarial-review-response-2026-03-30.md
+    summary: "Actioned adversarial review of PR #110. F1 (fileURLToPath regression) already resolved in a14753e, verified current next.config.ts uses import.meta.dirname. O1 (overstated commit message) acknowledged, immutable per SD-266. No code changes required."
+    backrefs: [a14753e, docs/internal/triangulation/pr-110-adversarial-review-2026-03-30.md]

--- a/docs/internal/triangulation/pr-110-adversarial-review-response-2026-03-30.md
+++ b/docs/internal/triangulation/pr-110-adversarial-review-response-2026-03-30.md
@@ -1,0 +1,31 @@
+# Response: Adversarial Review PR #110
+
+Date: 2026-03-30
+Responder: Claude
+Review: docs/internal/triangulation/pr-110-adversarial-review-2026-03-30.md
+
+## F1. High: fileURLToPath regression in next.config.ts
+
+**Status:** Already resolved.
+
+**Verification:**
+- Fix commit `a14753e` replaced `fileURLToPath(import.meta.url)` with `import.meta.dirname`
+- Current `next.config.ts` lines 4-9 use the corrected pattern with an explanatory comment
+- Sentry loading uses `createRequire(import.meta.url)` (stable under Next.js 16 ESM compilation)
+- Build and dev startup confirmed working on current main
+
+**Root cause:** The hotfix was shipped without testing the Next.js 16 config compilation path. `next.config.ts` is compiled differently from application code -- `import.meta.url` resolves correctly at the module level but `fileURLToPath` fails when the config compiler wraps the module in a CJS shim that defines `exports`, breaking ESM scope detection.
+
+**Process gap:** No pre-merge verification of `next dev` or `next build` startup. The gate (`test:ci`) runs lint, typecheck, and tests but does not boot the application. A config-level regression like this is invisible to the gate.
+
+**Preventive action:** None required at this time. The existing comment in `next.config.ts` serves as institutional memory. A startup smoke test would catch this class of defect but is not warranted for MVP scope (the fix is already in place and the pattern is documented).
+
+## O1. Commit message overstates the change
+
+**Status:** Acknowledged. Historical record is immutable per SD-266.
+
+The merge commit `84ad955` and PR head `6c4e11f` message claims middleware.ts restoration, but the merge-base diff only changes `next.config.ts`. The discrepancy is noted here for the audit trail. The commit cannot be rewritten.
+
+## Disposition
+
+Both items are closed. No code changes required. The review is valid -- the finding was real and the fix was necessary. The process gap (no boot smoke test in CI) is a known limitation at MVP scope.

--- a/drizzle/0004_m1.1-tasks.sql
+++ b/drizzle/0004_m1.1-tasks.sql
@@ -1,0 +1,24 @@
+-- M1.1: tasks table for the run model.
+-- Coexists alongside the bout model (no FK between runs and bouts).
+
+DO $$ BEGIN
+  CREATE TYPE "public"."expected_output_shape" AS ENUM('text', 'json', 'code');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "tasks" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "name" varchar(256) NOT NULL,
+  "description" text,
+  "prompt" text NOT NULL,
+  "constraints" jsonb,
+  "expected_output_shape" "expected_output_shape",
+  "acceptance_criteria" jsonb,
+  "domain" varchar(64),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "tasks_domain_idx" ON "tasks" USING btree ("domain");
+CREATE INDEX IF NOT EXISTS "tasks_created_at_idx" ON "tasks" USING btree ("created_at");

--- a/drizzle/0005_m1.2-runs.sql
+++ b/drizzle/0005_m1.2-runs.sql
@@ -1,0 +1,25 @@
+-- M1.2: runs table for the run model.
+-- Tracks execution lifecycle: pending -> running -> completed | failed.
+
+DO $$ BEGIN
+  CREATE TYPE "public"."run_status" AS ENUM('pending', 'running', 'completed', 'failed');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "runs" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "task_id" varchar(21) NOT NULL REFERENCES "tasks"("id"),
+  "status" "run_status" DEFAULT 'pending' NOT NULL,
+  "owner_id" varchar(128) REFERENCES "users"("id") ON DELETE SET NULL,
+  "started_at" timestamp with time zone,
+  "completed_at" timestamp with time zone,
+  "error" text,
+  "metadata" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "runs_task_id_idx" ON "runs" USING btree ("task_id");
+CREATE INDEX IF NOT EXISTS "runs_owner_id_idx" ON "runs" USING btree ("owner_id");
+CREATE INDEX IF NOT EXISTS "runs_status_created_idx" ON "runs" USING btree ("status", "created_at");

--- a/drizzle/0006_m1.3-contestants.sql
+++ b/drizzle/0006_m1.3-contestants.sql
@@ -1,0 +1,19 @@
+-- M1.3: contestants table for the run model.
+-- Agent configurations that compete within a run.
+-- Cascade delete: deleting a run deletes its contestants.
+
+CREATE TABLE IF NOT EXISTS "contestants" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "run_id" varchar(21) NOT NULL REFERENCES "runs"("id") ON DELETE CASCADE,
+  "label" varchar(128) NOT NULL,
+  "model" varchar(128) NOT NULL,
+  "provider" varchar(64),
+  "system_prompt" text,
+  "temperature" real,
+  "max_tokens" integer,
+  "tool_access" jsonb,
+  "context_bundle" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "contestants_run_id_idx" ON "contestants" USING btree ("run_id");

--- a/drizzle/0007_m1.4-traces.sql
+++ b/drizzle/0007_m1.4-traces.sql
@@ -1,0 +1,26 @@
+-- M1.4: traces table for the run model.
+-- Append-only record of each model call during run execution.
+-- Cascade delete: deleting a run deletes its traces.
+
+CREATE TABLE IF NOT EXISTS "traces" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "run_id" varchar(21) NOT NULL REFERENCES "runs"("id") ON DELETE CASCADE,
+  "contestant_id" varchar(21) NOT NULL REFERENCES "contestants"("id") ON DELETE CASCADE,
+  "request_messages" jsonb NOT NULL,
+  "request_model" varchar(128) NOT NULL,
+  "request_temperature" real,
+  "response_content" text,
+  "response_finish_reason" varchar(32),
+  "input_tokens" integer,
+  "output_tokens" integer,
+  "total_tokens" integer,
+  "latency_ms" integer,
+  "status" varchar(16) NOT NULL,
+  "error" text,
+  "started_at" timestamp with time zone NOT NULL,
+  "completed_at" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "traces_run_id_idx" ON "traces" USING btree ("run_id");
+CREATE INDEX IF NOT EXISTS "traces_contestant_id_idx" ON "traces" USING btree ("contestant_id");

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -223,3 +223,18 @@ export const addContestantSchema = z.object({
   }).optional(),
 });
 export type AddContestantBody = z.infer<typeof addContestantSchema>;
+
+// ---------------------------------------------------------------------------
+// Run model -- composite run creation (M1.5)
+// ---------------------------------------------------------------------------
+
+/** POST /api/runs -- create a run with task + contestants. */
+export const createRunSchema = z.object({
+  task: z.union([
+    createTaskSchema,
+    z.object({ taskId: z.string().length(21, 'taskId must be 21 characters.') }),
+  ]),
+  contestants: z.array(addContestantSchema).min(2, 'At least 2 contestants are required.'),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type CreateRunBody = z.infer<typeof createRunSchema>;

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -184,3 +184,19 @@ export const agentCreateSchema = z.object({
   clientManifestHash: z.string().optional(),
 });
 export type AgentCreateBody = z.infer<typeof agentCreateSchema>;
+
+// ---------------------------------------------------------------------------
+// Run model -- tasks (M1.1)
+// ---------------------------------------------------------------------------
+
+/** POST /api/tasks (future M1.5) -- validated at domain layer for now. */
+export const createTaskSchema = z.object({
+  name: z.string().min(1, 'Task name is required.').max(256, 'Task name must be 256 characters or fewer.'),
+  description: z.string().optional(),
+  prompt: z.string().min(1, 'Task prompt is required.'),
+  constraints: z.array(z.string()).optional(),
+  expectedOutputShape: z.enum(['text', 'json', 'code']).optional(),
+  acceptanceCriteria: z.array(z.string()).optional(),
+  domain: z.string().max(64, 'Domain must be 64 characters or fewer.').optional(),
+});
+export type CreateTaskBody = z.infer<typeof createTaskSchema>;

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -200,3 +200,26 @@ export const createTaskSchema = z.object({
   domain: z.string().max(64, 'Domain must be 64 characters or fewer.').optional(),
 });
 export type CreateTaskBody = z.infer<typeof createTaskSchema>;
+
+// ---------------------------------------------------------------------------
+// Run model -- contestants (M1.3)
+// ---------------------------------------------------------------------------
+
+/** Validation for adding a contestant to a run. */
+export const addContestantSchema = z.object({
+  label: z.string().min(1, 'Contestant label is required.').max(128, 'Label must be 128 characters or fewer.'),
+  model: z.string().min(1, 'Model is required.').max(128, 'Model must be 128 characters or fewer.'),
+  provider: z.enum(['openai', 'anthropic', 'google', 'xai']).optional(),
+  systemPrompt: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  maxTokens: z.number().int().positive().optional(),
+  toolAccess: z.array(z.string()).optional(),
+  contextBundle: z.object({
+    documents: z.array(z.object({
+      label: z.string(),
+      content: z.string(),
+      source: z.string().optional(),
+    })).optional(),
+  }).optional(),
+});
+export type AddContestantBody = z.infer<typeof addContestantSchema>;

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -40,6 +40,9 @@ export type MicroCredits = Brand<number, 'MicroCredits'>;
 /** Task identifier -- 21-char nanoid (M1.1). */
 export type TaskId = Brand<string, 'TaskId'>;
 
+/** Run identifier -- 21-char nanoid (M1.2). */
+export type RunId = Brand<string, 'RunId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -75,6 +78,11 @@ export function asMicroCredits(raw: number): MicroCredits {
 /** Brand a raw string as a TaskId. */
 export function asTaskId(raw: string): TaskId {
   return raw as TaskId;
+}
+
+/** Brand a raw string as a RunId. */
+export function asRunId(raw: string): RunId {
+  return raw as RunId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -34,8 +34,11 @@ export type UserId = Brand<string, 'UserId'>;
 /** Agent identifier — preset composite or custom nanoid. */
 export type AgentId = Brand<string, 'AgentId'>;
 
-/** Micro-credit amount — 1 credit = 100 micro. */
+/** Micro-credit amount -- 1 credit = 100 micro. */
 export type MicroCredits = Brand<number, 'MicroCredits'>;
+
+/** Task identifier -- 21-char nanoid (M1.1). */
+export type TaskId = Brand<string, 'TaskId'>;
 
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
@@ -67,6 +70,11 @@ export function asAgentId(raw: string): AgentId {
 /** Brand a raw number as MicroCredits. */
 export function asMicroCredits(raw: number): MicroCredits {
   return raw as MicroCredits;
+}
+
+/** Brand a raw string as a TaskId. */
+export function asTaskId(raw: string): TaskId {
+  return raw as TaskId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -43,6 +43,9 @@ export type TaskId = Brand<string, 'TaskId'>;
 /** Run identifier -- 21-char nanoid (M1.2). */
 export type RunId = Brand<string, 'RunId'>;
 
+/** Contestant identifier -- 21-char nanoid (M1.3). */
+export type ContestantId = Brand<string, 'ContestantId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -83,6 +86,11 @@ export function asTaskId(raw: string): TaskId {
 /** Brand a raw string as a RunId. */
 export function asRunId(raw: string): RunId {
   return raw as RunId;
+}
+
+/** Brand a raw string as a ContestantId. */
+export function asContestantId(raw: string): ContestantId {
+  return raw as ContestantId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -46,6 +46,9 @@ export type RunId = Brand<string, 'RunId'>;
 /** Contestant identifier -- 21-char nanoid (M1.3). */
 export type ContestantId = Brand<string, 'ContestantId'>;
 
+/** Trace identifier -- 21-char nanoid (M1.4). */
+export type TraceId = Brand<string, 'TraceId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -91,6 +94,11 @@ export function asRunId(raw: string): RunId {
 /** Brand a raw string as a ContestantId. */
 export function asContestantId(raw: string): ContestantId {
   return raw as ContestantId;
+}
+
+/** Brand a raw string as a TraceId. */
+export function asTraceId(raw: string): TraceId {
+  return raw as TraceId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/run/contestants.ts
+++ b/lib/run/contestants.ts
@@ -38,7 +38,7 @@ export async function addContestant(
     })
     .returning();
 
-  return contestant;
+  return contestant!;
 }
 
 /** Retrieve all contestants for a run. */

--- a/lib/run/contestants.ts
+++ b/lib/run/contestants.ts
@@ -1,0 +1,53 @@
+// Contestant CRUD -- domain module for the contestants table (M1.3).
+//
+// Pure persistence layer. Validates via Zod at the boundary,
+// persists via Drizzle. No HTTP awareness.
+
+import { eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { contestants } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asContestantId } from '@/lib/domain-ids';
+import type { RunId } from '@/lib/domain-ids';
+import { addContestantSchema, type AddContestantBody } from '@/lib/api-schemas';
+import type { Contestant } from './types';
+
+/** Add a contestant to a run. Validates input, generates nanoid, persists. */
+export async function addContestant(
+  db: DbOrTx,
+  runId: RunId,
+  input: AddContestantBody,
+): Promise<Contestant> {
+  const validated = addContestantSchema.parse(input);
+  const id = asContestantId(nanoid());
+
+  const [contestant] = await db
+    .insert(contestants)
+    .values({
+      id,
+      runId,
+      label: validated.label,
+      model: validated.model,
+      provider: validated.provider ?? null,
+      systemPrompt: validated.systemPrompt ?? null,
+      temperature: validated.temperature ?? null,
+      maxTokens: validated.maxTokens ?? null,
+      toolAccess: validated.toolAccess ?? null,
+      contextBundle: validated.contextBundle ?? null,
+    })
+    .returning();
+
+  return contestant;
+}
+
+/** Retrieve all contestants for a run. */
+export async function getContestantsForRun(
+  db: DbOrTx,
+  runId: RunId,
+): Promise<Contestant[]> {
+  return db
+    .select()
+    .from(contestants)
+    .where(eq(contestants.runId, runId));
+}

--- a/lib/run/engine.ts
+++ b/lib/run/engine.ts
@@ -129,7 +129,7 @@ export async function executeRun(
           content: m.content,
         })),
         temperature: contestant.temperature ?? undefined,
-        maxTokens: contestant.maxTokens ?? undefined,
+        maxOutputTokens: contestant.maxTokens ?? undefined,
       });
       const latencyMs = Math.round(performance.now() - start);
       const completedAt = new Date();
@@ -145,10 +145,10 @@ export async function executeRun(
           requestTemperature: contestant.temperature,
           responseContent: result.text,
           responseFinishReason: result.finishReason ?? null,
-          inputTokens: result.usage?.promptTokens ?? null,
-          outputTokens: result.usage?.completionTokens ?? null,
+          inputTokens: result.usage?.inputTokens ?? null,
+          outputTokens: result.usage?.outputTokens ?? null,
           totalTokens: result.usage
-            ? (result.usage.promptTokens ?? 0) + (result.usage.completionTokens ?? 0)
+            ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
             : null,
           latencyMs,
           status: 'success',
@@ -158,7 +158,7 @@ export async function executeRun(
         })
         .returning();
 
-      traceResults.push({ ...contestant, trace });
+      traceResults.push({ ...contestant, trace: trace ?? null });
     } catch (err) {
       failures++;
       const completedAt = new Date();
@@ -186,7 +186,7 @@ export async function executeRun(
         })
         .returning();
 
-      traceResults.push({ ...contestant, trace });
+      traceResults.push({ ...contestant, trace: trace ?? null });
     }
   }
 

--- a/lib/run/engine.ts
+++ b/lib/run/engine.ts
@@ -1,0 +1,266 @@
+// Run execution engine (M1.4).
+//
+// Orchestrates model calls for each contestant in a run,
+// captures full traces, and manages run lifecycle.
+// Sequential execution -- parallel is post-MVP.
+
+import { eq, and, lt } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import { generateText } from 'ai';
+
+import { runs, contestants, traces, tasks } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { getModel } from '@/lib/ai';
+import { asTraceId } from '@/lib/domain-ids';
+import type { RunId } from '@/lib/domain-ids';
+import type {
+  Run, Task, Contestant, Trace, RunWithTraces, TraceMessage,
+} from './types';
+
+const STALE_RUN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// ---------------------------------------------------------------------------
+// Message building
+// ---------------------------------------------------------------------------
+
+/** Build the messages array from task + contestant config. */
+export function buildMessages(
+  task: Task,
+  contestant: Contestant,
+): TraceMessage[] {
+  const messages: TraceMessage[] = [];
+
+  if (contestant.systemPrompt) {
+    messages.push({ role: 'system', content: contestant.systemPrompt });
+  }
+
+  // Inject context bundle documents as user context
+  const docs = contestant.contextBundle?.documents;
+  if (docs && docs.length > 0) {
+    const contextBlock = docs
+      .map((d) => `--- ${d.label} ---\n${d.content}`)
+      .join('\n\n');
+    messages.push({ role: 'user', content: contextBlock });
+  }
+
+  // Task prompt with constraints and acceptance criteria
+  let taskContent = task.prompt;
+  if (task.constraints && task.constraints.length > 0) {
+    taskContent += '\n\nConstraints:\n' +
+      task.constraints.map((c) => `- ${c}`).join('\n');
+  }
+  if (task.acceptanceCriteria && task.acceptanceCriteria.length > 0) {
+    taskContent += '\n\nAcceptance criteria:\n' +
+      task.acceptanceCriteria.map((c) => `- ${c}`).join('\n');
+  }
+  messages.push({ role: 'user', content: taskContent });
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a run: call each contestant's model, capture traces,
+ * update run status. Returns the completed run with traces.
+ *
+ * Contestants are executed sequentially for deterministic ordering
+ * and simpler error handling. Parallel execution is post-MVP.
+ */
+export async function executeRun(
+  db: DbOrTx,
+  runId: RunId,
+): Promise<RunWithTraces> {
+  // 1. Load run, validate status is 'pending'
+  const [run] = await db
+    .select()
+    .from(runs)
+    .where(eq(runs.id, runId))
+    .limit(1);
+
+  if (!run) {
+    throw new Error(`Run not found: ${runId}`);
+  }
+  if (run.status !== 'pending') {
+    throw new Error(`Run ${runId} is ${run.status}, expected pending`);
+  }
+
+  // 2. Set status to 'running'
+  const now = new Date();
+  await db
+    .update(runs)
+    .set({ status: 'running', startedAt: now, updatedAt: now })
+    .where(eq(runs.id, runId));
+
+  // 3. Load task and contestants
+  const [task] = await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.id, run.taskId))
+    .limit(1);
+
+  if (!task) {
+    throw new Error(`Task not found: ${run.taskId}`);
+  }
+
+  const contestantRows = await db
+    .select()
+    .from(contestants)
+    .where(eq(contestants.runId, runId));
+
+  // 4. Execute each contestant
+  const traceResults: (Contestant & { trace: Trace | null })[] = [];
+  let failures = 0;
+
+  for (const contestant of contestantRows) {
+    const messages = buildMessages(task, contestant);
+    const traceId = asTraceId(nanoid());
+    const startedAt = new Date();
+
+    try {
+      const model = getModel(contestant.model);
+      const start = performance.now();
+      const result = await generateText({
+        model,
+        messages: messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        })),
+        temperature: contestant.temperature ?? undefined,
+        maxTokens: contestant.maxTokens ?? undefined,
+      });
+      const latencyMs = Math.round(performance.now() - start);
+      const completedAt = new Date();
+
+      const [trace] = await db
+        .insert(traces)
+        .values({
+          id: traceId,
+          runId,
+          contestantId: contestant.id,
+          requestMessages: messages,
+          requestModel: contestant.model,
+          requestTemperature: contestant.temperature,
+          responseContent: result.text,
+          responseFinishReason: result.finishReason ?? null,
+          inputTokens: result.usage?.promptTokens ?? null,
+          outputTokens: result.usage?.completionTokens ?? null,
+          totalTokens: result.usage
+            ? (result.usage.promptTokens ?? 0) + (result.usage.completionTokens ?? 0)
+            : null,
+          latencyMs,
+          status: 'success',
+          error: null,
+          startedAt,
+          completedAt,
+        })
+        .returning();
+
+      traceResults.push({ ...contestant, trace });
+    } catch (err) {
+      failures++;
+      const completedAt = new Date();
+      const errorMsg = err instanceof Error ? err.message : String(err);
+
+      const [trace] = await db
+        .insert(traces)
+        .values({
+          id: traceId,
+          runId,
+          contestantId: contestant.id,
+          requestMessages: messages,
+          requestModel: contestant.model,
+          requestTemperature: contestant.temperature,
+          responseContent: null,
+          responseFinishReason: null,
+          inputTokens: null,
+          outputTokens: null,
+          totalTokens: null,
+          latencyMs: null,
+          status: 'error',
+          error: errorMsg,
+          startedAt,
+          completedAt,
+        })
+        .returning();
+
+      traceResults.push({ ...contestant, trace });
+    }
+  }
+
+  // 5. Set final status
+  const completedAt = new Date();
+  const allFailed = failures === contestantRows.length && contestantRows.length > 0;
+  const finalStatus = allFailed ? 'failed' : 'completed';
+  const errorSummary = failures > 0
+    ? `${failures}/${contestantRows.length} contestants failed`
+    : null;
+
+  await db
+    .update(runs)
+    .set({
+      status: finalStatus,
+      completedAt,
+      error: errorSummary,
+      updatedAt: completedAt,
+    })
+    .where(eq(runs.id, runId));
+
+  // 6. Return run with traces
+  const updatedRun: Run = {
+    ...run,
+    status: finalStatus,
+    startedAt: now,
+    completedAt,
+    error: errorSummary,
+    updatedAt: completedAt,
+  };
+
+  return {
+    ...updatedRun,
+    task,
+    contestants: traceResults,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Zombie sweep
+// ---------------------------------------------------------------------------
+
+/**
+ * Find runs stuck in 'running' past the timeout and mark them failed.
+ * Returns the number of runs swept. Call on startup or via admin endpoint.
+ */
+export async function sweepStaleRuns(
+  db: DbOrTx,
+  timeoutMs: number = STALE_RUN_TIMEOUT_MS,
+): Promise<number> {
+  const cutoff = new Date(Date.now() - timeoutMs);
+  const now = new Date();
+
+  const staleRuns = await db
+    .select()
+    .from(runs)
+    .where(and(
+      eq(runs.status, 'running'),
+      lt(runs.startedAt, cutoff),
+    ));
+
+  if (staleRuns.length === 0) return 0;
+
+  for (const run of staleRuns) {
+    await db
+      .update(runs)
+      .set({
+        status: 'failed',
+        error: 'Execution timed out or process died',
+        completedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(runs.id, run.id));
+  }
+
+  return staleRuns.length;
+}

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -1,0 +1,4 @@
+// Barrel export for the run domain module.
+
+export { createTask, getTask, listTasks } from './tasks';
+export type { Task, NewTask, ListTasksOptions } from './types';

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -9,3 +9,4 @@ export { addContestant, getContestantsForRun } from './contestants';
 export { executeRun, sweepStaleRuns, buildMessages } from './engine';
 export type { Contestant, NewContestant, ContextBundleInput } from './types';
 export type { Trace, NewTrace, TraceMessage, RunWithTraces } from './types';
+export { getRunWithTraces } from './queries';

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -5,3 +5,5 @@ export { createRun, getRun, listRuns } from './runs';
 export type { Task, NewTask, ListTasksOptions } from './types';
 export type { Run, NewRun, RunStatus, ListRunsOptions } from './types';
 export type { CreateRunInput } from './runs';
+export { addContestant, getContestantsForRun } from './contestants';
+export type { Contestant, NewContestant, ContextBundleInput } from './types';

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -1,4 +1,7 @@
 // Barrel export for the run domain module.
 
 export { createTask, getTask, listTasks } from './tasks';
+export { createRun, getRun, listRuns } from './runs';
 export type { Task, NewTask, ListTasksOptions } from './types';
+export type { Run, NewRun, RunStatus, ListRunsOptions } from './types';
+export type { CreateRunInput } from './runs';

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -6,4 +6,6 @@ export type { Task, NewTask, ListTasksOptions } from './types';
 export type { Run, NewRun, RunStatus, ListRunsOptions } from './types';
 export type { CreateRunInput } from './runs';
 export { addContestant, getContestantsForRun } from './contestants';
+export { executeRun, sweepStaleRuns, buildMessages } from './engine';
 export type { Contestant, NewContestant, ContextBundleInput } from './types';
+export type { Trace, NewTrace, TraceMessage, RunWithTraces } from './types';

--- a/lib/run/queries.ts
+++ b/lib/run/queries.ts
@@ -1,0 +1,59 @@
+// Composite queries for the run model (M1.5).
+//
+// Joins across tables to produce rich read models.
+// Pure persistence layer. No HTTP awareness.
+
+import { eq } from 'drizzle-orm';
+
+import { runs, tasks, contestants, traces } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import type { RunId } from '@/lib/domain-ids';
+import type { RunWithTraces } from './types';
+
+/**
+ * Load a run with its task, contestants, and traces.
+ * Each contestant is paired with its trace (or null if no trace exists).
+ * Returns null if the run does not exist.
+ */
+export async function getRunWithTraces(
+  db: DbOrTx,
+  runId: RunId,
+): Promise<RunWithTraces | null> {
+  const [run] = await db
+    .select()
+    .from(runs)
+    .where(eq(runs.id, runId))
+    .limit(1);
+
+  if (!run) return null;
+
+  const [task] = await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.id, run.taskId))
+    .limit(1);
+
+  if (!task) return null;
+
+  const contestantRows = await db
+    .select()
+    .from(contestants)
+    .where(eq(contestants.runId, runId));
+
+  const traceRows = await db
+    .select()
+    .from(traces)
+    .where(eq(traces.runId, runId));
+
+  // Pair each contestant with its trace
+  const contestantsWithTraces = contestantRows.map((c) => ({
+    ...c,
+    trace: traceRows.find((t) => t.contestantId === c.id) ?? null,
+  }));
+
+  return {
+    ...run,
+    task,
+    contestants: contestantsWithTraces,
+  };
+}

--- a/lib/run/runs.ts
+++ b/lib/run/runs.ts
@@ -36,7 +36,7 @@ export async function createRun(
     })
     .returning();
 
-  return run;
+  return run!;
 }
 
 /** Retrieve a single run by ID. Returns null if not found. */

--- a/lib/run/runs.ts
+++ b/lib/run/runs.ts
@@ -1,0 +1,84 @@
+// Run CRUD -- domain module for the runs table (M1.2).
+//
+// Creation and query only. Execution logic is M1.4.
+// Pure persistence layer. No HTTP awareness.
+
+import { eq, and, desc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { runs } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asRunId, type RunId } from '@/lib/domain-ids';
+import type { TaskId } from '@/lib/domain-ids';
+import type { Run, RunStatus, ListRunsOptions } from './types';
+
+/** Input for creating a new run. */
+export type CreateRunInput = {
+  taskId: TaskId;
+  ownerId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** Create a new run in pending status. */
+export async function createRun(
+  db: DbOrTx,
+  input: CreateRunInput,
+): Promise<Run> {
+  const id = asRunId(nanoid());
+
+  const [run] = await db
+    .insert(runs)
+    .values({
+      id,
+      taskId: input.taskId,
+      ownerId: input.ownerId ?? null,
+      metadata: input.metadata ?? null,
+    })
+    .returning();
+
+  return run;
+}
+
+/** Retrieve a single run by ID. Returns null if not found. */
+export async function getRun(
+  db: DbOrTx,
+  id: RunId,
+): Promise<Run | null> {
+  const [run] = await db
+    .select()
+    .from(runs)
+    .where(eq(runs.id, id))
+    .limit(1);
+
+  return run ?? null;
+}
+
+/** List runs with optional filters and pagination. */
+export async function listRuns(
+  db: DbOrTx,
+  opts: ListRunsOptions = {},
+): Promise<Run[]> {
+  const { taskId, status, ownerId, limit = 50, offset = 0 } = opts;
+
+  const conditions = [];
+  if (taskId) conditions.push(eq(runs.taskId, taskId));
+  if (status) conditions.push(eq(runs.status, status));
+  if (ownerId) conditions.push(eq(runs.ownerId, ownerId));
+
+  if (conditions.length > 0) {
+    return db
+      .select()
+      .from(runs)
+      .where(and(...conditions))
+      .orderBy(desc(runs.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  return db
+    .select()
+    .from(runs)
+    .orderBy(desc(runs.createdAt))
+    .limit(limit)
+    .offset(offset);
+}

--- a/lib/run/tasks.ts
+++ b/lib/run/tasks.ts
@@ -1,0 +1,77 @@
+// Task CRUD -- domain module for the tasks table (M1.1).
+//
+// Pure persistence layer. Validates via Zod at the boundary,
+// persists via Drizzle. No HTTP awareness.
+
+import { eq, desc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { tasks } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asTaskId, type TaskId } from '@/lib/domain-ids';
+import { createTaskSchema, type CreateTaskBody } from '@/lib/api-schemas';
+import type { Task, ListTasksOptions } from './types';
+
+/** Create a new task. Validates input, generates nanoid, persists. */
+export async function createTask(
+  db: DbOrTx,
+  input: CreateTaskBody,
+): Promise<Task> {
+  const validated = createTaskSchema.parse(input);
+  const id = asTaskId(nanoid());
+
+  const [task] = await db
+    .insert(tasks)
+    .values({
+      id,
+      name: validated.name,
+      description: validated.description ?? null,
+      prompt: validated.prompt,
+      constraints: validated.constraints ?? null,
+      expectedOutputShape: validated.expectedOutputShape ?? null,
+      acceptanceCriteria: validated.acceptanceCriteria ?? null,
+      domain: validated.domain ?? null,
+    })
+    .returning();
+
+  return task;
+}
+
+/** Retrieve a single task by ID. Returns null if not found. */
+export async function getTask(
+  db: DbOrTx,
+  id: TaskId,
+): Promise<Task | null> {
+  const [task] = await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.id, id))
+    .limit(1);
+
+  return task ?? null;
+}
+
+/** List tasks with optional domain filter and pagination. */
+export async function listTasks(
+  db: DbOrTx,
+  opts: ListTasksOptions = {},
+): Promise<Task[]> {
+  const { domain, limit = 50, offset = 0 } = opts;
+
+  if (domain) {
+    return db
+      .select()
+      .from(tasks)
+      .where(eq(tasks.domain, domain))
+      .orderBy(desc(tasks.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  return db
+    .select()
+    .from(tasks)
+    .orderBy(desc(tasks.createdAt))
+    .limit(limit)
+    .offset(offset);
+}

--- a/lib/run/tasks.ts
+++ b/lib/run/tasks.ts
@@ -34,7 +34,7 @@ export async function createTask(
     })
     .returning();
 
-  return task;
+  return task!;
 }
 
 /** Retrieve a single task by ID. Returns null if not found. */

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -1,0 +1,21 @@
+// Shared types and enums for the run model.
+//
+// This module defines types used across run domain modules.
+// Schema-derived types (from Drizzle InferSelect) are preferred
+// over manual type definitions where possible.
+
+import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
+import type { tasks } from '@/db/schema';
+
+/** A task as stored in the database. */
+export type Task = InferSelectModel<typeof tasks>;
+
+/** Input shape for creating a task (Drizzle insert). */
+export type NewTask = InferInsertModel<typeof tasks>;
+
+/** Options for listing tasks with filtering and pagination. */
+export type ListTasksOptions = {
+  domain?: string;
+  limit?: number;
+  offset?: number;
+};

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -5,7 +5,8 @@
 // over manual type definitions where possible.
 
 import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import type { tasks, runs } from '@/db/schema';
+import type { tasks, runs, contestants } from '@/db/schema';
+import type { ContextBundleInput } from '@/db/schema';
 
 /** A task as stored in the database. */
 export type Task = InferSelectModel<typeof tasks>;
@@ -37,3 +38,12 @@ export type ListRunsOptions = {
   limit?: number;
   offset?: number;
 };
+
+/** A contestant as stored in the database. */
+export type Contestant = InferSelectModel<typeof contestants>;
+
+/** Input shape for creating a contestant (Drizzle insert). */
+export type NewContestant = InferInsertModel<typeof contestants>;
+
+// Re-export for consumers
+export type { ContextBundleInput };

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -5,8 +5,8 @@
 // over manual type definitions where possible.
 
 import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import type { tasks, runs, contestants } from '@/db/schema';
-import type { ContextBundleInput } from '@/db/schema';
+import type { tasks, runs, contestants, traces } from '@/db/schema';
+import type { ContextBundleInput, TraceMessage } from '@/db/schema';
 
 /** A task as stored in the database. */
 export type Task = InferSelectModel<typeof tasks>;
@@ -47,3 +47,16 @@ export type NewContestant = InferInsertModel<typeof contestants>;
 
 // Re-export for consumers
 export type { ContextBundleInput };
+export type { TraceMessage };
+
+/** A trace as stored in the database. */
+export type Trace = InferSelectModel<typeof traces>;
+
+/** Input shape for creating a trace (Drizzle insert). */
+export type NewTrace = InferInsertModel<typeof traces>;
+
+/** A run with its task, contestants, and traces. */
+export type RunWithTraces = Run & {
+  task: Task;
+  contestants: (Contestant & { trace: Trace | null })[];
+};

--- a/lib/run/types.ts
+++ b/lib/run/types.ts
@@ -5,7 +5,7 @@
 // over manual type definitions where possible.
 
 import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-import type { tasks } from '@/db/schema';
+import type { tasks, runs } from '@/db/schema';
 
 /** A task as stored in the database. */
 export type Task = InferSelectModel<typeof tasks>;
@@ -16,6 +16,24 @@ export type NewTask = InferInsertModel<typeof tasks>;
 /** Options for listing tasks with filtering and pagination. */
 export type ListTasksOptions = {
   domain?: string;
+  limit?: number;
+  offset?: number;
+};
+
+/** A run as stored in the database. */
+export type Run = InferSelectModel<typeof runs>;
+
+/** Input shape for creating a run (Drizzle insert). */
+export type NewRun = InferInsertModel<typeof runs>;
+
+/** Run status enum values. */
+export type RunStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+/** Options for listing runs with filtering and pagination. */
+export type ListRunsOptions = {
+  taskId?: string;
+  status?: RunStatus;
+  ownerId?: string;
   limit?: number;
   offset?: number;
 };

--- a/tests/api/run/runs-api.test.ts
+++ b/tests/api/run/runs-api.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockAuth = vi.hoisted(() => vi.fn().mockResolvedValue({ userId: 'user-1' }));
+const mockRequireDb = vi.hoisted(() => vi.fn().mockReturnValue({}));
+const mockCreateTask = vi.hoisted(() => vi.fn());
+const mockCreateRun = vi.hoisted(() => vi.fn());
+const mockAddContestant = vi.hoisted(() => vi.fn());
+const mockListRuns = vi.hoisted(() => vi.fn());
+const mockGetRunWithTraces = vi.hoisted(() => vi.fn());
+const mockExecuteRun = vi.hoisted(() => vi.fn());
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: mockAuth }));
+vi.mock('@/db', () => ({ requireDb: mockRequireDb }));
+vi.mock('@/lib/run/tasks', () => ({ createTask: mockCreateTask }));
+vi.mock('@/lib/run/runs', () => ({ createRun: mockCreateRun, listRuns: mockListRuns }));
+vi.mock('@/lib/run/contestants', () => ({ addContestant: mockAddContestant }));
+vi.mock('@/lib/run/queries', () => ({ getRunWithTraces: mockGetRunWithTraces }));
+vi.mock('@/lib/run/engine', () => ({ executeRun: mockExecuteRun }));
+vi.mock('@/lib/api-logging', () => ({
+  withLogging: (_handler: (req: Request) => Promise<Response>, _name: string) => _handler,
+}));
+vi.mock('@/lib/anomaly', () => ({ checkAnomaly: vi.fn() }));
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeTask = {
+  id: 'task-00000000000000000',
+  name: 'Test task',
+  prompt: 'Do something.',
+};
+
+const fakeRun = {
+  id: 'run-000000000000000000',
+  taskId: fakeTask.id,
+  status: 'pending',
+  ownerId: 'user-1',
+  createdAt: new Date().toISOString(),
+};
+
+const fakeContestant1 = {
+  id: 'cont-00000000000000000',
+  runId: fakeRun.id,
+  label: 'GPT-4o',
+  model: 'gpt-4o',
+};
+
+const fakeContestant2 = {
+  id: 'cont-11111111111111111',
+  runId: fakeRun.id,
+  label: 'Claude',
+  model: 'claude-sonnet-4-6',
+};
+
+const validCreateBody = {
+  task: { name: 'Test', prompt: 'Do something.' },
+  contestants: [
+    { label: 'GPT-4o', model: 'gpt-4o' },
+    { label: 'Claude', model: 'claude-sonnet-4-6' },
+  ],
+};
+
+function makeRequest(method: string, url: string, body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests -- POST /api/runs
+// ---------------------------------------------------------------------------
+
+describe('POST /api/runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: 'user-1' });
+    mockCreateTask.mockResolvedValue(fakeTask);
+    mockCreateRun.mockResolvedValue(fakeRun);
+    mockAddContestant
+      .mockResolvedValueOnce(fakeContestant1)
+      .mockResolvedValueOnce(fakeContestant2);
+  });
+
+  it('creates a run with inline task and contestants (201)', async () => {
+    const { POST } = await import('@/app/api/runs/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs', validCreateBody);
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.id).toBe(fakeRun.id);
+    expect(json.contestants).toHaveLength(2);
+    expect(mockCreateTask).toHaveBeenCalledTimes(1);
+    expect(mockAddContestant).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates a run with taskId reference (201)', async () => {
+    const { POST } = await import('@/app/api/runs/route');
+    const body = {
+      task: { taskId: 'task-0000000000000000' },
+      contestants: validCreateBody.contestants,
+    };
+    const req = makeRequest('POST', 'http://localhost/api/runs', body);
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthenticated requests (401)', async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const { POST } = await import('@/app/api/runs/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs', validCreateBody);
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects fewer than 2 contestants (400)', async () => {
+    const { POST } = await import('@/app/api/runs/route');
+    const body = {
+      task: { name: 'Test', prompt: 'Do something.' },
+      contestants: [{ label: 'Solo', model: 'gpt-4o' }],
+    };
+    const req = makeRequest('POST', 'http://localhost/api/runs', body);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty task prompt (400)', async () => {
+    const { POST } = await import('@/app/api/runs/route');
+    const body = {
+      task: { name: 'Test', prompt: '' },
+      contestants: validCreateBody.contestants,
+    };
+    const req = makeRequest('POST', 'http://localhost/api/runs', body);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests -- GET /api/runs
+// ---------------------------------------------------------------------------
+
+describe('GET /api/runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: 'user-1' });
+    mockListRuns.mockResolvedValue([fakeRun]);
+  });
+
+  it('returns list of runs (200)', async () => {
+    const { GET } = await import('@/app/api/runs/route');
+    const req = makeRequest('GET', 'http://localhost/api/runs');
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toHaveLength(1);
+    expect(json[0].id).toBe(fakeRun.id);
+  });
+
+  it('passes status filter', async () => {
+    const { GET } = await import('@/app/api/runs/route');
+    const req = makeRequest('GET', 'http://localhost/api/runs?status=completed');
+    await GET(req);
+
+    expect(mockListRuns).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'completed' }),
+    );
+  });
+
+  it('clamps limit to 100', async () => {
+    const { GET } = await import('@/app/api/runs/route');
+    const req = makeRequest('GET', 'http://localhost/api/runs?limit=500');
+    await GET(req);
+
+    expect(mockListRuns).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 100 }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests -- GET /api/runs/:id
+// ---------------------------------------------------------------------------
+
+describe('GET /api/runs/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns run with traces (200)', async () => {
+    const fullRun = { ...fakeRun, task: fakeTask, contestants: [] };
+    mockGetRunWithTraces.mockResolvedValue(fullRun);
+
+    const { GET } = await import('@/app/api/runs/[id]/route');
+    const req = makeRequest('GET', 'http://localhost/api/runs/run-000000000000000000');
+    const res = await GET(req, { params: Promise.resolve({ id: 'run-000000000000000000' }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.id).toBe(fakeRun.id);
+    expect(json.task).toBeDefined();
+  });
+
+  it('returns 404 for missing run', async () => {
+    mockGetRunWithTraces.mockResolvedValue(null);
+
+    const { GET } = await import('@/app/api/runs/[id]/route');
+    const req = makeRequest('GET', 'http://localhost/api/runs/nonexistent');
+    const res = await GET(req, { params: Promise.resolve({ id: 'nonexistent' }) });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests -- POST /api/runs/:id/execute
+// ---------------------------------------------------------------------------
+
+describe('POST /api/runs/:id/execute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: 'user-1' });
+  });
+
+  it('executes a pending run (200)', async () => {
+    const executedRun = { ...fakeRun, status: 'completed', task: fakeTask, contestants: [] };
+    mockExecuteRun.mockResolvedValue(executedRun);
+
+    const { POST } = await import('@/app/api/runs/[id]/execute/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs/run-000/execute');
+    const res = await POST(req, { params: Promise.resolve({ id: 'run-000' }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe('completed');
+  });
+
+  it('rejects unauthenticated requests (401)', async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const { POST } = await import('@/app/api/runs/[id]/execute/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs/run-000/execute');
+    const res = await POST(req, { params: Promise.resolve({ id: 'run-000' }) });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for missing run', async () => {
+    mockExecuteRun.mockRejectedValue(new Error('Run not found: run-000'));
+
+    const { POST } = await import('@/app/api/runs/[id]/execute/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs/run-000/execute');
+    const res = await POST(req, { params: Promise.resolve({ id: 'run-000' }) });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 for non-pending run', async () => {
+    mockExecuteRun.mockRejectedValue(new Error('Run run-000 is completed, expected pending'));
+
+    const { POST } = await import('@/app/api/runs/[id]/execute/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs/run-000/execute');
+    const res = await POST(req, { params: Promise.resolve({ id: 'run-000' }) });
+
+    expect(res.status).toBe(409);
+  });
+});

--- a/tests/unit/run/contestants.test.ts
+++ b/tests/unit/run/contestants.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning, mockWhere } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockWhere = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockWhere,
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockWhere };
+});
+
+vi.mock('@/db/schema', () => ({
+  contestants: {
+    id: 'id',
+    runId: 'run_id',
+    label: 'label',
+    model: 'model',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'cont-nanoid-00000000'),
+}));
+
+import { addContestant, getContestantsForRun } from '@/lib/run/contestants';
+import type { DbOrTx } from '@/db';
+import type { RunId } from '@/lib/domain-ids';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeRunId = 'run-abc-000000000000' as RunId;
+
+const validInput = {
+  label: 'GPT-4o baseline',
+  model: 'gpt-4o',
+};
+
+const fullInput = {
+  label: 'Claude Sonnet tuned',
+  model: 'claude-sonnet-4-20250514',
+  provider: 'anthropic' as const,
+  systemPrompt: 'You are an expert evaluator.',
+  temperature: 0.7,
+  maxTokens: 4096,
+  toolAccess: ['web_search'],
+  contextBundle: {
+    documents: [
+      { label: 'CV', content: 'Senior engineer with 10 years...', source: 'upload' },
+    ],
+  },
+};
+
+const fakeContestant = {
+  id: 'cont-nanoid-00000000',
+  runId: fakeRunId,
+  label: 'GPT-4o baseline',
+  model: 'gpt-4o',
+  provider: null,
+  systemPrompt: null,
+  temperature: null,
+  maxTokens: null,
+  toolAccess: null,
+  contextBundle: null,
+  createdAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+  mockDb.select.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: mockWhere,
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/contestants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeContestant]);
+    mockWhere.mockResolvedValue([]);
+  });
+
+  // ── addContestant ───────────────────────────────────────────────────────
+
+  describe('addContestant', () => {
+    it('persists a contestant with generated id and runId', async () => {
+      const result = await addContestant(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+        validInput,
+      );
+      expect(result).toEqual(fakeContestant);
+      expect(result.runId).toBe(fakeRunId);
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts all optional fields', async () => {
+      const fullContestant = {
+        ...fakeContestant,
+        ...fullInput,
+        id: 'cont-nanoid-00000000',
+        runId: fakeRunId,
+        createdAt: fakeContestant.createdAt,
+      };
+      mockReturning.mockResolvedValue([fullContestant]);
+
+      const result = await addContestant(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+        fullInput,
+      );
+      expect(result.model).toBe('claude-sonnet-4-20250514');
+      expect(result.temperature).toBe(0.7);
+      expect(result.contextBundle).toBeDefined();
+    });
+
+    it('rejects empty label', async () => {
+      await expect(
+        addContestant(mockDb as unknown as DbOrTx, fakeRunId, {
+          ...validInput,
+          label: '',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects empty model', async () => {
+      await expect(
+        addContestant(mockDb as unknown as DbOrTx, fakeRunId, {
+          ...validInput,
+          model: '',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects temperature above 2', async () => {
+      await expect(
+        addContestant(mockDb as unknown as DbOrTx, fakeRunId, {
+          ...validInput,
+          temperature: 2.5,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── getContestantsForRun ────────────────────────────────────────────────
+
+  describe('getContestantsForRun', () => {
+    it('returns empty array when no contestants exist', async () => {
+      mockWhere.mockResolvedValue([]);
+      const result = await getContestantsForRun(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('returns all contestants for a run', async () => {
+      const contestants = [
+        fakeContestant,
+        { ...fakeContestant, id: 'cont-2', label: 'Claude baseline' },
+      ];
+      mockWhere.mockResolvedValue(contestants);
+
+      const result = await getContestantsForRun(
+        mockDb as unknown as DbOrTx,
+        fakeRunId,
+      );
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/tests/unit/run/engine.test.ts
+++ b/tests/unit/run/engine.test.ts
@@ -217,7 +217,7 @@ describe('lib/run/engine', () => {
     it('omits system prompt when absent', () => {
       const noPrompt = { ...fakeContestant1, systemPrompt: null };
       const msgs = buildMessages(fakeTask, noPrompt);
-      expect(msgs[0].role).toBe('user');
+      expect(msgs[0]!.role).toBe('user');
     });
 
     it('includes context bundle documents', () => {
@@ -239,7 +239,7 @@ describe('lib/run/engine', () => {
       const simpleTask = { ...fakeTask, constraints: null, acceptanceCriteria: null };
       const msgs = buildMessages(simpleTask, { ...fakeContestant1, systemPrompt: null });
       expect(msgs).toHaveLength(1);
-      expect(msgs[0].content).toBe('Score this answer.');
+      expect(msgs[0]!.content).toBe('Score this answer.');
     });
   });
 
@@ -255,7 +255,7 @@ describe('lib/run/engine', () => {
       const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
       expect(result.task).toBeDefined();
       expect(result.contestants).toHaveLength(2);
-      expect(result.contestants[0].trace).toBeDefined();
+      expect(result.contestants[0]!.trace).toBeDefined();
     });
 
     it('updates run status to running then completed', async () => {

--- a/tests/unit/run/engine.test.ts
+++ b/tests/unit/run/engine.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockDb, mockReturning, mockSelectWhere, mockUpdateSet, mockGenerateText,
+} = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockSelectWhere = vi.fn();
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockSelectWhere,
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: mockUpdateSet,
+    }),
+  };
+
+  const mockGenerateText = vi.fn().mockResolvedValue({
+    text: 'Generated response',
+    finishReason: 'stop',
+    usage: { promptTokens: 100, completionTokens: 50 },
+  });
+
+  return { mockDb, mockReturning, mockSelectWhere, mockUpdateSet, mockGenerateText };
+});
+
+vi.mock('@/db/schema', () => ({
+  runs: { id: 'id', taskId: 'task_id', status: 'status', startedAt: 'started_at' },
+  tasks: { id: 'id' },
+  contestants: { runId: 'run_id' },
+  traces: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  lt: vi.fn((_col: unknown, val: unknown) => ({ _lt: val })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'trace-nanoid-0000000'),
+}));
+
+vi.mock('ai', () => ({
+  generateText: mockGenerateText,
+}));
+
+vi.mock('@/lib/ai', () => ({
+  getModel: vi.fn(() => 'mocked-model-instance'),
+}));
+
+import { executeRun, sweepStaleRuns, buildMessages } from '@/lib/run/engine';
+import type { DbOrTx } from '@/db';
+import type { RunId } from '@/lib/domain-ids';
+import type { Task, Contestant } from '@/lib/run/types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeRunId = 'run-abc-000000000000' as RunId;
+
+const fakeRun = {
+  id: fakeRunId,
+  taskId: 'task-abc-00000000000',
+  status: 'pending' as const,
+  ownerId: null,
+  startedAt: null,
+  completedAt: null,
+  error: null,
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeTask: Task = {
+  id: 'task-abc-00000000000',
+  name: 'Test task',
+  description: null,
+  prompt: 'Score this answer.',
+  constraints: ['Be concise'],
+  expectedOutputShape: 'text',
+  acceptanceCriteria: ['Correct score'],
+  domain: 'evaluation',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeContestant1: Contestant = {
+  id: 'cont-1-00000000000',
+  runId: fakeRunId,
+  label: 'GPT-4o',
+  model: 'gpt-4o',
+  provider: 'openai',
+  systemPrompt: 'You are an expert.',
+  temperature: 0.5,
+  maxTokens: 1000,
+  toolAccess: null,
+  contextBundle: null,
+  createdAt: new Date(),
+};
+
+const fakeContestant2: Contestant = {
+  id: 'cont-2-00000000000',
+  runId: fakeRunId,
+  label: 'Claude Sonnet',
+  model: 'claude-sonnet-4-20250514',
+  provider: 'anthropic',
+  systemPrompt: null,
+  temperature: null,
+  maxTokens: null,
+  toolAccess: null,
+  contextBundle: {
+    documents: [{ label: 'CV', content: 'Senior engineer...' }],
+  },
+  createdAt: new Date(),
+};
+
+const fakeTrace = {
+  id: 'trace-nanoid-0000000',
+  runId: fakeRunId,
+  contestantId: 'cont-1-00000000000',
+  requestMessages: [{ role: 'user', content: 'Score this answer.' }],
+  requestModel: 'gpt-4o',
+  requestTemperature: 0.5,
+  responseContent: 'Generated response',
+  responseFinishReason: 'stop',
+  inputTokens: 100,
+  outputTokens: 50,
+  totalTokens: 150,
+  latencyMs: 500,
+  status: 'success',
+  error: null,
+  startedAt: new Date(),
+  completedAt: new Date(),
+  createdAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let selectCallCount = 0;
+
+function resetMocks() {
+  selectCallCount = 0;
+
+  // insert chain
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  // update chain
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+  mockDb.update.mockReturnValue({ set: mockUpdateSet });
+
+  // select chain -- sequential: run, task, contestants
+  mockSelectWhere.mockImplementation(() => {
+    selectCallCount++;
+    if (selectCallCount === 1) {
+      // getRun -- returns .limit()
+      return { limit: vi.fn().mockResolvedValue([fakeRun]) };
+    }
+    if (selectCallCount === 2) {
+      // getTask -- returns .limit()
+      return { limit: vi.fn().mockResolvedValue([fakeTask]) };
+    }
+    // getContestants -- returns array directly
+    return Promise.resolve([fakeContestant1, fakeContestant2]);
+  });
+
+  // generateText mock
+  mockGenerateText.mockResolvedValue({
+    text: 'Generated response',
+    finishReason: 'stop',
+    usage: { promptTokens: 100, completionTokens: 50 },
+  });
+
+  // trace insert
+  mockReturning.mockResolvedValue([fakeTrace]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/engine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMocks();
+  });
+
+  // ── buildMessages ──────────────────────────────────────────────────────
+
+  describe('buildMessages', () => {
+    it('includes system prompt when present', () => {
+      const msgs = buildMessages(fakeTask, fakeContestant1);
+      expect(msgs[0]).toEqual({ role: 'system', content: 'You are an expert.' });
+    });
+
+    it('omits system prompt when absent', () => {
+      const noPrompt = { ...fakeContestant1, systemPrompt: null };
+      const msgs = buildMessages(fakeTask, noPrompt);
+      expect(msgs[0].role).toBe('user');
+    });
+
+    it('includes context bundle documents', () => {
+      const msgs = buildMessages(fakeTask, fakeContestant2);
+      const contextMsg = msgs.find((m) => m.content.includes('--- CV ---'));
+      expect(contextMsg).toBeDefined();
+      expect(contextMsg!.content).toContain('Senior engineer...');
+    });
+
+    it('includes constraints and acceptance criteria', () => {
+      const msgs = buildMessages(fakeTask, fakeContestant1);
+      const taskMsg = msgs.find((m) => m.content.includes('Constraints:'));
+      expect(taskMsg).toBeDefined();
+      expect(taskMsg!.content).toContain('Be concise');
+      expect(taskMsg!.content).toContain('Correct score');
+    });
+
+    it('handles task with no constraints or criteria', () => {
+      const simpleTask = { ...fakeTask, constraints: null, acceptanceCriteria: null };
+      const msgs = buildMessages(simpleTask, { ...fakeContestant1, systemPrompt: null });
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].content).toBe('Score this answer.');
+    });
+  });
+
+  // ── executeRun ─────────────────────────────────────────────────────────
+
+  describe('executeRun', () => {
+    it('calls generateText for each contestant', async () => {
+      await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns run with traces', async () => {
+      const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      expect(result.task).toBeDefined();
+      expect(result.contestants).toHaveLength(2);
+      expect(result.contestants[0].trace).toBeDefined();
+    });
+
+    it('updates run status to running then completed', async () => {
+      await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      // update called at least twice: running + completed
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it('rejects non-pending runs', async () => {
+      selectCallCount = 0;
+      mockSelectWhere.mockImplementation(() => {
+        selectCallCount++;
+        return { limit: vi.fn().mockResolvedValue([{ ...fakeRun, status: 'completed' }]) };
+      });
+
+      await expect(
+        executeRun(mockDb as unknown as DbOrTx, fakeRunId),
+      ).rejects.toThrow('expected pending');
+    });
+
+    it('rejects missing run', async () => {
+      selectCallCount = 0;
+      mockSelectWhere.mockImplementation(() => {
+        selectCallCount++;
+        return { limit: vi.fn().mockResolvedValue([]) };
+      });
+
+      await expect(
+        executeRun(mockDb as unknown as DbOrTx, fakeRunId),
+      ).rejects.toThrow('Run not found');
+    });
+
+    it('handles single contestant failure gracefully', async () => {
+      let genCallCount = 0;
+      mockGenerateText.mockImplementation(() => {
+        genCallCount++;
+        if (genCallCount === 1) throw new Error('Model unavailable');
+        return {
+          text: 'OK',
+          finishReason: 'stop',
+          usage: { promptTokens: 50, completionTokens: 20 },
+        };
+      });
+
+      const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      // Should complete (not fail) because one contestant succeeded
+      expect(result.status).toBe('completed');
+    });
+
+    it('marks run as failed when all contestants error', async () => {
+      mockGenerateText.mockRejectedValue(new Error('All broken'));
+
+      const result = await executeRun(mockDb as unknown as DbOrTx, fakeRunId);
+      expect(result.status).toBe('failed');
+    });
+  });
+
+  // ── sweepStaleRuns ─────────────────────────────────────────────────────
+
+  describe('sweepStaleRuns', () => {
+    it('returns 0 when no stale runs exist', async () => {
+      selectCallCount = 0;
+      mockSelectWhere.mockResolvedValue([]);
+
+      const count = await sweepStaleRuns(mockDb as unknown as DbOrTx);
+      expect(count).toBe(0);
+    });
+
+    it('marks stale runs as failed', async () => {
+      const staleRun = {
+        ...fakeRun,
+        status: 'running',
+        startedAt: new Date(Date.now() - 10 * 60 * 1000),
+      };
+      selectCallCount = 0;
+      mockSelectWhere.mockResolvedValue([staleRun]);
+
+      const count = await sweepStaleRuns(mockDb as unknown as DbOrTx);
+      expect(count).toBe(1);
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/run/queries.test.ts
+++ b/tests/unit/run/queries.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { RunId } from '@/lib/domain-ids';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockSelectLimit, mockSelectAll } = vi.hoisted(() => {
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+  const mockSelectAll = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+      }),
+    }),
+  };
+  return { mockDb, mockSelectLimit, mockSelectAll };
+});
+
+vi.mock('@/db/schema', () => ({
+  runs: { id: 'id', taskId: 'task_id' },
+  tasks: { id: 'id' },
+  contestants: { runId: 'run_id', id: 'id' },
+  traces: { runId: 'run_id', contestantId: 'contestant_id' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+}));
+
+import { getRunWithTraces } from '@/lib/run/queries';
+import type { DbOrTx } from '@/db';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeRun = {
+  id: 'run-000000000000000000',
+  taskId: 'task-00000000000000000',
+  status: 'completed' as const,
+  ownerId: 'user-1',
+  startedAt: new Date(),
+  completedAt: new Date(),
+  error: null,
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeTask = {
+  id: 'task-00000000000000000',
+  name: 'Test task',
+  description: null,
+  prompt: 'Do something.',
+  constraints: null,
+  expectedOutputShape: null,
+  acceptanceCriteria: null,
+  domain: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeContestant = {
+  id: 'cont-00000000000000000',
+  runId: 'run-000000000000000000',
+  label: 'GPT-4o',
+  model: 'gpt-4o',
+  provider: 'openai',
+  systemPrompt: null,
+  temperature: null,
+  maxTokens: null,
+  toolAccess: null,
+  contextBundle: null,
+  createdAt: new Date(),
+};
+
+const fakeTrace = {
+  id: 'trace-0000000000000000',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-00000000000000000',
+  requestMessages: [{ role: 'user', content: 'Do something.' }],
+  requestModel: 'gpt-4o',
+  requestTemperature: null,
+  responseContent: 'Done.',
+  responseFinishReason: 'stop',
+  inputTokens: 10,
+  outputTokens: 5,
+  totalTokens: 15,
+  latencyMs: 500,
+  status: 'success',
+  error: null,
+  startedAt: new Date(),
+  completedAt: new Date(),
+  createdAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up mock chain to return specific values for each sequential select call.
+ * Handles both `.where().limit()` (run/task) and `.where()` as thenable (contestants/traces).
+ */
+function setupSelectSequence(responses: unknown[][]) {
+  let callIndex = 0;
+
+  const mockWhere = vi.fn().mockImplementation(() => {
+    const idx = callIndex++;
+    const data = responses[idx] ?? [];
+    // Return object that works as both thenable (for queries without .limit())
+    // and as chain with .limit() (for queries with .limit())
+    const result = Promise.resolve(data);
+    return Object.assign(result, {
+      limit: vi.fn().mockResolvedValue(data),
+    });
+  });
+
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+  });
+
+  mockDb.select.mockReturnValue({ from: mockFrom });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getRunWithTraces', () => {
+    it('returns null when run does not exist', async () => {
+      setupSelectSequence([[]]);
+      const result = await getRunWithTraces(
+        mockDb as unknown as DbOrTx,
+        'nonexistent' as unknown as RunId,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null when task does not exist', async () => {
+      setupSelectSequence([[fakeRun], []]);
+      const result = await getRunWithTraces(
+        mockDb as unknown as DbOrTx,
+        fakeRun.id as unknown as RunId,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns run with task, contestants, and traces', async () => {
+      setupSelectSequence([
+        [fakeRun],           // run lookup
+        [fakeTask],          // task lookup
+        [fakeContestant],    // contestants lookup
+        [fakeTrace],         // traces lookup
+      ]);
+
+      const result = await getRunWithTraces(
+        mockDb as unknown as DbOrTx,
+        fakeRun.id as unknown as RunId,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(fakeRun.id);
+      expect(result!.task).toEqual(fakeTask);
+      expect(result!.contestants).toHaveLength(1);
+      expect(result!.contestants[0]!.trace).toEqual(fakeTrace);
+    });
+
+    it('returns null trace for contestant without trace', async () => {
+      setupSelectSequence([
+        [fakeRun],
+        [fakeTask],
+        [fakeContestant],
+        [],  // no traces
+      ]);
+
+      const result = await getRunWithTraces(
+        mockDb as unknown as DbOrTx,
+        fakeRun.id as unknown as RunId,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.contestants[0]!.trace).toBeNull();
+    });
+
+    it('pairs traces to correct contestants', async () => {
+      const contestant2 = { ...fakeContestant, id: 'cont-11111111111111111' };
+      const trace2 = { ...fakeTrace, id: 'trace-1111111111111111', contestantId: 'cont-11111111111111111' };
+
+      setupSelectSequence([
+        [fakeRun],
+        [fakeTask],
+        [fakeContestant, contestant2],
+        [fakeTrace, trace2],
+      ]);
+
+      const result = await getRunWithTraces(
+        mockDb as unknown as DbOrTx,
+        fakeRun.id as unknown as RunId,
+      );
+
+      expect(result!.contestants).toHaveLength(2);
+      expect(result!.contestants[0]!.trace!.id).toBe(fakeTrace.id);
+      expect(result!.contestants[1]!.trace!.id).toBe(trace2.id);
+    });
+  });
+});

--- a/tests/unit/run/runs.test.ts
+++ b/tests/unit/run/runs.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning, mockSelectLimit } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({
+            offset: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockSelectLimit };
+});
+
+vi.mock('@/db/schema', () => ({
+  runs: {
+    id: 'id',
+    taskId: 'task_id',
+    status: 'status',
+    ownerId: 'owner_id',
+    createdAt: 'created_at',
+  },
+  runStatus: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  desc: vi.fn((col: unknown) => ({ _desc: col })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'run-nanoid-000000000'),
+}));
+
+import { createRun, getRun, listRuns } from '@/lib/run/runs';
+import type { DbOrTx } from '@/db';
+import type { TaskId } from '@/lib/domain-ids';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeTaskId = 'task-abc-000000000000' as TaskId;
+
+const fakeRun = {
+  id: 'run-nanoid-000000000',
+  taskId: fakeTaskId,
+  status: 'pending',
+  ownerId: null,
+  startedAt: null,
+  completedAt: null,
+  error: null,
+  metadata: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  const mockOffset = vi.fn().mockResolvedValue([]);
+  const mockLimitList = vi.fn().mockReturnValue({ offset: mockOffset });
+  const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimitList });
+  const mockWhere = vi.fn().mockReturnValue({
+    limit: mockSelectLimit,
+    orderBy: mockOrderBy,
+  });
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+    orderBy: mockOrderBy,
+  });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+
+  return { mockFrom, mockWhere, mockOrderBy, mockLimitList, mockOffset };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeRun]);
+    mockSelectLimit.mockResolvedValue([]);
+  });
+
+  // ── createRun ───────────────────────────────────────────────────────────
+
+  describe('createRun', () => {
+    it('persists a run with pending status and generated id', async () => {
+      const result = await createRun(mockDb as unknown as DbOrTx, {
+        taskId: fakeTaskId,
+      });
+      expect(result).toEqual(fakeRun);
+      expect(result.status).toBe('pending');
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts optional ownerId', async () => {
+      const runWithOwner = { ...fakeRun, ownerId: 'user-123' };
+      mockReturning.mockResolvedValue([runWithOwner]);
+
+      const result = await createRun(mockDb as unknown as DbOrTx, {
+        taskId: fakeTaskId,
+        ownerId: 'user-123',
+      });
+      expect(result.ownerId).toBe('user-123');
+    });
+
+    it('accepts optional metadata', async () => {
+      const meta = { source: 'test', priority: 1 };
+      const runWithMeta = { ...fakeRun, metadata: meta };
+      mockReturning.mockResolvedValue([runWithMeta]);
+
+      const result = await createRun(mockDb as unknown as DbOrTx, {
+        taskId: fakeTaskId,
+        metadata: meta,
+      });
+      expect(result.metadata).toEqual(meta);
+    });
+  });
+
+  // ── getRun ──────────────────────────────────────────────────────────────
+
+  describe('getRun', () => {
+    it('returns null for missing id', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+      const result = await getRun(
+        mockDb as unknown as DbOrTx,
+        'nonexistent' as any,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns the run when found', async () => {
+      mockSelectLimit.mockResolvedValue([fakeRun]);
+      const result = await getRun(
+        mockDb as unknown as DbOrTx,
+        fakeRun.id as any,
+      );
+      expect(result).toEqual(fakeRun);
+    });
+  });
+
+  // ── listRuns ────────────────────────────────────────────────────────────
+
+  describe('listRuns', () => {
+    it('returns empty array when no runs exist', async () => {
+      const result = await listRuns(mockDb as unknown as DbOrTx);
+      expect(result).toEqual([]);
+    });
+
+    it('calls select with default limit and offset', async () => {
+      await listRuns(mockDb as unknown as DbOrTx);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes status filter when specified', async () => {
+      const { mockWhere } = resetMockChains();
+
+      // For filtered queries with conditions, chain goes:
+      // select().from().where(and(...)).orderBy().limit().offset()
+      const mockOffset = vi.fn().mockResolvedValue([fakeRun]);
+      const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      mockWhere.mockReturnValue({
+        orderBy: mockOrderBy,
+      });
+
+      await listRuns(mockDb as unknown as DbOrTx, { status: 'pending' });
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/run/runs.test.ts
+++ b/tests/unit/run/runs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { RunId } from '@/lib/domain-ids';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks -- Drizzle query chain
@@ -156,7 +157,7 @@ describe('lib/run/runs', () => {
       mockSelectLimit.mockResolvedValue([]);
       const result = await getRun(
         mockDb as unknown as DbOrTx,
-        'nonexistent' as any,
+        'nonexistent' as unknown as RunId,
       );
       expect(result).toBeNull();
     });
@@ -165,7 +166,7 @@ describe('lib/run/runs', () => {
       mockSelectLimit.mockResolvedValue([fakeRun]);
       const result = await getRun(
         mockDb as unknown as DbOrTx,
-        fakeRun.id as any,
+        fakeRun.id as unknown as RunId,
       );
       expect(result).toEqual(fakeRun);
     });

--- a/tests/unit/run/tasks.test.ts
+++ b/tests/unit/run/tasks.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning, mockSelectLimit } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({
+            offset: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockSelectLimit };
+});
+
+vi.mock('@/db/schema', () => ({
+  tasks: {
+    id: 'id',
+    name: 'name',
+    domain: 'domain',
+    createdAt: 'created_at',
+  },
+  expectedOutputShape: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  desc: vi.fn((col: unknown) => ({ _desc: col })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'test-nanoid-00000000'),
+}));
+
+import { createTask, getTask, listTasks } from '@/lib/run/tasks';
+import type { DbOrTx } from '@/db';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validInput = {
+  name: 'Evaluate CV bullet',
+  prompt: 'Score this CV bullet against the role requirement.',
+  domain: 'job-application',
+};
+
+const fullInput = {
+  name: 'Full task',
+  description: 'A thorough task definition',
+  prompt: 'Do the thing.',
+  constraints: ['No hallucination', 'Stay on topic'],
+  expectedOutputShape: 'json' as const,
+  acceptanceCriteria: ['Correct answer', 'Well structured'],
+  domain: 'evaluation',
+};
+
+const fakeTask = {
+  id: 'test-nanoid-00000000',
+  name: 'Evaluate CV bullet',
+  description: null,
+  prompt: 'Score this CV bullet against the role requirement.',
+  constraints: null,
+  expectedOutputShape: null,
+  acceptanceCriteria: null,
+  domain: 'job-application',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  const mockOffset = vi.fn().mockResolvedValue([]);
+  const mockLimitList = vi.fn().mockReturnValue({ offset: mockOffset });
+  const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimitList });
+  const mockWhere = vi.fn().mockReturnValue({ limit: mockSelectLimit });
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+    orderBy: mockOrderBy,
+  });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+
+  return { mockFrom, mockWhere, mockOrderBy, mockLimitList, mockOffset };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/tasks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeTask]);
+    mockSelectLimit.mockResolvedValue([]);
+  });
+
+  // ── createTask ──────────────────────────────────────────────────────────
+
+  describe('createTask', () => {
+    it('persists and returns a task with generated id', async () => {
+      const result = await createTask(mockDb as unknown as DbOrTx, validInput);
+      expect(result).toEqual(fakeTask);
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes all fields including optional ones', async () => {
+      const fullTask = { ...fakeTask, ...fullInput, id: 'test-nanoid-00000000' };
+      mockReturning.mockResolvedValue([fullTask]);
+
+      const result = await createTask(mockDb as unknown as DbOrTx, fullInput);
+      expect(result.name).toBe('Full task');
+      expect(result.constraints).toEqual(['No hallucination', 'Stay on topic']);
+    });
+
+    it('rejects empty name', async () => {
+      await expect(
+        createTask(mockDb as unknown as DbOrTx, { ...validInput, name: '' }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects empty prompt', async () => {
+      await expect(
+        createTask(mockDb as unknown as DbOrTx, { ...validInput, prompt: '' }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects name over 256 characters', async () => {
+      await expect(
+        createTask(mockDb as unknown as DbOrTx, {
+          ...validInput,
+          name: 'x'.repeat(257),
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── getTask ─────────────────────────────────────────────────────────────
+
+  describe('getTask', () => {
+    it('returns null for missing id', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+      const result = await getTask(
+        mockDb as unknown as DbOrTx,
+        'nonexistent' as any,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns the task when found', async () => {
+      mockSelectLimit.mockResolvedValue([fakeTask]);
+      const result = await getTask(
+        mockDb as unknown as DbOrTx,
+        fakeTask.id as any,
+      );
+      expect(result).toEqual(fakeTask);
+    });
+  });
+
+  // ── listTasks ───────────────────────────────────────────────────────────
+
+  describe('listTasks', () => {
+    it('returns empty array when no tasks exist', async () => {
+      const result = await listTasks(mockDb as unknown as DbOrTx);
+      expect(result).toEqual([]);
+    });
+
+    it('calls with default limit and offset', async () => {
+      await listTasks(mockDb as unknown as DbOrTx);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes domain filter when specified', async () => {
+      const { mockFrom } = resetMockChains();
+
+      // For domain-filtered queries, the chain goes:
+      // select().from(tasks).where(eq(domain, val)).orderBy().limit().offset()
+      const mockOffset = vi.fn().mockResolvedValue([fakeTask]);
+      const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockWhere = vi.fn().mockReturnValue({
+        orderBy: mockOrderBy,
+      });
+      mockFrom.mockReturnValue({
+        where: mockWhere,
+        orderBy: mockOrderBy,
+      });
+
+      const result = await listTasks(mockDb as unknown as DbOrTx, {
+        domain: 'job-application',
+      });
+
+      // The domain filter should have been applied
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/run/tasks.test.ts
+++ b/tests/unit/run/tasks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { TaskId } from '@/lib/domain-ids';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks -- Drizzle query chain
@@ -168,7 +169,7 @@ describe('lib/run/tasks', () => {
       mockSelectLimit.mockResolvedValue([]);
       const result = await getTask(
         mockDb as unknown as DbOrTx,
-        'nonexistent' as any,
+        'nonexistent' as unknown as TaskId,
       );
       expect(result).toBeNull();
     });
@@ -177,7 +178,7 @@ describe('lib/run/tasks', () => {
       mockSelectLimit.mockResolvedValue([fakeTask]);
       const result = await getTask(
         mockDb as unknown as DbOrTx,
-        fakeTask.id as any,
+        fakeTask.id as unknown as TaskId,
       );
       expect(result).toEqual(fakeTask);
     });
@@ -212,7 +213,7 @@ describe('lib/run/tasks', () => {
         orderBy: mockOrderBy,
       });
 
-      const result = await listTasks(mockDb as unknown as DbOrTx, {
+      await listTasks(mockDb as unknown as DbOrTx, {
         domain: 'job-application',
       });
 


### PR DESCRIPTION
## Summary

Complete Phase 1 implementation of the run model. Closes #100, #102, #104, #106, #109.

### M1.1 - Tasks table
- `tasks` table with nanoid PK, prompt, constraints, acceptance criteria, domain
- `TaskId` branded type, `createTaskSchema` Zod schema
- `createTask`, `getTask`, `listTasks` domain functions
- 8 unit tests

### M1.2 - Runs table
- `runs` table with status enum (pending/running/completed/failed), owner, metadata
- `RunId` branded type
- `createRun`, `getRun`, `listRuns` domain functions
- 7 unit tests

### M1.3 - Contestants table
- `contestants` table with model config, system prompt, context bundle (JSONB)
- `ContestantId` branded type, `addContestantSchema` Zod schema
- `addContestant`, `getContestantsForRun` domain functions
- 7 unit tests

### M1.4 - Execution engine
- `traces` table capturing request, response, tokens, latency, status
- `TraceId` branded type
- `executeRun`: loads task + contestants, calls models via AI SDK, captures traces
- `buildMessages`: constructs message array from task + contestant config
- `sweepStaleRuns`: marks zombie runs as failed
- Single contestant failure continues; all fail = run failed
- 13 unit tests

### M1.5 - Run API
- `POST /api/runs`: create run with inline task or taskId + 2+ contestants (201)
- `GET /api/runs`: list with status/taskId/ownerId filters, pagination (200)
- `GET /api/runs/:id`: run with task, contestants, traces via composite query (200/404)
- `POST /api/runs/:id/execute`: execute pending run, 120s maxDuration (200/404/409)
- `getRunWithTraces` composite query, `createRunSchema` Zod union
- 14 API tests, 5 query unit tests

### Stats
- 4 migrations, 4 branded types, 4 Zod schemas
- 17 new files, ~1,830 lines added
- 54 new tests, 1,576 total passing
- Gate green: typecheck + lint + test

## Test plan

- [x] 54 new tests covering CRUD, execution lifecycle, error handling, API validation
- [x] Zero regressions on existing 1,522 tests
- [x] Gate green: typecheck (0 errors), lint (0 errors)
- [ ] Manual: create + execute a run via API
- [ ] Manual: verify traces contain model/messages/response/tokens/latency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Create and manage tasks for competitive AI model evaluation
  * Execute runs with multiple models and track performance metrics
  * Record detailed execution traces for comprehensive analysis
  * Support task constraints, acceptance criteria, and domain classification

* **Tests**
  * Added comprehensive test coverage for evaluation workflows and APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->