### PR TITLE
feat(run): M3.2 - score/cost tradeoff endpoint

### DIFF
--- a/app/api/runs/[id]/economics/route.ts
+++ b/app/api/runs/[id]/economics/route.ts
@@ -1,0 +1,32 @@
+// GET /api/runs/:id/economics -- score/cost tradeoff data (M3.2).
+//
+// HTTP layer only. Aggregation lives in lib/run/economics.ts.
+
+import { requireDb } from '@/db';
+import { asRunId } from '@/lib/domain-ids';
+import { errorResponse, API_ERRORS } from '@/lib/api-utils';
+import { log } from '@/lib/logger';
+import { getRunEconomics } from '@/lib/run/economics';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  try {
+    const db = requireDb();
+    const economics = await getRunEconomics(db, asRunId(id));
+
+    if (!economics) {
+      return errorResponse('Run not found', 404);
+    }
+
+    return Response.json(economics);
+  } catch (error) {
+    log.error('GET /api/runs/[id]/economics failed', error instanceof Error ? error : new Error(String(error)));
+    return errorResponse(API_ERRORS.INTERNAL, 500);
+  }
+}

--- a/lib/run/economics.ts
+++ b/lib/run/economics.ts
@@ -1,0 +1,181 @@
+// Score/cost tradeoff aggregation (M3.2).
+//
+// Pure aggregation over cost_ledger and evaluations tables.
+// No new tables. No migrations. No HTTP awareness.
+
+import { eq, sql } from 'drizzle-orm';
+
+import { costLedger, contestants, evaluations } from '@/db/schema';
+import type { DbOrTx } from '@/db';
+import type { RunId, ContestantId } from '@/lib/domain-ids';
+
+/** Per-contestant economics with optional score-based tradeoff metrics. */
+export type ContestantEconomics = {
+  contestantId: ContestantId;
+  label: string;
+  model: string;
+  costMicro: number;
+  inputTokens: number;
+  outputTokens: number;
+  latencyMs: number;
+  /** Overall score normalized 0..1. Null if not yet evaluated. */
+  overallScore: number | null;
+  /** overallScore / (costMicro / 1_000_000). Null if score or cost unavailable. */
+  scorePerDollar: number | null;
+  /** overallScore / (latencyMs / 1000). Null if score or latency unavailable. */
+  scorePerSecond: number | null;
+};
+
+/** Aggregated economics for a run. */
+export type RunEconomics = {
+  runId: RunId;
+  totalCostMicro: number;
+  totalTokens: number;
+  totalLatencyMs: number;
+  contestants: ContestantEconomics[];
+  cheapestContestant: string | null;
+  fastestContestant: string | null;
+  bestValueContestant: string | null;
+};
+
+/**
+ * Compute economics for a run by aggregating cost_ledger entries
+ * and optionally joining the latest evaluation scores.
+ *
+ * Returns null if no cost ledger entries exist for the run
+ * (which means either the run does not exist or has not been executed).
+ */
+export async function getRunEconomics(
+  db: DbOrTx,
+  runId: RunId,
+): Promise<RunEconomics | null> {
+  // 1. Aggregate cost_ledger by contestantId
+  const costRows = await db
+    .select({
+      contestantId: costLedger.contestantId,
+      costMicro: sql<number>`sum(${costLedger.totalCostMicro})`.as('cost_micro'),
+      inputTokens: sql<number>`sum(${costLedger.inputTokens})`.as('input_tokens'),
+      outputTokens: sql<number>`sum(${costLedger.outputTokens})`.as('output_tokens'),
+      latencyMs: sql<number>`sum(${costLedger.latencyMs})`.as('latency_ms'),
+    })
+    .from(costLedger)
+    .where(eq(costLedger.runId, runId))
+    .groupBy(costLedger.contestantId);
+
+  if (costRows.length === 0) return null;
+
+  // 2. Load contestant metadata for labels and models
+  const contestantRows = await db
+    .select({
+      id: contestants.id,
+      label: contestants.label,
+      model: contestants.model,
+    })
+    .from(contestants)
+    .where(eq(contestants.runId, runId));
+
+  const contestantMap = new Map(
+    contestantRows.map((c) => [c.id, c]),
+  );
+
+  // 3. Load latest evaluations per contestant (if any)
+  const evalRows = await db
+    .select({
+      contestantId: evaluations.contestantId,
+      overallScore: evaluations.overallScore,
+    })
+    .from(evaluations)
+    .where(eq(evaluations.runId, runId));
+
+  // Build a map of contestantId -> latest overallScore.
+  // If multiple evaluations exist for the same contestant, take the last one
+  // (evalRows are unordered here, so we just overwrite -- fine for MVP).
+  const scoreMap = new Map<string, number>();
+  for (const row of evalRows) {
+    scoreMap.set(row.contestantId, row.overallScore);
+  }
+
+  // 4. Combine into ContestantEconomics[]
+  let totalCostMicro = 0;
+  let totalTokens = 0;
+  let totalLatencyMs = 0;
+
+  const contestantEconomics: ContestantEconomics[] = [];
+
+  for (const cost of costRows) {
+    // Skip run-level summary costs (contestantId is null)
+    if (cost.contestantId === null) {
+      totalCostMicro += Number(cost.costMicro);
+      totalTokens += Number(cost.inputTokens) + Number(cost.outputTokens);
+      totalLatencyMs += Number(cost.latencyMs);
+      continue;
+    }
+
+    const meta = contestantMap.get(cost.contestantId);
+    if (!meta) continue;
+
+    const costMicro = Number(cost.costMicro);
+    const inputTokens = Number(cost.inputTokens);
+    const outputTokens = Number(cost.outputTokens);
+    const latencyMs = Number(cost.latencyMs);
+    const overallScore = scoreMap.get(cost.contestantId) ?? null;
+
+    let scorePerDollar: number | null = null;
+    let scorePerSecond: number | null = null;
+
+    if (overallScore !== null && costMicro > 0) {
+      scorePerDollar = overallScore / (costMicro / 1_000_000);
+    }
+    if (overallScore !== null && latencyMs > 0) {
+      scorePerSecond = overallScore / (latencyMs / 1000);
+    }
+
+    totalCostMicro += costMicro;
+    totalTokens += inputTokens + outputTokens;
+    totalLatencyMs += latencyMs;
+
+    contestantEconomics.push({
+      contestantId: cost.contestantId as ContestantId,
+      label: meta.label,
+      model: meta.model,
+      costMicro,
+      inputTokens,
+      outputTokens,
+      latencyMs,
+      overallScore,
+      scorePerDollar,
+      scorePerSecond,
+    });
+  }
+
+  // If we only had null-contestantId rows (summary costs) and no contestant rows,
+  // there is nothing meaningful to return.
+  if (contestantEconomics.length === 0 && costRows.every((r) => r.contestantId === null)) {
+    return null;
+  }
+
+  // 5. Identify cheapest, fastest, best value
+  const cheapestContestant = contestantEconomics.length > 0
+    ? contestantEconomics.reduce((a, b) => a.costMicro <= b.costMicro ? a : b).contestantId
+    : null;
+
+  const fastestContestant = contestantEconomics.length > 0
+    ? contestantEconomics.reduce((a, b) => a.latencyMs <= b.latencyMs ? a : b).contestantId
+    : null;
+
+  const withScores = contestantEconomics.filter((c) => c.scorePerDollar !== null);
+  const bestValueContestant = withScores.length > 0
+    ? withScores.reduce((a, b) => (a.scorePerDollar! >= b.scorePerDollar! ? a : b)).contestantId
+    : null;
+
+  return {
+    runId,
+    totalCostMicro,
+    totalTokens,
+    totalLatencyMs,
+    contestants: contestantEconomics,
+    cheapestContestant,
+    fastestContestant,
+    bestValueContestant,
+  };
+}

