### PR TITLE
feat(eval): M2.4 failure tagging for run evaluation

### DIFF
--- a/app/api/runs/[id]/failures/route.ts
+++ b/app/api/runs/[id]/failures/route.ts
@@ -1,0 +1,63 @@
+// GET/POST /api/runs/:id/failures -- failure tag CRUD (M2.4).
+//
+// GET: list failure tags for a run.
+// POST: add a manual failure tag (auth required).
+
+import { auth } from '@clerk/nextjs/server';
+import { requireDb } from '@/db';
+import { asRunId, asContestantId } from '@/lib/domain-ids';
+import { parseValidBody, errorResponse, API_ERRORS } from '@/lib/api-utils';
+import { log } from '@/lib/logger';
+import { addFailureTagSchema } from '@/lib/api-schemas';
+import { addFailureTag, getFailureTagsForRun } from '@/lib/eval/failure-tags';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  try {
+    const db = requireDb();
+    const tags = await getFailureTagsForRun(db, asRunId(id));
+    return Response.json(tags, { status: 200 });
+  } catch (error) {
+    log.error('GET /api/runs/[id]/failures failed', error instanceof Error ? error : new Error(String(error)));
+    return errorResponse(API_ERRORS.INTERNAL, 500);
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return errorResponse(API_ERRORS.AUTH_REQUIRED, 401);
+  }
+
+  const { id } = await params;
+
+  const parsed = await parseValidBody(req, addFailureTagSchema);
+  if (parsed.error) return parsed.error;
+
+  const { contestantId, category, description } = parsed.data;
+
+  try {
+    const db = requireDb();
+    const tag = await addFailureTag(db, {
+      runId: asRunId(id),
+      contestantId: asContestantId(contestantId),
+      category,
+      description: description ?? null,
+      source: 'manual',
+      evaluationId: null,
+    });
+    return Response.json(tag, { status: 201 });
+  } catch (error) {
+    log.error('POST /api/runs/[id]/failures failed', error instanceof Error ? error : new Error(String(error)));
+    return errorResponse(API_ERRORS.INTERNAL, 500);
+  }
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -700,3 +700,41 @@ export const evaluations = pgTable('evaluations', {
   index('evaluations_contestant_id_idx').on(table.contestantId),
   index('evaluations_rubric_id_idx').on(table.rubricId),
 ]);
+
+// ---------------------------------------------------------------------------
+// Phase 2: Failure Tags (M2.4)
+// ---------------------------------------------------------------------------
+
+export const failureCategory = pgEnum('failure_category', [
+  'wrong_answer',
+  'partial_answer',
+  'refusal',
+  'off_topic',
+  'unsafe_output',
+  'hallucination',
+  'format_violation',
+  'context_misuse',
+  'instruction_violation',
+]);
+
+export const failureTags = pgTable('failure_tags', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  runId: varchar('run_id', { length: 21 })
+    .notNull()
+    .references(() => runs.id, { onDelete: 'cascade' }),
+  contestantId: varchar('contestant_id', { length: 21 })
+    .notNull()
+    .references(() => contestants.id, { onDelete: 'cascade' }),
+  category: failureCategory('category').notNull(),
+  description: text('description'),
+  source: varchar('source', { length: 32 }).notNull(),
+  evaluationId: varchar('evaluation_id', { length: 21 })
+    .references(() => evaluations.id),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => [
+  index('failure_tags_run_id_idx').on(table.runId),
+  index('failure_tags_contestant_id_idx').on(table.contestantId),
+  index('failure_tags_category_idx').on(table.category),
+]);

