### PR TITLE
feat(run): M3.1 - cost ledger for tracking model call costs

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -738,3 +738,38 @@ export const failureTags = pgTable('failure_tags', {
   index('failure_tags_contestant_id_idx').on(table.contestantId),
   index('failure_tags_category_idx').on(table.category),
 ]);
+
+// ---------------------------------------------------------------------------
+// Phase 3: Cost Ledger (M3.1)
+// ---------------------------------------------------------------------------
+
+export const costSourceType = pgEnum('cost_source_type', [
+  'trace',
+  'evaluation',
+  'summary',
+]);
+
+export const costLedger = pgTable('cost_ledger', {
+  id: varchar('id', { length: 21 }).primaryKey(),
+  sourceType: costSourceType('source_type').notNull(),
+  sourceId: varchar('source_id', { length: 21 }).notNull(),
+  runId: varchar('run_id', { length: 21 })
+    .notNull()
+    .references(() => runs.id, { onDelete: 'cascade' }),
+  contestantId: varchar('contestant_id', { length: 21 })
+    .references(() => contestants.id, { onDelete: 'cascade' }),
+  model: varchar('model', { length: 128 }).notNull(),
+  inputTokens: integer('input_tokens').notNull(),
+  outputTokens: integer('output_tokens').notNull(),
+  inputCostMicro: integer('input_cost_micro').notNull(),
+  outputCostMicro: integer('output_cost_micro').notNull(),
+  totalCostMicro: integer('total_cost_micro').notNull(),
+  latencyMs: integer('latency_ms').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+}, (table) => [
+  index('cost_ledger_run_id_idx').on(table.runId),
+  index('cost_ledger_contestant_id_idx').on(table.contestantId),
+  index('cost_ledger_source_idx').on(table.sourceType, table.sourceId),
+]);

--- a/drizzle/0010_m3.1-cost-ledger.sql
+++ b/drizzle/0010_m3.1-cost-ledger.sql
@@ -1,0 +1,33 @@
+-- M3.1: Cost ledger table for tracking model call costs.
+
+CREATE TYPE "public"."cost_source_type" AS ENUM('trace', 'evaluation', 'summary');
+
+CREATE TABLE "cost_ledger" (
+  "id" varchar(21) PRIMARY KEY NOT NULL,
+  "source_type" "cost_source_type" NOT NULL,
+  "source_id" varchar(21) NOT NULL,
+  "run_id" varchar(21) NOT NULL,
+  "contestant_id" varchar(21),
+  "model" varchar(128) NOT NULL,
+  "input_tokens" integer NOT NULL,
+  "output_tokens" integer NOT NULL,
+  "input_cost_micro" integer NOT NULL,
+  "output_cost_micro" integer NOT NULL,
+  "total_cost_micro" integer NOT NULL,
+  "latency_ms" integer NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "cost_ledger"
+  ADD CONSTRAINT "cost_ledger_run_id_runs_id_fk"
+  FOREIGN KEY ("run_id") REFERENCES "public"."runs"("id")
+  ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "cost_ledger"
+  ADD CONSTRAINT "cost_ledger_contestant_id_contestants_id_fk"
+  FOREIGN KEY ("contestant_id") REFERENCES "public"."contestants"("id")
+  ON DELETE cascade ON UPDATE no action;
+
+CREATE INDEX "cost_ledger_run_id_idx" ON "cost_ledger" USING btree ("run_id");
+CREATE INDEX "cost_ledger_contestant_id_idx" ON "cost_ledger" USING btree ("contestant_id");
+CREATE INDEX "cost_ledger_source_idx" ON "cost_ledger" USING btree ("source_type", "source_id");

--- a/lib/eval/judge.ts
+++ b/lib/eval/judge.ts
@@ -7,7 +7,8 @@ import { z } from 'zod/v4';
 import { generateObject } from 'ai';
 import { eq } from 'drizzle-orm';
 
-import { runs, contestants, traces, tasks } from '@/db/schema';
+import { nanoid } from 'nanoid';
+import { runs, contestants, traces, tasks, costLedger } from '@/db/schema';
 import type { DbOrTx } from '@/db';
 import { getModel } from '@/lib/ai';
 import type { RunId, RubricId, ContestantId, EvaluationId } from '@/lib/domain-ids';
@@ -18,6 +19,7 @@ import { getRubric } from './rubrics';
 import { insertEvaluation } from './evaluations';
 import { computeWeightedScore } from './scoring';
 import { addFailureTag } from './failure-tags';
+import { computeCostMicro } from '@/lib/run/pricing';
 
 // ---------------------------------------------------------------------------
 // Judge config
@@ -245,6 +247,27 @@ export async function evaluateContestant(
         evaluationId: evaluation.id as EvaluationId,
       });
     }