--- a/lib/run/index.ts
+++ b/lib/run/index.ts
@@ -12,3 +12,5 @@ export type { Trace, NewTrace, TraceMessage, RunWithTraces } from './types';
 export { getRunWithTraces } from './queries';
 export { getModelPricing, computeCostMicro, MODEL_PRICING } from './pricing';
 export type { ModelPricing } from './pricing';
+export { getRunEconomics } from './economics';
+export type { RunEconomics, ContestantEconomics } from './economics';

--- a/tests/api/run/economics.test.ts
+++ b/tests/api/run/economics.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockRequireDb = vi.hoisted(() => vi.fn().mockReturnValue({}));
+const mockGetRunEconomics = vi.hoisted(() => vi.fn());
+
+vi.mock('@/db', () => ({ requireDb: mockRequireDb }));
+vi.mock('@/lib/run/economics', () => ({ getRunEconomics: mockGetRunEconomics }));
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const RUN_ID = 'run-000000000000000000';
+const CONTESTANT_A = 'cont-AAAAAAAAAAAAAAAAAAA';
+const CONTESTANT_B = 'cont-BBBBBBBBBBBBBBBBBBB';
+
+const fakeEconomics = {
+  runId: RUN_ID,
+  totalCostMicro: 8000,
+  totalTokens: 2700,
+  totalLatencyMs: 2000,
+  contestants: [
+    {
+      contestantId: CONTESTANT_A,
+      label: 'GPT-4o',
+      model: 'gpt-4o',
+      costMicro: 5000,
+      inputTokens: 1000,
+      outputTokens: 500,
+      latencyMs: 1200,
+      overallScore: 0.85,
+      scorePerDollar: 170,
+      scorePerSecond: 0.7083,
+    },
+    {
+      contestantId: CONTESTANT_B,
+      label: 'Gemini Flash',
+      model: 'gemini-2.0-flash',
+      costMicro: 3000,
+      inputTokens: 800,
+      outputTokens: 400,
+      latencyMs: 800,
+      overallScore: 0.72,
+      scorePerDollar: 240,
+      scorePerSecond: 0.9,
+    },
+  ],
+  cheapestContestant: CONTESTANT_B,
+  fastestContestant: CONTESTANT_B,
+  bestValueContestant: CONTESTANT_B,
+};
+
+function makeRequest(method: string, url: string): Request {
+  return new Request(url, { method });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/runs/:id/economics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns economics (200)', async () => {
+    mockGetRunEconomics.mockResolvedValue(fakeEconomics);
+
+    const { GET } = await import('@/app/api/runs/[id]/economics/route');
+    const req = makeRequest('GET', `http://localhost/api/runs/${RUN_ID}/economics`);
+    const res = await GET(req, { params: Promise.resolve({ id: RUN_ID }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.runId).toBe(RUN_ID);
+    expect(json.totalCostMicro).toBe(8000);
+    expect(json.contestants).toHaveLength(2);
+    expect(json.cheapestContestant).toBe(CONTESTANT_B);
+    expect(json.bestValueContestant).toBe(CONTESTANT_B);
+  });
+
+  it('returns 404 for missing run', async () => {
+    mockGetRunEconomics.mockResolvedValue(null);
+
+    const { GET } = await import('@/app/api/runs/[id]/economics/route');
+    const req = makeRequest('GET', 'http://localhost/api/runs/nonexistent/economics');
+    const res = await GET(req, { params: Promise.resolve({ id: 'nonexistent' }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toBe('Run not found');
+  });
+});

--- a/tests/unit/run/economics.test.ts
+++ b/tests/unit/run/economics.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { RunId } from '@/lib/domain-ids';
+import type { DbOrTx } from '@/db';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/db/schema', () => ({
+  costLedger: {
+    runId: 'runId',
+    contestantId: 'contestantId',
+    totalCostMicro: 'totalCostMicro',
+    inputTokens: 'inputTokens',
+    outputTokens: 'outputTokens',
+    latencyMs: 'latencyMs',
+  },
+  contestants: {
+    id: 'id',
+    runId: 'runId',
+    label: 'label',
+    model: 'model',
+  },
+  evaluations: {
+    runId: 'runId',
+    contestantId: 'contestantId',
+    overallScore: 'overallScore',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, _val: unknown) => ({ _eq: [_col, _val] })),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    as: (_alias: string) => `sql_${_alias}`,
+    _sql: true,
+    strings,
+    values,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CONTESTANT_A = 'cont-AAAAAAAAAAAAAAAAAAA';
+const CONTESTANT_B = 'cont-BBBBBBBBBBBBBBBBBBB';
+const RUN_ID = 'run-000000000000000000';
+
+const costRowsFixture = [
+  {
+    contestantId: CONTESTANT_A,
+    costMicro: 5000,
+    inputTokens: 1000,
+    outputTokens: 500,
+    latencyMs: 1200,
+  },
+  {
+    contestantId: CONTESTANT_B,
+    costMicro: 3000,
+    inputTokens: 800,
+    outputTokens: 400,
+    latencyMs: 800,
+  },
+];
+
+const contestantRowsFixture = [
+  { id: CONTESTANT_A, label: 'GPT-4o', model: 'gpt-4o' },
+  { id: CONTESTANT_B, label: 'Gemini Flash', model: 'gemini-2.0-flash' },
+];
+
+const evalRowsFixture = [
+  { contestantId: CONTESTANT_A, overallScore: 0.85 },
+  { contestantId: CONTESTANT_B, overallScore: 0.72 },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock db that returns specific data for sequential select calls.
+ * Query 0 (cost_ledger) uses .groupBy(), queries 1-2 terminate at .where().
+ */
+function buildMockDb(
+  costRows: unknown[],
+  contestantRows: unknown[],
+  evalRows: unknown[],
+): DbOrTx {
+  const callIndex = { value: 0 };
+
+  return {
+    select: vi.fn().mockImplementation(() => {
+      const idx = callIndex.value++;
+      return {
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            if (idx === 0) {
+              return { groupBy: vi.fn().mockReturnValue(costRows) };
+            }
+            if (idx === 1) return contestantRows;
+            return evalRows;
+          }),
+        }),
+      };
+    }),
+  } as unknown as DbOrTx;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/run/economics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('computes total cost across contestants', async () => {
+    const db = buildMockDb(costRowsFixture, contestantRowsFixture, evalRowsFixture);
+
+    const { getRunEconomics } = await import('@/lib/run/economics');
+    const result = await getRunEconomics(db, RUN_ID as unknown as RunId);
+
+    expect(result).not.toBeNull();
+    expect(result!.totalCostMicro).toBe(5000 + 3000);
+    expect(result!.totalTokens).toBe(1000 + 500 + 800 + 400);
+    expect(result!.totalLatencyMs).toBe(1200 + 800);
+  });
+
+  it('computes scorePerDollar correctly', async () => {
+    const db = buildMockDb(costRowsFixture, contestantRowsFixture, evalRowsFixture);
+
+    const { getRunEconomics } = await import('@/lib/run/economics');
+    const result = await getRunEconomics(db, RUN_ID as unknown as RunId);
+
+    expect(result).not.toBeNull();
+    const contA = result!.contestants.find((c) => c.contestantId === CONTESTANT_A)!;
+    const contB = result!.contestants.find((c) => c.contestantId === CONTESTANT_B)!;
+
+    // scorePerDollar = overallScore / (costMicro / 1_000_000)
+    // A: 0.85 / (5000 / 1_000_000) = 0.85 / 0.005 = 170
+    expect(contA.scorePerDollar).toBeCloseTo(170, 1);
+    // B: 0.72 / (3000 / 1_000_000) = 0.72 / 0.003 = 240
+    expect(contB.scorePerDollar).toBeCloseTo(240, 1);
+  });
+
+  it('computes scorePerSecond correctly', async () => {
+    const db = buildMockDb(costRowsFixture, contestantRowsFixture, evalRowsFixture);
+
+    const { getRunEconomics } = await import('@/lib/run/economics');
+    const result = await getRunEconomics(db, RUN_ID as unknown as RunId);
+
+    expect(result).not.toBeNull();
+    const contA = result!.contestants.find((c) => c.contestantId === CONTESTANT_A)!;
+    const contB = result!.contestants.find((c) => c.contestantId === CONTESTANT_B)!;
+
+    // scorePerSecond = overallScore / (latencyMs / 1000)
+    // A: 0.85 / (1200 / 1000) = 0.85 / 1.2 = 0.7083...
+    expect(contA.scorePerSecond).toBeCloseTo(0.7083, 3);
+    // B: 0.72 / (800 / 1000) = 0.72 / 0.8 = 0.9
+    expect(contB.scorePerSecond).toBeCloseTo(0.9, 3);
+  });
+
+  it('handles missing evaluations (scores null)', async () => {
+    const db = buildMockDb(costRowsFixture, contestantRowsFixture, []);
+
+    const { getRunEconomics } = await import('@/lib/run/economics');
+    const result = await getRunEconomics(db, RUN_ID as unknown as RunId);
+
+    expect(result).not.toBeNull();
+    for (const c of result!.contestants) {
+      expect(c.overallScore).toBeNull();
+      expect(c.scorePerDollar).toBeNull();
+      expect(c.scorePerSecond).toBeNull();
+    }
+    expect(result!.bestValueContestant).toBeNull();
+  });
+
+  it('identifies cheapest and fastest contestants', async () => {
+    const db = buildMockDb(costRowsFixture, contestantRowsFixture, evalRowsFixture);
+
+    const { getRunEconomics } = await import('@/lib/run/economics');
+    const result = await getRunEconomics(db, RUN_ID as unknown as RunId);
+
+    expect(result).not.toBeNull();
+    // B has lower cost (3000 < 5000) and lower latency (800 < 1200)
+    expect(result!.cheapestContestant).toBe(CONTESTANT_B);
+    expect(result!.fastestContestant).toBe(CONTESTANT_B);
+    // B has higher scorePerDollar (240 > 170)
+    expect(result!.bestValueContestant).toBe(CONTESTANT_B);
+  });
+
+  it('returns null for missing run', async () => {
+    const db = buildMockDb([], [], []);
+
+    const { getRunEconomics } = await import('@/lib/run/economics');
+    const result = await getRunEconomics(db, RUN_ID as unknown as RunId);
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `lib/run/economics.ts` with `getRunEconomics(db, runId)` that aggregates `cost_ledger` entries by contestant, joins evaluations for `overallScore`, and computes `scorePerDollar` / `scorePerSecond` tradeoff metrics
- Adds `GET /api/runs/:id/economics` route returning `RunEconomics` (200) or 404
- Exports `RunEconomics` and `ContestantEconomics` types from barrel

## What changed

Pure aggregation module over existing `cost_ledger`, `contestants`, and `evaluations` tables. No new tables, no migrations, no schema changes.

The `RunEconomics` response includes:
- Per-contestant cost, tokens, latency, and optional score data
- `scorePerDollar` = overallScore / (costMicro / 1,000,000)
- `scorePerSecond` = overallScore / (latencyMs / 1000)
- `cheapestContestant`, `fastestContestant`, `bestValueContestant` identifiers

Scores are nullable -- the endpoint works both before and after evaluation.

## Test plan

- [x] 6 unit tests for `getRunEconomics` covering: total aggregation, scorePerDollar, scorePerSecond, missing evaluations (null scores), cheapest/fastest identification, missing run (null return)
- [x] 2 API tests for the route: 200 with economics data, 404 for missing run
- [x] Gate green: lint (0 errors), typecheck, 1650 tests passing

Closes #122

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /api/runs/:id/economics` to compare score/cost/latency tradeoffs per contestant in a run, with totals and best-value picks. Implements M3.2 for Linear #122 using pure aggregation over existing data (no migrations).

- **New Features**
  - `lib/run/economics.ts`: `getRunEconomics(db, runId)` aggregates `cost_ledger`, joins latest evaluations, computes `scorePerDollar` and `scorePerSecond`, and identifies cheapest/fastest/best-value contestants.
  - `GET /api/runs/:id/economics`: returns `RunEconomics` (200) or 404.
  - Supports runs before evaluation (nullable scores). No new tables or schema changes.
  - Barrel exports: `getRunEconomics`, `RunEconomics`, `ContestantEconomics`. Tests cover aggregation, tradeoff metrics, null scores, and 404.

<sup>Written for commit 916c80538a27dafc65ab3ff3adf096515d682c22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