--- a/drizzle/0010_m2.4-failure-tags.sql
+++ b/drizzle/0010_m2.4-failure-tags.sql
@@ -1,0 +1,28 @@
+-- M2.4: Failure tags for run evaluation
+
+CREATE TYPE "public"."failure_category" AS ENUM(
+  'wrong_answer',
+  'partial_answer',
+  'refusal',
+  'off_topic',
+  'unsafe_output',
+  'hallucination',
+  'format_violation',
+  'context_misuse',
+  'instruction_violation'
+);
+
+CREATE TABLE "failure_tags" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "run_id" varchar(21) NOT NULL REFERENCES "runs"("id") ON DELETE CASCADE,
+  "contestant_id" varchar(21) NOT NULL REFERENCES "contestants"("id") ON DELETE CASCADE,
+  "category" "failure_category" NOT NULL,
+  "description" text,
+  "source" varchar(32) NOT NULL,
+  "evaluation_id" varchar(21) REFERENCES "evaluations"("id"),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX "failure_tags_run_id_idx" ON "failure_tags" USING btree ("run_id");
+CREATE INDEX "failure_tags_contestant_id_idx" ON "failure_tags" USING btree ("contestant_id");
+CREATE INDEX "failure_tags_category_idx" ON "failure_tags" USING btree ("category");

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -297,3 +297,28 @@ export const evaluateRunSchema = z.object({
   judgeModel: z.string().max(128).optional(),
 });
 export type EvaluateRunBody = z.infer<typeof evaluateRunSchema>;
+
+// ---------------------------------------------------------------------------
+// Failure tags (M2.4)
+// ---------------------------------------------------------------------------
+
+/** Failure category values -- mirrors failureCategory pgEnum in db/schema.ts. */
+const FAILURE_CATEGORIES = [
+  'wrong_answer',
+  'partial_answer',
+  'refusal',
+  'off_topic',
+  'unsafe_output',
+  'hallucination',
+  'format_violation',
+  'context_misuse',
+  'instruction_violation',
+] as const;
+
+/** POST /api/runs/:id/failures -- add a manual failure tag. */
+export const addFailureTagSchema = z.object({
+  contestantId: z.string().length(21, 'contestantId must be 21 characters.'),
+  category: z.enum(FAILURE_CATEGORIES, { message: 'Invalid failure category.' }),
+  description: z.string().optional(),
+});
+export type AddFailureTagBody = z.infer<typeof addFailureTagSchema>;

--- a/lib/domain-ids.ts
+++ b/lib/domain-ids.ts
@@ -55,6 +55,9 @@ export type RubricId = Brand<string, 'RubricId'>;
 /** Evaluation identifier -- 21-char nanoid (M2.2). */
 export type EvaluationId = Brand<string, 'EvaluationId'>;
 
+/** Failure tag identifier -- 21-char nanoid (M2.4). */
+export type FailureTagId = Brand<string, 'FailureTagId'>;
+
 // ─── Brand constructors ─────────────────────────────────────────────────────
 //
 // These cast raw values to branded types. Use them at trust boundaries:
