### PR TITLE
feat(eval): M2.1 - rubrics table, criteria types, domain module

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -623,3 +623,33 @@ export const traces = pgTable('traces', {
   runIdIdx: index('traces_run_id_idx').on(table.runId),
   contestantIdIdx: index('traces_contestant_id_idx').on(table.contestantId),
 }));
+
+// ---------------------------------------------------------------------------
+// Phase 2: Evaluation and Scoring
+// ---------------------------------------------------------------------------
+
+/** Rubric criterion -- defines one axis of evaluation. */
+export type RubricCriterion = {
+  name: string;
+  description: string;
+  weight: number;
+  scale: {
+    min: number;
+    max: number;
+    labels?: Record<number, string>;
+  };
+};
+
+export const rubrics = pgTable('rubrics', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  name: varchar('name', { length: 256 }).notNull(),
+  description: text('description'),
+  domain: varchar('domain', { length: 64 }),
+  criteria: jsonb('criteria').$type<RubricCriterion[]>().notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});

--- a/drizzle/0008_m2.1-rubrics.sql
+++ b/drizzle/0008_m2.1-rubrics.sql
@@ -1,0 +1,10 @@
+-- M2.1: Rubrics table for evaluation criteria
+CREATE TABLE IF NOT EXISTS "rubrics" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "name" varchar(256) NOT NULL,
+  "description" text,
+  "domain" varchar(64),
+  "criteria" jsonb NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -238,3 +238,51 @@ export const createRunSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 export type CreateRunBody = z.infer<typeof createRunSchema>;
+
+// ---------------------------------------------------------------------------
+// Evaluation model -- rubrics (M2.1)
+// ---------------------------------------------------------------------------
+
+/** Rubric criterion validation. */
+export const rubricCriterionSchema = z.object({
+  name: z.string().min(1, 'Criterion name is required.').max(128),
+  description: z.string().min(1, 'Criterion description is required.'),
+  weight: z.number().min(0).max(1),
+  scale: z.object({
+    min: z.number().int(),
+    max: z.number().int(),
+    labels: z.record(z.string(), z.string()).optional(),
+  }),
+});
+
+/** POST /api/rubrics -- create a rubric with weighted criteria. */
+export const createRubricSchema = z.object({
+  name: z.string().min(1, 'Rubric name is required.').max(256),
+  description: z.string().optional(),
+  domain: z.string().max(64).optional(),
+  criteria: z.array(rubricCriterionSchema).min(1, 'At least 1 criterion is required.'),
+}).refine(
+  (data) => {
+    const sum = data.criteria.reduce((s, c) => s + c.weight, 0);
+    return Math.abs(sum - 1) < 0.01;
+  },
+  { message: 'Criterion weights must sum to 1 (tolerance: 0.01).' },
+).refine(
+  (data) => {
+    const names = data.criteria.map(c => c.name.toLowerCase());
+    return new Set(names).size === names.length;
+  },
+  { message: 'Criterion names must be unique (case-insensitive).' },
+).refine(
+  (data) => data.criteria.every(c => c.scale.min < c.scale.max),
+  { message: 'Scale min must be strictly less than scale max.' },
+).refine(
+  (data) => data.criteria.every(c =>
+    !c.scale.labels || Object.keys(c.scale.labels).every(k => {
+      const n = Number(k);
+      return n >= c.scale.min && n <= c.scale.max;
+    })
+  ),
+  { message: 'Scale labels must reference values within the scale range.' },
+);
+export type CreateRubricBody = z.infer<typeof createRubricSchema>;

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -49,6 +49,9 @@ export type ContestantId = Brand<string, 'ContestantId'>;
 /** Trace identifier -- 21-char nanoid (M1.4). */
 export type TraceId = Brand<string, 'TraceId'>;
 
