### PR TITLE
feat(eval): M2.5 - run report assembly and API

### DIFF
--- a/app/api/runs/[id]/report/route.ts
+++ b/app/api/runs/[id]/report/route.ts
@@ -1,0 +1,41 @@
+// GET /api/runs/:id/report -- run report assembly (M2.5).
+//
+// Pure read, never writes. Assembles existing evaluations, scorecards,
+// comparison, and failure tags into a composite report. If the run has
+// not been evaluated against the specified rubric, returns a report
+// shell with needsEvaluation=true.
+
+import { requireDb } from '@/db';
+import { asRunId, asRubricId } from '@/lib/domain-ids';
+import { errorResponse, API_ERRORS } from '@/lib/api-utils';
+import { log } from '@/lib/logger';
+import { assembleRunReport } from '@/lib/eval/report';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const url = new URL(req.url);
+  const rubricId = url.searchParams.get('rubricId');
+
+  if (!rubricId) {
+    return errorResponse('rubricId query param is required', 400);
+  }
+
+  try {
+    const db = requireDb();
+    const report = await assembleRunReport(db, asRunId(id), asRubricId(rubricId));
+
+    if (!report) {
+      return errorResponse('Run or rubric not found', 404);
+    }
+
+    return Response.json(report, { status: 200 });
+  } catch (error) {
+    log.error('GET /api/runs/[id]/report failed', error instanceof Error ? error : new Error(String(error)));
+    return errorResponse(API_ERRORS.INTERNAL, 500);
+  }
+}

--- a/lib/eval/index.ts
+++ b/lib/eval/index.ts
@@ -23,3 +23,7 @@ export type { Scorecard, RunComparison } from './types';
 export { addFailureTag, getFailureTagsForRun, getFailureTagsForContestant, getFailureDistribution } from './failure-tags';
 export type { AddFailureTagInput } from './failure-tags';
 export type { FailureTag, FailureCategory } from './types';
+
+// Run report (M2.5)
+export { assembleRunReport } from './report';
+export type { RunReport } from './types';