@@ -115,6 +118,11 @@ export function asRubricId(raw: string): RubricId {
 /** Brand a raw string as an EvaluationId. */
 export function asEvaluationId(raw: string): EvaluationId {
   return raw as EvaluationId;
+}
+
+/** Brand a raw string as a FailureTagId. */
+export function asFailureTagId(raw: string): FailureTagId {
+  return raw as FailureTagId;
 }
 
 // ─── Type guards ────────────────────────────────────────────────────────────

--- a/lib/eval/failure-tags.ts
+++ b/lib/eval/failure-tags.ts
@@ -1,0 +1,107 @@
+// Failure tag persistence -- domain module for the failure_tags table (M2.4).
+//
+// Pure persistence layer. No HTTP awareness, no AI calls.
+// Tags can be assigned manually (via API) or by the judge engine.
+
+import { eq, sql } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+import { failureTags, failureCategory } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import { asFailureTagId } from '@/lib/domain-ids';
+import type { RunId, ContestantId, EvaluationId } from '@/lib/domain-ids';
+import type { FailureTag, FailureCategory } from './types';
+
+// ---------------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------------
+
+export type AddFailureTagInput = {
+  runId: RunId;
+  contestantId: ContestantId;
+  category: FailureCategory;
+  description?: string | null;
+  source: 'manual' | 'judge';
+  evaluationId?: EvaluationId | null;
+};
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+/** Persist a new failure tag. Returns the created tag. */
+export async function addFailureTag(
+  db: DbOrTx,
+  input: AddFailureTagInput,
+): Promise<FailureTag> {
+  const id = asFailureTagId(nanoid());
+
+  const [tag] = await db
+    .insert(failureTags)
+    .values({
+      id,
+      runId: input.runId,
+      contestantId: input.contestantId,
+      category: input.category,
+      description: input.description ?? null,
+      source: input.source,
+      evaluationId: input.evaluationId ?? null,
+    })
+    .returning();
+
+  return tag!;
+}
+
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+/** Get all failure tags for a run. */
+export async function getFailureTagsForRun(
+  db: DbOrTx,
+  runId: RunId,
+): Promise<FailureTag[]> {
+  return db
+    .select()
+    .from(failureTags)
+    .where(eq(failureTags.runId, runId));
+}
+
+/** Get all failure tags for a contestant. */
+export async function getFailureTagsForContestant(
+  db: DbOrTx,
+  contestantId: ContestantId,
+): Promise<FailureTag[]> {
+  return db
+    .select()
+    .from(failureTags)
+    .where(eq(failureTags.contestantId, contestantId));
+}
+
+/** Get failure distribution counts by category. */
+export async function getFailureDistribution(
+  db: DbOrTx,
+  opts?: { runId?: RunId; domain?: string },
+): Promise<Record<FailureCategory, number>> {
+  // Initialize all categories to 0
+  const distribution = Object.fromEntries(
+    failureCategory.enumValues.map((c) => [c, 0]),
+  ) as Record<FailureCategory, number>;
+
+  const baseQuery = db
+    .select({
+      category: failureTags.category,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(failureTags);
+
+  const rows = opts?.runId
+    ? await baseQuery.where(eq(failureTags.runId, opts.runId)).groupBy(failureTags.category)
+    : await baseQuery.groupBy(failureTags.category);
+
+  for (const row of rows) {
+    distribution[row.category] = row.count;
+  }
+
+  return distribution;
+}

--- a/lib/eval/index.ts
+++ b/lib/eval/index.ts
@@ -18,3 +18,8 @@ export type { InsertEvaluationInput } from './evaluations';
 // Scorecard and comparison (M2.3)
 export { buildScorecard, compareRun } from './scoring';
 export type { Scorecard, RunComparison } from './types';
+
+// Failure tags (M2.4)
+export { addFailureTag, getFailureTagsForRun, getFailureTagsForContestant, getFailureDistribution } from './failure-tags';
+export type { AddFailureTagInput } from './failure-tags';
+export type { FailureTag, FailureCategory } from './types';

--- a/lib/eval/judge.ts
+++ b/lib/eval/judge.ts
@@ -10,13 +10,14 @@ import { eq } from 'drizzle-orm';
 import { runs, contestants, traces, tasks } from '@/db/schema';
 import type { DbOrTx } from '@/db';
 import { getModel } from '@/lib/ai';
-import type { RunId, RubricId, ContestantId } from '@/lib/domain-ids';
-import type { Rubric, Evaluation, RubricCriterion } from './types';
+import type { RunId, RubricId, ContestantId, EvaluationId } from '@/lib/domain-ids';
+import type { Rubric, Evaluation, RubricCriterion, FailureCategory } from './types';
 import type { CriterionScore, ReconciliationEvent } from '@/db/schema';
 import type { TraceMessage } from '@/db/schema';
 import { getRubric } from './rubrics';
 import { insertEvaluation } from './evaluations';
 import { computeWeightedScore } from './scoring';
+import { addFailureTag } from './failure-tags';
 
 // ---------------------------------------------------------------------------
 // Judge config
@@ -39,6 +40,20 @@ const judgeOutputSchema = z.object({
     rationale: z.string().min(1),
   })),
   overallRationale: z.string().min(1),
+  failureTags: z.array(z.object({
+    category: z.enum([
+      'wrong_answer',
+      'partial_answer',
+      'refusal',
+      'off_topic',
+      'unsafe_output',
+      'hallucination',
+      'format_violation',
+      'context_misuse',
+      'instruction_violation',
+    ]),
+    description: z.string(),
+  })).optional(),
 });
 
 type JudgeOutput = z.infer<typeof judgeOutputSchema>;