+  }
+
+  // Cost ledger entry for judge evaluation (M3.1)
+  const cost = computeCostMicro(
+    config.model,
+    result.usage?.inputTokens ?? 0,
+    result.usage?.outputTokens ?? 0,
+  );
+  if (cost) {
+    await db.insert(costLedger).values({
+      id: nanoid(),
+      sourceType: 'evaluation',
+      sourceId: evaluation.id,
+      runId: trace.runId,
+      contestantId: trace.contestantId,
+      model: config.model,
+      inputTokens: result.usage?.inputTokens ?? 0,
+      outputTokens: result.usage?.outputTokens ?? 0,
+      ...cost,
+      latencyMs,
+    });
   }
 
   return evaluation;

--- a/lib/run/engine.ts
+++ b/lib/run/engine.ts
@@ -8,7 +8,7 @@ import { eq, and, lt } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { generateText } from 'ai';
 
-import { runs, contestants, traces, tasks } from '@/db/schema';
+import { runs, contestants, traces, tasks, costLedger } from '@/db/schema';
 import type { DbOrTx } from '@/db';
 import { getModel } from '@/lib/ai';
 import { asTraceId } from '@/lib/domain-ids';
@@ -16,6 +16,7 @@ import type { RunId } from '@/lib/domain-ids';
 import type {
   Run, Task, Contestant, Trace, RunWithTraces, TraceMessage,
 } from './types';
+import { computeCostMicro } from '@/lib/run/pricing';
 
 const STALE_RUN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -157,6 +158,27 @@ export async function executeRun(
           completedAt,
         })
         .returning();
+
+      // Cost ledger entry for successful trace
+      const cost = computeCostMicro(
+        contestant.model,
+        result.usage?.inputTokens ?? 0,
+        result.usage?.outputTokens ?? 0,
+      );
+      if (cost) {
+        await db.insert(costLedger).values({
+          id: nanoid(),
+          sourceType: 'trace',
+          sourceId: traceId,
+          runId,
+          contestantId: contestant.id,
+          model: contestant.model,
+          inputTokens: result.usage?.inputTokens ?? 0,
+          outputTokens: result.usage?.outputTokens ?? 0,
+          ...cost,
+          latencyMs,
+        });
+      }
 
       traceResults.push({ ...contestant, trace: trace ?? null });
     } catch (err) {

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -10,3 +10,5 @@ export { executeRun, sweepStaleRuns, buildMessages } from './engine';
 export type { Contestant, NewContestant, ContextBundleInput } from './types';
 export type { Trace, NewTrace, TraceMessage, RunWithTraces } from './types';
 export { getRunWithTraces } from './queries';
+export { getModelPricing, computeCostMicro, MODEL_PRICING } from './pricing';
+export type { ModelPricing } from './pricing';

--- a/lib/run/pricing.ts
+++ b/lib/run/pricing.ts
@@ -1,0 +1,37 @@
+// Model pricing table and cost computation (M3.1).
+//
+// Pure data module. No imports except types. No side effects.
+// Prices in dollars per 1k tokens. Updated manually.
+
+export type ModelPricing = {
+  inputPer1kTokens: number;
+  outputPer1kTokens: number;
+};
+
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  'gpt-4o':            { inputPer1kTokens: 0.0025,  outputPer1kTokens: 0.01 },
+  'gpt-4o-mini':       { inputPer1kTokens: 0.00015, outputPer1kTokens: 0.0006 },
+  'claude-sonnet-4-20250514': { inputPer1kTokens: 0.003,  outputPer1kTokens: 0.015 },
+  'claude-haiku-3.5':  { inputPer1kTokens: 0.0008,  outputPer1kTokens: 0.004 },
+  'gemini-2.0-flash':  { inputPer1kTokens: 0.0001,  outputPer1kTokens: 0.0004 },
+};
+
+export function getModelPricing(model: string): ModelPricing | null {
+  return MODEL_PRICING[model] ?? null;
+}
+
+export function computeCostMicro(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): { inputCostMicro: number; outputCostMicro: number; totalCostMicro: number } | null {
+  const pricing = getModelPricing(model);
+  if (!pricing) return null;
+  const inputCostMicro = Math.round((inputTokens / 1000) * pricing.inputPer1kTokens * 1_000_000);
+  const outputCostMicro = Math.round((outputTokens / 1000) * pricing.outputPer1kTokens * 1_000_000);
+  return {
+    inputCostMicro,
+    outputCostMicro,
+    totalCostMicro: inputCostMicro + outputCostMicro,
+  };
+}