--- a/lib/eval/report.ts
+++ b/lib/eval/report.ts
@@ -1,0 +1,144 @@
+// Run report assembly -- composite read model for evaluated runs (M2.5).
+//
+// Pure read, never writes. Assembles existing data into a RunReport.
+// If evaluations exist for the rubric, includes scorecards, comparison,
+// and stored summary. If not, returns the report shell with
+// needsEvaluation=true.
+
+import type { DbOrTx } from '@/db';
+import type { RunId, RubricId } from '@/lib/domain-ids';
+import type { RunReport } from './types';
+import type { TraceMessage } from '@/db/schema';
+
+import { getRunWithTraces } from '@/lib/run/queries';
+import { getEvaluationsForRun } from './evaluations';
+import { getRubric } from './rubrics';
+import { getFailureTagsForRun } from './failure-tags';
+import { buildScorecard, compareRun } from './scoring';
+
+/**
+ * Assemble a run report from existing data. Pure read -- no model
+ * calls, no writes. If evaluations exist for the rubric, includes
+ * scorecards, comparison, and pre-generated summary. If not,
+ * returns the report shell with needsEvaluation=true.
+ */
+export async function assembleRunReport(
+  db: DbOrTx,
+  runId: RunId,
+  rubricId: RubricId,
+): Promise<RunReport | null> {
+  // 1. Load run with task, contestants, traces
+  const runData = await getRunWithTraces(db, runId);
+  if (!runData) return null;
+
+  const { task, contestants: contestantsWithTraces, ...run } = runData;
+
+  // 2. Load rubric
+  const rubric = await getRubric(db, rubricId);
+  if (!rubric) return null;
+
+  // 3. Load all failure tags for this run
+  const allFailureTags = await getFailureTagsForRun(db, runId);
+
+  // 4. Load evaluations and filter by rubricId
+  const allEvaluations = await getEvaluationsForRun(db, runId);
+
+  // Get latest evaluation per contestant for this rubric
+  const evaluationsByContestant = new Map<string, typeof allEvaluations[0]>();
+  for (const evaluation of allEvaluations) {
+    if (evaluation.rubricId !== rubricId) continue;
+    const existing = evaluationsByContestant.get(evaluation.contestantId);
+    if (!existing || evaluation.createdAt > existing.createdAt) {
+      evaluationsByContestant.set(evaluation.contestantId, evaluation);
+    }
+  }
+
+  const hasEvaluations = evaluationsByContestant.size > 0;
+
+  // 5. Build per-contestant report entries
+  const reportContestants = contestantsWithTraces.map((c) => {
+    const contestantFailureTags = allFailureTags.filter(
+      (ft) => ft.contestantId === c.id,
+    );
+
+    const evaluation = evaluationsByContestant.get(c.id);
+    const scorecard = evaluation
+      ? buildScorecard(evaluation, c, rubric)
+      : null;
+
+    // Separate the trace from the contestant fields
+    const { trace, ...contestant } = c;
+
+    return {
+      contestant,
+      trace,
+      scorecard,
+      failureTags: contestantFailureTags,
+    };
+  });
+
+  // 6. Build comparison if evaluations exist
+  let comparison: RunReport['comparison'] = null;
+  let summary: string | null = null;
+
+  if (hasEvaluations) {
+    const latestEvaluations = [...evaluationsByContestant.values()];
+    const evaluatedContestants = contestantsWithTraces.filter((c) =>
+      evaluationsByContestant.has(c.id),
+    );
+
+    comparison = compareRun(latestEvaluations, evaluatedContestants, rubric, task);
+
+    // Use the first evaluation's rationale as a summary if available
+    const firstEvaluation = latestEvaluations[0];
+    summary = firstEvaluation?.rationale ?? null;
+  }
+
+  return {
+    run,
+    task,
+    rubric,
+    needsEvaluation: !hasEvaluations,
+    contestants: reportContestants,
+    comparison,
+    summary,
+  };
+}
+
+/**
+ * Build the summary generation prompt from comparison data.
+ * Internal helper for future use -- summary generation is not
+ * called during report assembly (GET must be safe/idempotent).
+ */
+export function buildSummaryPrompt(
+  comparison: NonNullable<RunReport['comparison']>,
+  contestants: RunReport['contestants'],
+): TraceMessage[] {
+  return [
+    {
+      role: 'system',
+      content: `You are a technical report writer. Summarize evaluation results.
+Be specific about what each contestant did well and poorly.
+Reference specific criterion scores and failure tags.
+Do not use filler language. State facts and conclusions.`,
+    },
+    {
+      role: 'user',
+      content: `## Comparison data
+${JSON.stringify(comparison, null, 2)}
+
+## Failure tags
+${contestants.map((c) =>
+  `${c.contestant.label}: ${c.failureTags.length > 0
+    ? c.failureTags.map((t) => `${t.category}: ${t.description}`).join('; ')
+    : 'none'}`
+).join('\n')}
+
+Write a 2-3 paragraph summary explaining:
+1. Which contestant won and by what margin
+2. The key criteria where they differed
+3. Any failure patterns observed
+4. Whether the result is decisive or marginal`,
+    },
+  ];
+}

--- a/lib/eval/types.ts
+++ b/lib/eval/types.ts
@@ -152,3 +152,25 @@ export type FailureTag = InferSelectModel<typeof failureTags>;
 
 /** Failure category enum values. */
 export type FailureCategory = (typeof failureCategory.enumValues)[number];
+
+// ---------------------------------------------------------------------------
+// Run report (M2.5)
+// ---------------------------------------------------------------------------
+
+import type { Run, Task, Contestant, Trace } from '@/lib/run/types';
+
+/** Composite report assembling run data, evaluations, and comparisons. */
+export type RunReport = {
+  run: Run;
+  task: Task;
+  rubric: Rubric;
+  needsEvaluation: boolean;
+  contestants: Array<{
+    contestant: Contestant;
+    trace: Trace | null;
+    scorecard: Scorecard | null;
+    failureTags: FailureTag[];
+  }>;
+  comparison: RunComparison | null;
+  summary: string | null;
+};