@@ -217,6 +232,20 @@ export async function evaluateContestant(
     outputTokens: result.usage?.outputTokens ?? null,
     latencyMs,
   });
+
+  // Persist judge-assigned failure tags (M2.4)
+  if (judgeOutput.failureTags && judgeOutput.failureTags.length > 0) {
+    for (const ft of judgeOutput.failureTags) {
+      await addFailureTag(db, {
+        runId: trace.runId as RunId,
+        contestantId: trace.contestantId as ContestantId,
+        category: ft.category as FailureCategory,
+        description: ft.description,
+        source: 'judge',
+        evaluationId: evaluation.id as EvaluationId,
+      });
+    }
+  }
 
   return evaluation;
 }

--- a/lib/eval/types.ts
+++ b/lib/eval/types.ts
@@ -75,10 +75,12 @@ import type { InferSelectModel } from 'drizzle-orm';
 import type {
   rubrics,
   evaluations,
+  failureTags,
   RubricCriterion,
   CriterionScore,
   ReconciliationEvent,
 } from '@/db/schema';
+import type { failureCategory } from '@/db/schema';
 
 /** A rubric as stored in the database. */
 export type Rubric = InferSelectModel<typeof rubrics>;
@@ -140,3 +142,13 @@ export type RunComparison = {
     winner: string | null;
   }>;
 };
+
+// ---------------------------------------------------------------------------
+// Failure tags (M2.4)
+// ---------------------------------------------------------------------------
+
+/** A failure tag as stored in the database. */
+export type FailureTag = InferSelectModel<typeof failureTags>;
+
+/** Failure category enum values. */
+export type FailureCategory = (typeof failureCategory.enumValues)[number];