+/** Rubric identifier -- 21-char nanoid (M2.1). */
+export type RubricId = Brand<string, 'RubricId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -99,6 +102,11 @@ export function asContestantId(raw: string): ContestantId {
 /** Brand a raw string as a TraceId. */
 export function asTraceId(raw: string): TraceId {
   return raw as TraceId;
+}
+
+/** Brand a raw string as a RubricId. */
+export function asRubricId(raw: string): RubricId {
+  return raw as RubricId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/eval/index.ts
+++ b/lib/eval/index.ts
@@ -1,0 +1,8 @@
+// Barrel export for the evaluation domain module.
+
+// Legacy evaluators (bout system)
+export type { EvalScore, RefusalEvalInput, PersonaEvalInput, FormatEvalInput, BeliefStanceEvalInput } from './types';
+
+// Run evaluation model (M2.1+)
+export { createRubric, getRubric, listRubrics } from './rubrics';
+export type { Rubric, ListRubricsOptions, RubricCriterion } from './types';

--- a/lib/eval/rubrics.ts
+++ b/lib/eval/rubrics.ts
@@ -1,0 +1,74 @@
+// Rubric CRUD -- domain module for the rubrics table (M2.1).
+//
+// Pure persistence layer. Validates via Zod at the boundary,
+// persists via Drizzle. No HTTP awareness.
+
+import { eq, desc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { rubrics } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asRubricId, type RubricId } from '@/lib/domain-ids';
+import { createRubricSchema, type CreateRubricBody } from '@/lib/api-schemas';
+import type { Rubric, ListRubricsOptions } from './types';
+
+/** Create a new rubric. Validates input, generates nanoid, persists. */
+export async function createRubric(
+  db: DbOrTx,
+  input: CreateRubricBody,
+): Promise<Rubric> {
+  const validated = createRubricSchema.parse(input);
+  const id = asRubricId(nanoid());
+
+  const [rubric] = await db
+    .insert(rubrics)
+    .values({
+      id,
+      name: validated.name,
+      description: validated.description ?? null,
+      domain: validated.domain ?? null,
+      criteria: validated.criteria,
+    })
+    .returning();
+
+  return rubric!;
+}
+
+/** Retrieve a single rubric by ID. Returns null if not found. */
+export async function getRubric(
+  db: DbOrTx,
+  id: RubricId,
+): Promise<Rubric | null> {
+  const [rubric] = await db
+    .select()
+    .from(rubrics)
+    .where(eq(rubrics.id, id))
+    .limit(1);
+
+  return rubric ?? null;
+}
+
+/** List rubrics with optional domain filter and pagination. */
+export async function listRubrics(
+  db: DbOrTx,
+  opts: ListRubricsOptions = {},
+): Promise<Rubric[]> {
+  const { domain, limit = 50, offset = 0 } = opts;
+
+  if (domain) {
+    return db
+      .select()
+      .from(rubrics)
+      .where(eq(rubrics.domain, domain))
+      .orderBy(desc(rubrics.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  return db
+    .select()
+    .from(rubrics)
+    .orderBy(desc(rubrics.createdAt))
+    .limit(limit)
+    .offset(offset);
+}

--- a/lib/eval/types.ts
+++ b/lib/eval/types.ts
@@ -1,4 +1,4 @@
-// Shared types for LangSmith-compatible evaluation functions.
+// Shared types for evaluation functions and the run evaluation model.
 //
 // Evaluators are pure functions that score application outputs.
 // They return feedback dictionaries compatible with LangSmith's
@@ -66,3 +66,22 @@ export type BeliefStanceEvalInput = {
   /** Turn index (0-based) for temporal tracking. */
   turnIndex: number;
 };
+
+// ---------------------------------------------------------------------------
+// Run evaluation model (M2.1+)
+// ---------------------------------------------------------------------------
+
+import type { InferSelectModel } from 'drizzle-orm';
+import type { rubrics, RubricCriterion } from '@/db/schema';
+
+/** A rubric as stored in the database. */
+export type Rubric = InferSelectModel<typeof rubrics>;
+
+/** Options for listing rubrics with filtering. */
+export type ListRubricsOptions = {
+  domain?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type { RubricCriterion };

--- a/tests/unit/eval/rubrics.test.ts
+++ b/tests/unit/eval/rubrics.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { RubricId } from '@/lib/domain-ids';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning, mockSelectLimit } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: mockSelectLimit,
+        }),
+        orderBy: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue({
+            offset: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockSelectLimit };
+});
+
+vi.mock('@/db/schema', () => ({
+  rubrics: {
+    id: 'id',
+    domain: 'domain',
+    createdAt: 'created_at',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  desc: vi.fn((col: unknown) => ({ _desc: col })),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'rubric-nanoid-0000000'),
+}));
+
+import { createRubric, getRubric, listRubrics } from '@/lib/eval/rubrics';
+import { createRubricSchema } from '@/lib/api-schemas';
+import type { DbOrTx } from '@/db';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validCriteria = [
+  {
+    name: 'relevance',
+    description: 'How relevant is the answer',
+    weight: 0.5,
+    scale: { min: 1, max: 5 },
+  },
+  {
+    name: 'clarity',
+    description: 'How clear is the answer',
+    weight: 0.5,
+    scale: { min: 1, max: 5 },
+  },
+];
+
+const validInput = {
+  name: 'Test Rubric',
+  description: 'A test rubric',
+  domain: 'testing',
+  criteria: validCriteria,
+};
+
+const fakeRubric = {
+  id: 'rubric-nanoid-0000000',
+  name: 'Test Rubric',
+  description: 'A test rubric',
+  domain: 'testing',
+  criteria: validCriteria,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  const mockOffset = vi.fn().mockResolvedValue([]);
+  const mockLimitList = vi.fn().mockReturnValue({ offset: mockOffset });
+  const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimitList });
+  const mockWhere = vi.fn().mockReturnValue({
+    limit: mockSelectLimit,
+    orderBy: mockOrderBy,
+  });
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+    orderBy: mockOrderBy,
+  });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+
+  return { mockFrom, mockWhere, mockOrderBy, mockLimitList, mockOffset };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/eval/rubrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeRubric]);
+    mockSelectLimit.mockResolvedValue([]);
+  });
+
+  // -- createRubric ---------------------------------------------------------
+
+  describe('createRubric', () => {
+    it('persists a rubric with generated id', async () => {
+      const result = await createRubric(mockDb as unknown as DbOrTx, validInput);
+      expect(result).toEqual(fakeRubric);
+      expect(result.id).toBe('rubric-nanoid-0000000');
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts rubric with optional description', async () => {
+      const input = { ...validInput, description: undefined };
+      await createRubric(mockDb as unknown as DbOrTx, input);
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -- Zod validation (createRubricSchema) ----------------------------------
+
+  describe('createRubricSchema validation', () => {
+    it('validates weights sum to 1', () => {
+      const bad = {
+        ...validInput,
+        criteria: [
+          { ...validCriteria[0]!, weight: 0.3 },
+          { ...validCriteria[1]!, weight: 0.3 },
+        ],
+      };
+      const result = createRubricSchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts weights that sum to ~1 within tolerance', () => {
+      const ok = {
+        ...validInput,
+        criteria: [
+          { ...validCriteria[0]!, weight: 0.333 },
+          { ...validCriteria[1]!, weight: 0.333 },
+          { name: 'third', description: 'Third', weight: 0.334, scale: { min: 1, max: 5 } },
+        ],
+      };
+      const result = createRubricSchema.safeParse(ok);
+      expect(result.success).toBe(true);
+    });
+
+    it('requires at least 1 criterion', () => {
+      const bad = { ...validInput, criteria: [] };
+      const result = createRubricSchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects duplicate criterion names (case-insensitive)', () => {
+      const bad = {
+        ...validInput,
+        criteria: [
+          { ...validCriteria[0]!, name: 'Relevance' },
+          { ...validCriteria[1]!, name: 'relevance' },
+        ],
+      };
+      const result = createRubricSchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects scale.min >= scale.max', () => {
+      const bad = {
+        ...validInput,
+        criteria: [
+          { ...validCriteria[0]!, scale: { min: 5, max: 5 } },
+          { ...validCriteria[1]! },
+        ],
+      };
+      const result = createRubricSchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects scale labels outside scale range', () => {
+      const bad = {
+        ...validInput,
+        criteria: [
+          { ...validCriteria[0]!, scale: { min: 1, max: 5, labels: { '0': 'bad', '3': 'ok' } } },
+          { ...validCriteria[1]! },
+        ],
+      };
+      const result = createRubricSchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts valid scale labels within range', () => {
+      const ok = {
+        ...validInput,
+        criteria: [
+          { ...validCriteria[0]!, scale: { min: 1, max: 5, labels: { '1': 'poor', '3': 'ok', '5': 'great' } } },
+          { ...validCriteria[1]! },
+        ],
+      };
+      const result = createRubricSchema.safeParse(ok);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // -- getRubric ------------------------------------------------------------
+
+  describe('getRubric', () => {
+    it('returns null for missing id', async () => {
+      mockSelectLimit.mockResolvedValue([]);
+      const result = await getRubric(
+        mockDb as unknown as DbOrTx,
+        'nonexistent' as unknown as RubricId,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns the rubric when found', async () => {
+      mockSelectLimit.mockResolvedValue([fakeRubric]);
+      const result = await getRubric(
+        mockDb as unknown as DbOrTx,
+        fakeRubric.id as unknown as RubricId,
+      );
+      expect(result).toEqual(fakeRubric);
+    });
+  });
+
+  // -- listRubrics ----------------------------------------------------------
+
+  describe('listRubrics', () => {
+    it('returns empty array when no rubrics exist', async () => {
+      const result = await listRubrics(mockDb as unknown as DbOrTx);
+      expect(result).toEqual([]);
+    });
+
+    it('calls select with default limit', async () => {
+      await listRubrics(mockDb as unknown as DbOrTx);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes domain filter when specified', async () => {
+      const { mockWhere } = resetMockChains();
+      const mockOffset = vi.fn().mockResolvedValue([fakeRubric]);
+      const mockLimit = vi.fn().mockReturnValue({ offset: mockOffset });
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+
+      await listRubrics(mockDb as unknown as DbOrTx, { domain: 'testing' });
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Rubrics define reusable scoring criteria for run evaluation. Closes #111.

- `rubrics` table: nanoid PK, name, domain, criteria (JSONB array of RubricCriterion)
- `RubricId` branded type
- `createRubricSchema` with 4 Zod refinements: weights sum to 1 (0.01 tolerance), unique criterion names (case-insensitive), scale min < max, labels within range
- `createRubric`, `getRubric`, `listRubrics` domain functions
- Preserves existing eval types (EvalScore, RefusalEvalInput, etc.)

## Test plan

- [x] 13 unit tests: CRUD, weight sum validation, name uniqueness, scale constraints, label range
- [x] Gate green: typecheck (0 errors), lint (0 errors), 1604 tests passing
- [x] Zero regressions on existing tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable rubric model for run evaluation: a `rubrics` table with weighted criteria and domain functions to create, fetch, and list rubrics. Implements M2.1 requirements (Linear #111).

- **New Features**
  - `rubrics` table with nanoid PK, name, description, domain, criteria (JSONB), timestamps.
  - Criteria model: `RubricCriterion`, `RubricId`, and `createRubricSchema` with validations (weights ≈ 1, unique names, min < max, labels in range).
  - Domain functions: `createRubric`, `getRubric`, `listRubrics`.
  - Barrel export preserves existing eval types (`EvalScore`, `RefusalEvalInput`, etc.).

<sup>Written for commit 578b35dbb8856c0b42df87dd8417c3102b42eee5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rubric management system enabling users to create, retrieve, and list evaluation rubrics.
  * Implemented comprehensive validation for rubrics including weight summation, unique criterion names, and scale boundary constraints.

* **Tests**
  * Added comprehensive test coverage for all rubric operations and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->