--- a/tests/api/eval/report.test.ts
+++ b/tests/api/eval/report.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockRequireDb = vi.hoisted(() => vi.fn().mockReturnValue({}));
+const mockAssembleRunReport = vi.hoisted(() => vi.fn());
+
+vi.mock('@/db', () => ({ requireDb: mockRequireDb }));
+vi.mock('@/lib/eval/report', () => ({ assembleRunReport: mockAssembleRunReport }));
+vi.mock('@/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeReport = {
+  run: {
+    id: 'run-000000000000000000',
+    taskId: 'task-0000000000000000000',
+    status: 'completed',
+    ownerId: 'user-1',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  task: {
+    id: 'task-0000000000000000000',
+    name: 'Test Task',
+    prompt: 'Do something.',
+  },
+  rubric: {
+    id: 'rubric-00000000000000',
+    name: 'Test Rubric',
+    criteria: [{ name: 'quality', weight: 1.0, scale: { min: 1, max: 5 } }],
+  },
+  needsEvaluation: false,
+  contestants: [
+    {
+      contestant: { id: 'cont-a', label: 'GPT-4o' },
+      trace: { id: 'trace-a', responseContent: 'Response' },
+      scorecard: { overallScore: 0.75 },
+      failureTags: [],
+    },
+  ],
+  comparison: {
+    taskName: 'Test Task',
+    rubricName: 'Test Rubric',
+    contestants: [],
+    winner: { contestantId: 'cont-a', label: 'GPT-4o', margin: 0.25 },
+    criterionBreakdown: [],
+  },
+  summary: 'Contestant A performed well.',
+};
+
+function makeRequest(method: string, url: string): Request {
+  return new Request(url, { method });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/runs/:id/report', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAssembleRunReport.mockResolvedValue(fakeReport);
+  });
+
+  it('returns report (200)', async () => {
+    const { GET } = await import('@/app/api/runs/[id]/report/route');
+    const req = makeRequest(
+      'GET',
+      'http://localhost/api/runs/run-000/report?rubricId=rubric-00000000000000',
+    );
+    const res = await GET(req, { params: Promise.resolve({ id: 'run-000' }) });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.run.id).toBe('run-000000000000000000');
+    expect(json.needsEvaluation).toBe(false);
+    expect(json.comparison.winner.contestantId).toBe('cont-a');
+    expect(json.summary).toBe('Contestant A performed well.');
+  });
+
+  it('requires rubricId query param (400)', async () => {
+    const { GET } = await import('@/app/api/runs/[id]/report/route');
+    const req = makeRequest(
+      'GET',
+      'http://localhost/api/runs/run-000/report',
+    );
+    const res = await GET(req, { params: Promise.resolve({ id: 'run-000' }) });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain('rubricId');
+  });
+
+  it('returns 404 for missing run', async () => {
+    mockAssembleRunReport.mockResolvedValue(null);
+
+    const { GET } = await import('@/app/api/runs/[id]/report/route');
+    const req = makeRequest(
+      'GET',
+      'http://localhost/api/runs/missing/report?rubricId=rubric-00000000000000',
+    );
+    const res = await GET(req, { params: Promise.resolve({ id: 'missing' }) });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/eval/report.test.ts
+++ b/tests/unit/eval/report.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockGetRunWithTraces = vi.hoisted(() => vi.fn());
+const mockGetEvaluationsForRun = vi.hoisted(() => vi.fn());
+const mockGetRubric = vi.hoisted(() => vi.fn());
+const mockGetFailureTagsForRun = vi.hoisted(() => vi.fn());
+const mockBuildScorecard = vi.hoisted(() => vi.fn());
+const mockCompareRun = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/run/queries', () => ({ getRunWithTraces: mockGetRunWithTraces }));
+vi.mock('@/lib/eval/evaluations', () => ({ getEvaluationsForRun: mockGetEvaluationsForRun }));
+vi.mock('@/lib/eval/rubrics', () => ({ getRubric: mockGetRubric }));
+vi.mock('@/lib/eval/failure-tags', () => ({ getFailureTagsForRun: mockGetFailureTagsForRun }));
+vi.mock('@/lib/eval/scoring', () => ({
+  buildScorecard: mockBuildScorecard,
+  compareRun: mockCompareRun,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeRun = {
+  id: 'run-000000000000000000',
+  taskId: 'task-0000000000000000000',
+  status: 'completed',
+  ownerId: 'user-1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeTask = {
+  id: 'task-0000000000000000000',
+  name: 'Test Task',
+  prompt: 'Do something.',
+  domain: null,
+  description: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeContestantA = {
+  id: 'cont-aaaaaaaaaaaaaaaaaa',
+  runId: 'run-000000000000000000',
+  label: 'GPT-4o',
+  model: 'gpt-4o',
+  systemPrompt: null,
+  contextBundle: null,
+  createdAt: new Date(),
+};
+
+const fakeContestantB = {
+  id: 'cont-bbbbbbbbbbbbbbbbbb',
+  runId: 'run-000000000000000000',
+  label: 'Claude',
+  model: 'claude-sonnet-4-6',
+  systemPrompt: null,
+  contextBundle: null,
+  createdAt: new Date(),
+};
+
+const fakeTraceA = {
+  id: 'trace-aaaaaaaaaaaaaaaa',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-aaaaaaaaaaaaaaaaaa',
+  status: 'completed',
+  responseContent: 'Response A',
+  messages: [],
+  createdAt: new Date(),
+};
+
+const fakeTraceB = {
+  id: 'trace-bbbbbbbbbbbbbbbb',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-bbbbbbbbbbbbbbbbbb',
+  status: 'completed',
+  responseContent: 'Response B',
+  messages: [],
+  createdAt: new Date(),
+};
+
+const fakeRunWithTraces = {
+  ...fakeRun,
+  task: fakeTask,
+  contestants: [
+    { ...fakeContestantA, trace: fakeTraceA },
+    { ...fakeContestantB, trace: fakeTraceB },
+  ],
+};
+
+const fakeRubric = {
+  id: 'rubric-00000000000000',
+  name: 'Test Rubric',
+  description: 'A test rubric.',
+  domain: null,
+  criteria: [
+    { name: 'quality', description: 'Quality of response', weight: 1.0, scale: { min: 1, max: 5 } },
+  ],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeEvaluationA = {
+  id: 'eval-aaaaaaaaaaaaaaaa0',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-aaaaaaaaaaaaaaaaaa',
+  rubricId: 'rubric-00000000000000',
+  judgeModel: 'gpt-4o',
+  scores: [{ criterionName: 'quality', score: 4, rationale: 'Good' }],
+  overallScore: 0.75,
+  rationale: 'Contestant A performed well overall.',
+  rawJudgeResponse: null,
+  reconciliation: null,
+  inputTokens: null,
+  outputTokens: null,
+  latencyMs: null,
+  createdAt: new Date('2026-03-30T10:00:00Z'),
+};
+
+const fakeEvaluationB = {
+  id: 'eval-bbbbbbbbbbbbbbbb0',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-bbbbbbbbbbbbbbbbbb',
+  rubricId: 'rubric-00000000000000',
+  judgeModel: 'gpt-4o',
+  scores: [{ criterionName: 'quality', score: 3, rationale: 'Adequate' }],
+  overallScore: 0.5,
+  rationale: 'Contestant B was adequate.',
+  rawJudgeResponse: null,
+  reconciliation: null,
+  inputTokens: null,
+  outputTokens: null,
+  latencyMs: null,
+  createdAt: new Date('2026-03-30T10:00:00Z'),
+};
+
+const fakeScorecardA = {
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-aaaaaaaaaaaaaaaaaa',
+  contestantLabel: 'GPT-4o',
+  rubricName: 'Test Rubric',
+  overallScore: 0.75,
+  criterionScores: [
+    { name: 'quality', score: 4, normalizedScore: 0.75, weight: 1.0, weightedScore: 0.75, rationale: 'Good' },
+  ],
+};
+
+const fakeScorecardB = {
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-bbbbbbbbbbbbbbbbbb',
+  contestantLabel: 'Claude',
+  rubricName: 'Test Rubric',
+  overallScore: 0.5,
+  criterionScores: [
+    { name: 'quality', score: 3, normalizedScore: 0.5, weight: 1.0, weightedScore: 0.5, rationale: 'Adequate' },
+  ],
+};
+
+const fakeComparison = {
+  taskName: 'Test Task',
+  rubricName: 'Test Rubric',
+  contestants: [fakeScorecardA, fakeScorecardB],
+  winner: { contestantId: 'cont-aaaaaaaaaaaaaaaaaa', label: 'GPT-4o', margin: 0.25 },
+  criterionBreakdown: [
+    {
+      criterionName: 'quality',
+      scores: [
+        { contestantLabel: 'GPT-4o', score: 4 },
+        { contestantLabel: 'Claude', score: 3 },
+      ],
+      winner: 'GPT-4o',
+    },
+  ],
+};
+
+const fakeFailureTag = {
+  id: 'ftag-00000000000000000',
+  runId: 'run-000000000000000000',
+  contestantId: 'cont-bbbbbbbbbbbbbbbbbb',
+  category: 'partial_answer',
+  description: 'Missed key detail',
+  source: 'judge',
+  evaluationId: 'eval-bbbbbbbbbbbbbbbb0',
+  createdAt: new Date(),
+};
+
+const fakeDb = {};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('assembleRunReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns report with evaluations when they exist', async () => {
+    mockGetRunWithTraces.mockResolvedValue(fakeRunWithTraces);
+    mockGetRubric.mockResolvedValue(fakeRubric);
+    mockGetFailureTagsForRun.mockResolvedValue([]);
+    mockGetEvaluationsForRun.mockResolvedValue([fakeEvaluationA, fakeEvaluationB]);
+    mockBuildScorecard
+      .mockReturnValueOnce(fakeScorecardA)
+      .mockReturnValueOnce(fakeScorecardB);
+    mockCompareRun.mockReturnValue(fakeComparison);
+
+    const { assembleRunReport } = await import('@/lib/eval/report');
+    const report = await assembleRunReport(
+      fakeDb as never,
+      'run-000000000000000000' as never,
+      'rubric-00000000000000' as never,
+    );
+
+    expect(report).not.toBeNull();
+    expect(report!.needsEvaluation).toBe(false);
+    expect(report!.run.id).toBe('run-000000000000000000');
+    expect(report!.task.name).toBe('Test Task');
+    expect(report!.rubric.name).toBe('Test Rubric');
+    expect(report!.contestants).toHaveLength(2);
+    expect(report!.contestants[0]!.scorecard).toEqual(fakeScorecardA);
+    expect(report!.contestants[1]!.scorecard).toEqual(fakeScorecardB);
+    expect(report!.comparison).toEqual(fakeComparison);
+    expect(report!.summary).toBe('Contestant A performed well overall.');
+  });
+
+  it('returns needsEvaluation=true when no evaluations exist', async () => {
+    mockGetRunWithTraces.mockResolvedValue(fakeRunWithTraces);
+    mockGetRubric.mockResolvedValue(fakeRubric);
+    mockGetFailureTagsForRun.mockResolvedValue([]);
+    mockGetEvaluationsForRun.mockResolvedValue([]);
+
+    const { assembleRunReport } = await import('@/lib/eval/report');
+    const report = await assembleRunReport(
+      fakeDb as never,
+      'run-000000000000000000' as never,
+      'rubric-00000000000000' as never,
+    );
+
+    expect(report).not.toBeNull();
+    expect(report!.needsEvaluation).toBe(true);
+    expect(report!.contestants[0]!.scorecard).toBeNull();
+    expect(report!.contestants[1]!.scorecard).toBeNull();
+    expect(report!.comparison).toBeNull();
+    expect(report!.summary).toBeNull();
+  });
+
+  it('includes failure tags per contestant', async () => {
+    mockGetRunWithTraces.mockResolvedValue(fakeRunWithTraces);
+    mockGetRubric.mockResolvedValue(fakeRubric);
+    mockGetFailureTagsForRun.mockResolvedValue([fakeFailureTag]);
+    mockGetEvaluationsForRun.mockResolvedValue([fakeEvaluationA, fakeEvaluationB]);
+    mockBuildScorecard
+      .mockReturnValueOnce(fakeScorecardA)
+      .mockReturnValueOnce(fakeScorecardB);
+    mockCompareRun.mockReturnValue(fakeComparison);
+
+    const { assembleRunReport } = await import('@/lib/eval/report');
+    const report = await assembleRunReport(
+      fakeDb as never,
+      'run-000000000000000000' as never,
+      'rubric-00000000000000' as never,
+    );
+
+    expect(report).not.toBeNull();
+    // Contestant A has no failure tags
+    expect(report!.contestants[0]!.failureTags).toHaveLength(0);
+    // Contestant B has the failure tag
+    expect(report!.contestants[1]!.failureTags).toHaveLength(1);
+    expect(report!.contestants[1]!.failureTags[0]!.category).toBe('partial_answer');
+  });
+
+  it('returns null comparison when unevaluated', async () => {
+    mockGetRunWithTraces.mockResolvedValue(fakeRunWithTraces);
+    mockGetRubric.mockResolvedValue(fakeRubric);
+    mockGetFailureTagsForRun.mockResolvedValue([fakeFailureTag]);
+    mockGetEvaluationsForRun.mockResolvedValue([]);
+
+    const { assembleRunReport } = await import('@/lib/eval/report');
+    const report = await assembleRunReport(
+      fakeDb as never,
+      'run-000000000000000000' as never,
+      'rubric-00000000000000' as never,
+    );
+
+    expect(report).not.toBeNull();
+    expect(report!.comparison).toBeNull();
+    expect(report!.needsEvaluation).toBe(true);
+    // Failure tags are still present even without evaluations
+    expect(report!.contestants[1]!.failureTags).toHaveLength(1);
+  });
+
+  it('returns null when run does not exist', async () => {
+    mockGetRunWithTraces.mockResolvedValue(null);
+
+    const { assembleRunReport } = await import('@/lib/eval/report');
+    const report = await assembleRunReport(
+      fakeDb as never,
+      'run-missing000000000000' as never,
+      'rubric-00000000000000' as never,
+    );
+
+    expect(report).toBeNull();
+  });
+
+  it('returns null when rubric does not exist', async () => {
+    mockGetRunWithTraces.mockResolvedValue(fakeRunWithTraces);
+    mockGetRubric.mockResolvedValue(null);
+
+    const { assembleRunReport } = await import('@/lib/eval/report');
+    const report = await assembleRunReport(
+      fakeDb as never,
+      'run-000000000000000000' as never,
+      'rubric-missing0000000' as never,
+    );
+
+    expect(report).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #121.

- Adds `RunReport` composite type that assembles run data, evaluations, scorecards, comparisons, and failure tags into a single read model
- Adds `assembleRunReport(db, runId, rubricId)` -- pure read function, no model calls, no writes
- Adds `GET /api/runs/:id/report?rubricId=xxx` -- safe, idempotent endpoint (200/400/404)
- Returns `needsEvaluation: true` with null scores/comparison/summary when no evaluations exist for the rubric
- Includes `buildSummaryPrompt` internal helper for future summary generation (not called during assembly)

## What changed

| File | Change |
|------|--------|
| `lib/eval/types.ts` | `RunReport` type definition |
| `lib/eval/report.ts` | `assembleRunReport`, `buildSummaryPrompt` |
| `lib/eval/index.ts` | Barrel exports for M2.5 |
| `app/api/runs/[id]/report/route.ts` | GET endpoint |
| `tests/unit/eval/report.test.ts` | 6 unit tests |
| `tests/api/eval/report.test.ts` | 3 API route tests |

## Design decisions

- GET is pure read per spec: no evaluation triggers, no writes, no model costs on browser refresh
- Summary field populated from evaluation rationale when available, null otherwise
- Uses same dynamic route pattern as `app/api/runs/[id]/route.ts` (try/catch + log.error, not withLogging)
- No new migrations -- assembles existing M2.1-M2.4 data

## Test plan

- [x] `assembleRunReport` returns full report when evaluations exist
- [x] `assembleRunReport` returns `needsEvaluation: true` when no evaluations
- [x] `assembleRunReport` includes failure tags per contestant
- [x] `assembleRunReport` returns null comparison when unevaluated
- [x] `assembleRunReport` returns null for missing run or rubric
- [x] GET returns 200 with report
- [x] GET returns 400 when rubricId missing
- [x] GET returns 404 for missing run
- [x] Gate green: typecheck + lint + test:unit (1651 tests, 0 failures)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Run Report that assembles run data, rubric evaluations, scorecards, comparisons, and failure tags into one response. Exposes GET `/api/runs/:id/report?rubricId=...` to deliver this report safely and idempotently (M2.5; aligns with Linear #121).

- **New Features**
  - `RunReport` type and `assembleRunReport(db, runId, rubricId)`; pure read with no model calls or writes.
  - GET endpoint: 200 with report, 400 if missing `rubricId`, 404 if run or rubric not found.
  - When no evaluations for the rubric: `needsEvaluation: true` and null `scorecard`, `comparison`, `summary`; failure tags still included.
  - Adds internal `buildSummaryPrompt` for future summaries (not invoked).

<sup>Written for commit cd8b61baae753d3f3552cd905e5b1340c621685c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