--- a/tests/unit/eval/judge.test.ts
+++ b/tests/unit/eval/judge.test.ts
@@ -40,6 +40,7 @@ vi.mock('@/db/schema', () => ({
   traces: { runId: 'run_id', contestantId: 'contestant_id' },
   evaluations: {},
   rubrics: {},
+  costLedger: {},
 }));
 
 vi.mock('drizzle-orm', () => ({

--- a/tests/unit/run/engine.test.ts
+++ b/tests/unit/run/engine.test.ts
@@ -42,6 +42,7 @@ vi.mock('@/db/schema', () => ({
   tasks: { id: 'id' },
   contestants: { runId: 'run_id' },
   traces: {},
+  costLedger: {},
 }));
 
 vi.mock('drizzle-orm', () => ({

--- a/tests/unit/run/pricing.test.ts
+++ b/tests/unit/run/pricing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeCostMicro,
+  getModelPricing,
+  MODEL_PRICING,
+} from '@/lib/run/pricing';
+
+describe('lib/run/pricing', () => {
+  // ── getModelPricing ─────────────────────────────────────────────────────
+
+  describe('getModelPricing', () => {
+    it.each(Object.keys(MODEL_PRICING))(
+      'returns pricing for %s',
+      (model) => {
+        const pricing = getModelPricing(model);
+        expect(pricing).not.toBeNull();
+        expect(pricing!.inputPer1kTokens).toBeGreaterThan(0);
+        expect(pricing!.outputPer1kTokens).toBeGreaterThan(0);
+      },
+    );
+
+    it('returns null for unknown model', () => {
+      expect(getModelPricing('unknown-model-xyz')).toBeNull();
+    });
+  });
+
+  // ── computeCostMicro ────────────────────────────────────────────────────
+
+  describe('computeCostMicro', () => {
+    it('computes correctly for gpt-4o', () => {
+      // gpt-4o: input $0.0025/1k, output $0.01/1k
+      // 1000 input tokens = 0.0025 * 1_000_000 = 2500 microdollars
+      // 500 output tokens = (500/1000) * 0.01 * 1_000_000 = 5000 microdollars
+      const result = computeCostMicro('gpt-4o', 1000, 500);
+      expect(result).not.toBeNull();
+      expect(result!.inputCostMicro).toBe(2500);
+      expect(result!.outputCostMicro).toBe(5000);
+      expect(result!.totalCostMicro).toBe(7500);
+    });
+
+    it('returns null for unknown model', () => {
+      expect(computeCostMicro('nonexistent-model', 100, 50)).toBeNull();
+    });
+
+    it('rounds to integer microdollars', () => {
+      // gpt-4o-mini: input $0.00015/1k, output $0.0006/1k
+      // 1 input token = (1/1000) * 0.00015 * 1_000_000 = 0.15 -> rounds to 0
+      // 1 output token = (1/1000) * 0.0006 * 1_000_000 = 0.6 -> rounds to 1
+      const result = computeCostMicro('gpt-4o-mini', 1, 1);
+      expect(result).not.toBeNull();
+      expect(Number.isInteger(result!.inputCostMicro)).toBe(true);
+      expect(Number.isInteger(result!.outputCostMicro)).toBe(true);
+      expect(Number.isInteger(result!.totalCostMicro)).toBe(true);
+      expect(result!.inputCostMicro).toBe(0);
+      expect(result!.outputCostMicro).toBe(1);
+    });
+
+    it('handles zero tokens', () => {
+      const result = computeCostMicro('gpt-4o', 0, 0);
+      expect(result).not.toBeNull();
+      expect(result!.inputCostMicro).toBe(0);
+      expect(result!.outputCostMicro).toBe(0);
+      expect(result!.totalCostMicro).toBe(0);
+    });
+
+    it('computes correctly for gemini-2.0-flash', () => {
+      // gemini-2.0-flash: input $0.0001/1k, output $0.0004/1k
+      // 10000 input = (10000/1000) * 0.0001 * 1_000_000 = 1000
+      // 5000 output = (5000/1000) * 0.0004 * 1_000_000 = 2000
+      const result = computeCostMicro('gemini-2.0-flash', 10000, 5000);
+      expect(result).not.toBeNull();
+      expect(result!.inputCostMicro).toBe(1000);
+      expect(result!.outputCostMicro).toBe(2000);
+      expect(result!.totalCostMicro).toBe(3000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #117.

- Adds `cost_ledger` table and `cost_source_type` enum to track model call costs in microdollars
- Adds `lib/run/pricing.ts` with a code-maintained pricing table (5 models) and `computeCostMicro` function
- Patches `lib/run/engine.ts` to insert cost entries after each successful trace
- Patches `lib/eval/judge.ts` to insert cost entries after each evaluation (minimal, additive changes to reduce merge conflict with M2.4)
- Exports pricing functions from `lib/run/index.ts` barrel
- Migration: `drizzle/0010_m3.1-cost-ledger.sql`

## What changed

| File | Change |
|------|--------|
| `db/schema.ts` | Append `costSourceType` enum + `costLedger` table |
| `drizzle/0010_m3.1-cost-ledger.sql` | DDL for enum, table, FKs, indexes |
| `lib/run/pricing.ts` | NEW: `ModelPricing` type, `MODEL_PRICING` constant, `getModelPricing`, `computeCostMicro` |
| `lib/run/engine.ts` | Add cost ledger insert after successful trace persist |
| `lib/eval/judge.ts` | Add cost ledger insert after evaluation persist (additive only) |
| `lib/run/index.ts` | Export pricing functions |
| `tests/unit/run/pricing.test.ts` | NEW: 11 tests for pricing functions |
| `tests/unit/run/engine.test.ts` | Add `costLedger` to schema mock |
| `tests/unit/eval/judge.test.ts` | Add `costLedger` to schema mock |

## Design decisions

- Costs stored in **microdollars** (integer arithmetic) matching existing `balanceMicro`/`deltaMicro` pattern
- `sourceType` + `sourceId` polymorphic reference to traces or evaluations (no direct FK)
- Pricing table is a TypeScript constant, not a database table (spec decision D2)
- Judge patch is intentionally minimal (imports + one insert block) to reduce conflict with M2.4 failure tagging

## Test plan

- [x] `computeCostMicro` computes correctly for known model (gpt-4o)
- [x] `computeCostMicro` returns null for unknown model
- [x] `computeCostMicro` rounds to integer microdollars
- [x] `getModelPricing` returns pricing for each listed model
- [x] `getModelPricing` returns null for unknown model
- [x] Zero token edge case handled
- [x] All 1622 existing + new tests pass
- [x] Gate green: typecheck (0 errors) + lint (0 errors) + test:unit (148 files, 1622 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cost ledger to track model call costs for traces and judge evaluations, computed in microdollars from a code-maintained pricing table. Implements M3.1 in #117 to provide per-run and per-contestant cost visibility.

- New Features
  - `cost_ledger` table + `cost_source_type` enum (`trace` | `evaluation` | `summary`) with indexes on run, contestant, and source; stores tokens, per-leg costs, total, and `latencyMs`.
  - `lib/run/pricing.ts` with `MODEL_PRICING`, `getModelPricing`, and `computeCostMicro` (5 models).
  - Cost entries written after successful traces in `lib/run/engine.ts` and after evaluations in `lib/eval/judge.ts`.
  - Pricing utilities exported from `lib/run/index.ts`.
  - Unit tests for pricing; updated test mocks for `costLedger`.

- Migration
  - Apply `drizzle/0010_m3.1-cost-ledger.sql`.

<sup>Written for commit 33ef3005801ae86c1594cfaae0e12fec6d45dee1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