--- a/tests/api/eval/failures.test.ts
+++ b/tests/api/eval/failures.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockAuth = vi.hoisted(() => vi.fn().mockResolvedValue({ userId: 'user-1' }));
+const mockRequireDb = vi.hoisted(() => vi.fn().mockReturnValue({}));
+const mockAddFailureTag = vi.hoisted(() => vi.fn());
+const mockGetFailureTagsForRun = vi.hoisted(() => vi.fn());
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: mockAuth }));
+vi.mock('@/db', () => ({ requireDb: mockRequireDb }));
+vi.mock('@/lib/eval/failure-tags', () => ({
+  addFailureTag: mockAddFailureTag,
+  getFailureTagsForRun: mockGetFailureTagsForRun,
+}));
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeTag = {
+  id: 'ftag-00000000000000000',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-0000000000000000',
+  category: 'wrong_answer',
+  description: 'Incorrect output',
+  source: 'manual',
+  evaluationId: null,
+  createdAt: new Date().toISOString(),
+};
+
+const validBody = {
+  contestantId: 'cont-0000000000000000',
+  category: 'wrong_answer',
+  description: 'Incorrect output',
+};
+
+function makeRequest(method: string, url: string, body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/runs/:id/failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: 'user-1' });
+    mockAddFailureTag.mockResolvedValue(fakeTag);
+  });
+
+  it('creates tag (201)', async () => {
+    const { POST } = await import('@/app/api/runs/[id]/failures/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs/run-000/failures', validBody);
+    const res = await POST(req, { params: Promise.resolve({ id: 'run-000' }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.id).toBe(fakeTag.id);
+    expect(json.category).toBe('wrong_answer');
+    expect(json.source).toBe('manual');
+  });
+
+  it('validates category enum (400)', async () => {
+    const { POST } = await import('@/app/api/runs/[id]/failures/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs/run-000/failures', {
+      contestantId: 'cont-0000000000000000',
+      category: 'nonexistent_category',
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: 'run-000' }) });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unauthenticated (401)', async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+
+    const { POST } = await import('@/app/api/runs/[id]/failures/route');
+    const req = makeRequest('POST', 'http://localhost/api/runs/run-000/failures', validBody);
+    const res = await POST(req, { params: Promise.resolve({ id: 'run-000' }) });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/runs/:id/failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFailureTagsForRun.mockResolvedValue([fakeTag]);
+  });
+
+  it('returns tags (200)', async () => {
+    const { GET } = await import('@/app/api/runs/[id]/failures/route');
+    const req = makeRequest('GET', 'http://localhost/api/runs/run-000/failures');
+    const res = await GET(req, { params: Promise.resolve({ id: 'run-000' }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toHaveLength(1);
+    expect(json[0].category).toBe('wrong_answer');
+  });
+});

--- a/tests/unit/eval/failure-tags.test.ts
+++ b/tests/unit/eval/failure-tags.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { RunId, ContestantId, EvaluationId } from '@/lib/domain-ids';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks -- Drizzle query chain
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockReturning } = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([]);
+  const mockGroupBy = vi.fn().mockResolvedValue([]);
+  const mockWhere = vi.fn();
+
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: mockReturning,
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockWhere.mockReturnValue([]),
+        groupBy: mockGroupBy,
+      }),
+    }),
+  };
+  return { mockDb, mockReturning, mockGroupBy, mockWhere };
+});
+
+vi.mock('@/db/schema', () => ({
+  failureTags: {
+    id: 'id',
+    runId: 'run_id',
+    contestantId: 'contestant_id',
+    category: 'category',
+  },
+  failureCategory: {
+    enumValues: [
+      'wrong_answer',
+      'partial_answer',
+      'refusal',
+      'off_topic',
+      'unsafe_output',
+      'hallucination',
+      'format_violation',
+      'context_misuse',
+      'instruction_violation',
+    ],
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => ({ _eq: val })),
+  sql: vi.fn(),
+}));
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'ftag-nanoid-000000000'),
+}));
+
+import { addFailureTag, getFailureTagsForRun, getFailureTagsForContestant, getFailureDistribution } from '@/lib/eval/failure-tags';
+import type { DbOrTx } from '@/db';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeTag = {
+  id: 'ftag-nanoid-000000000',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-00000000000000000',
+  category: 'wrong_answer' as const,
+  description: 'Gave incorrect result',
+  source: 'manual',
+  evaluationId: null,
+  createdAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetMockChains() {
+  mockDb.insert.mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: mockReturning,
+    }),
+  });
+
+  const mockWhere = vi.fn().mockResolvedValue([]);
+  const mockGroupBy = vi.fn().mockResolvedValue([]);
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+    groupBy: mockGroupBy,
+  });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+
+  return { mockFrom, mockWhere, mockGroupBy };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/eval/failure-tags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockChains();
+    mockReturning.mockResolvedValue([fakeTag]);
+  });
+
+  // -- addFailureTag ---------------------------------------------------------
+
+  describe('addFailureTag', () => {
+    it('persists with category and source', async () => {
+      const result = await addFailureTag(mockDb as unknown as DbOrTx, {
+        runId: 'run-000000000000000000' as RunId,
+        contestantId: 'cont-00000000000000000' as ContestantId,
+        category: 'wrong_answer',
+        description: 'Gave incorrect result',
+        source: 'manual',
+      });
+
+      expect(result).toEqual(fakeTag);
+      expect(result.category).toBe('wrong_answer');
+      expect(result.source).toBe('manual');
+      expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('links evaluationId when provided', async () => {
+      const tagWithEval = {
+        ...fakeTag,
+        source: 'judge',
+        evaluationId: 'eval-00000000000000000',
+      };
+      mockReturning.mockResolvedValue([tagWithEval]);
+
+      const result = await addFailureTag(mockDb as unknown as DbOrTx, {
+        runId: 'run-000000000000000000' as RunId,
+        contestantId: 'cont-00000000000000000' as ContestantId,
+        category: 'wrong_answer',
+        description: 'Gave incorrect result',
+        source: 'judge',
+        evaluationId: 'eval-00000000000000000' as EvaluationId,
+      });
+
+      expect(result.evaluationId).toBe('eval-00000000000000000');
+      expect(result.source).toBe('judge');
+    });
+  });
+
+  // -- getFailureTagsForRun --------------------------------------------------
+
+  describe('getFailureTagsForRun', () => {
+    it('returns all tags for a run', async () => {
+      const { mockWhere } = resetMockChains();
+      mockWhere.mockResolvedValue([fakeTag, { ...fakeTag, id: 'ftag-2', category: 'refusal' }]);
+
+      const result = await getFailureTagsForRun(
+        mockDb as unknown as DbOrTx,
+        'run-000000000000000000' as RunId,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -- getFailureTagsForContestant -------------------------------------------
+
+  describe('getFailureTagsForContestant', () => {
+    it('returns all tags for a contestant', async () => {
+      const { mockWhere } = resetMockChains();
+      mockWhere.mockResolvedValue([fakeTag]);
+
+      const result = await getFailureTagsForContestant(
+        mockDb as unknown as DbOrTx,
+        'cont-00000000000000000' as ContestantId,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -- getFailureDistribution ------------------------------------------------
+
+  describe('getFailureDistribution', () => {
+    it('returns correct counts per category', async () => {
+      const { mockGroupBy } = resetMockChains();
+      mockGroupBy.mockResolvedValue([
+        { category: 'wrong_answer', count: 3 },
+        { category: 'refusal', count: 1 },
+      ]);
+
+      const result = await getFailureDistribution(mockDb as unknown as DbOrTx);
+
+      expect(result.wrong_answer).toBe(3);
+      expect(result.refusal).toBe(1);
+      expect(result.hallucination).toBe(0);
+      expect(result.off_topic).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #116

## Summary

- **Schema**: `failureCategory` enum (9 values) + `failureTags` table with indexes on runId, contestantId, category. Migration `0010_m2.4-failure-tags.sql`.
- **Branded type**: `FailureTagId` + `asFailureTagId` constructor in `lib/domain-ids.ts`.
- **Types**: `FailureTag` and `FailureCategory` types appended to `lib/eval/types.ts`.
- **Domain module**: `lib/eval/failure-tags.ts` with `addFailureTag`, `getFailureTagsForRun`, `getFailureTagsForContestant`, `getFailureDistribution`.
- **Judge extension**: Extended `judgeOutputSchema` with optional `failureTags` field. `evaluateContestant` persists judge-assigned tags with `source: 'judge'` linked to `evaluationId`. Changes are minimal and additive (append after evaluation persist block) to reduce merge conflict risk with M3.1.
- **Zod schema**: `addFailureTagSchema` in `lib/api-schemas.ts` with static `FAILURE_CATEGORIES` array (avoids schema import in tests).
- **API route**: `GET/POST /api/runs/:id/failures` for listing and manual tagging (auth required for POST).
- **Barrel**: Updated `lib/eval/index.ts` with failure-tags exports.

## Test plan

- [x] 5 unit tests in `tests/unit/eval/failure-tags.test.ts` (addFailureTag persists, links evaluationId, getFailureTagsForRun, getFailureTagsForContestant, getFailureDistribution)
- [x] 4 API tests in `tests/api/eval/failures.test.ts` (POST 201, POST 400 invalid category, POST 401 unauthenticated, GET 200)
- [x] All 1620 existing tests pass (zero regressions)
- [x] Gate green: typecheck + lint (0 errors) + test:unit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements failure tagging (M2.4, Linear #116) for run evaluation. Adds DB schema, judge support, and an API to create and list tags, enabling manual and automatic failure classification.

- **New Features**
  - DB: `failure_category` enum (9 values) and `failure_tags` table with indexes.
  - Domain: `addFailureTag`, `getFailureTagsForRun`, `getFailureTagsForContestant`, `getFailureDistribution`.
  - Judge: optional `failureTags` in `judgeOutputSchema`; `evaluateContestant` saves tags with `source: 'judge'` linked to `evaluationId`.
  - API: `GET/POST /api/runs/:id/failures` (POST requires auth).

- **Migration**
  - Run `drizzle/0010_m2.4-failure-tags.sql`.
  - Additive change; no breaking migrations or config updates.

<sup>Written for commit 92727c11956b7b62f3d6b3c019f0f917c554e4a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

