### PR TITLE
feat(ui): M3.4 - run report page with scores, traces, economics

### DIFF
--- a/app/(eval)/runs/[id]/page.tsx
+++ b/app/(eval)/runs/[id]/page.tsx
@@ -1,0 +1,252 @@
+// Run report page -- server component displaying run data, traces,
+// evaluations, economics, and comparison (M3.4). Closes #127.
+
+import { notFound } from 'next/navigation';
+import { requireDb } from '@/db';
+import { asRunId, asRubricId } from '@/lib/domain-ids';
+import { getRunWithTraces } from '@/lib/run/queries';
+import { getRunEconomics } from '@/lib/run/economics';
+import { getEvaluationsForRun } from '@/lib/eval/evaluations';
+import { assembleRunReport } from '@/lib/eval/report';
+import { getFailureTagsForRun } from '@/lib/eval/failure-tags';
+
+import { ScoreCard } from '@/components/eval/ScoreCard';
+import { FailureTagBadge } from '@/components/eval/FailureTagBadge';
+import { CostBreakdown } from '@/components/eval/CostBreakdown';
+import { ComparisonView } from '@/components/eval/ComparisonView';
+import { TraceViewer } from '@/components/eval/TraceViewer';
+import { EvaluateButton } from '@/components/eval/EvaluateButton';
+
+import type { RunReport } from '@/lib/eval/types';
+
+export default async function RunReportPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const db = requireDb();
+  const runId = asRunId(id);
+
+  const run = await getRunWithTraces(db, runId);
+  if (!run) notFound();
+
+  const economics = await getRunEconomics(db, runId);
+
+  // Check for evaluations and build report if any exist.
+  // We need a rubricId to assemble the report. Find it from
+  // the first evaluation, if evaluations exist.
+  const allEvaluations = await getEvaluationsForRun(db, runId);
+  const allFailureTags = await getFailureTagsForRun(db, runId);
+
+  let report: RunReport | null = null;
+  if (allEvaluations.length > 0) {
+    const rubricId = asRubricId(allEvaluations[0]!.rubricId);
+    report = await assembleRunReport(db, runId, rubricId);
+  }
+
+  const { task, contestants, status } = run;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-lg text-foreground">{task.name}</h1>
+        <p className="mt-1 text-sm text-foreground/50">
+          Run {id} / {status}
+        </p>
+      </div>
+
+      {/* Task details */}
+      <section className="space-y-2">
+        <h2 className="text-xs uppercase tracking-[0.3em] text-muted">
+          Task
+        </h2>
+        <div className="rounded border border-foreground/10 p-4 text-sm">
+          <p className="text-foreground/70">{task.prompt}</p>
+
+          {task.constraints && (task.constraints as string[]).length > 0 && (
+            <div className="mt-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-muted">
+                Constraints
+              </p>
+              <ul className="ml-4 mt-1 list-disc text-foreground/50">
+                {(task.constraints as string[]).map((c, i) => (
+                  <li key={i}>{c}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {task.acceptanceCriteria &&
+            (task.acceptanceCriteria as string[]).length > 0 && (
+              <div className="mt-3">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted">
+                  Acceptance Criteria
+                </p>
+                <ul className="ml-4 mt-1 list-disc text-foreground/50">
+                  {(task.acceptanceCriteria as string[]).map((c, i) => (
+                    <li key={i}>{c}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+        </div>
+      </section>
+
+      {/* Summary (from report) */}
+      {report?.summary && (
+        <section className="space-y-2">
+          <h2 className="text-xs uppercase tracking-[0.3em] text-muted">
+            Summary
+          </h2>
+          <div className="rounded border border-foreground/10 p-4 text-sm text-foreground/70">
+            {report.summary}
+          </div>
+        </section>
+      )}
+
+      {/* Comparison (if evaluated and 2+ contestants) */}
+      {report?.comparison && (
+        <section>
+          <ComparisonView comparison={report.comparison} />
+        </section>
+      )}
+
+      {/* Contestants */}
+      <section className="space-y-6">
+        <h2 className="text-xs uppercase tracking-[0.3em] text-muted">
+          Contestants ({contestants.length})
+        </h2>
+
+        {contestants.map((c) => {
+          const contestantFailureTags = allFailureTags.filter(
+            (ft) => ft.contestantId === c.id,
+          );
+          const reportContestant = report?.contestants.find(
+            (rc) => rc.contestant.id === c.id,
+          );
+          const contestantEconomics = economics?.contestants.find(
+            (ce) => ce.contestantId === c.id,
+          );
+
+          return (
+            <div
+              key={c.id}
+              className="space-y-4 rounded border border-foreground/10 p-4"
+            >
+              {/* Contestant header */}
+              <div className="flex items-baseline justify-between">
+                <h3 className="text-sm text-foreground">{c.label}</h3>
+                <span className="font-mono text-xs text-foreground/50">
+                  {c.model}
+                </span>
+              </div>
+
+              {/* Config summary */}
+              <div className="flex gap-4 text-xs text-foreground/40">
+                {c.temperature !== null && (
+                  <span>temp={c.temperature}</span>
+                )}
+                {c.systemPrompt && (
+                  <span>system prompt set</span>
+                )}
+              </div>
+
+              {/* Trace */}
+              {c.trace && (
+                <TraceViewer
+                  requestMessages={c.trace.requestMessages}
+                  responseContent={c.trace.responseContent}
+                />
+              )}
+
+              {/* Scorecard */}
+              {reportContestant?.scorecard && (
+                <ScoreCard scorecard={reportContestant.scorecard} />
+              )}
+
+              {/* Failure tags */}
+              {contestantFailureTags.length > 0 && (
+                <div className="space-y-1">
+                  <p className="text-xs uppercase tracking-[0.3em] text-muted">
+                    Failure Tags
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {contestantFailureTags.map((ft) => (
+                      <FailureTagBadge
+                        key={ft.id}
+                        category={ft.category}
+                        description={ft.description}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Economics */}
+              {contestantEconomics && (
+                <CostBreakdown economics={contestantEconomics} />
+              )}
+            </div>
+          );
+        })}
+      </section>
+
+      {/* Economics summary */}
+      {economics && (
+        <section className="space-y-2">
+          <h2 className="text-xs uppercase tracking-[0.3em] text-muted">
+            Economics Summary
+          </h2>
+          <div className="rounded border border-foreground/10 p-4">
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-3">
+              <dt className="text-foreground/50">Total cost</dt>
+              <dd className="font-mono text-accent">
+                ${(economics.totalCostMicro / 1_000_000).toFixed(4)}
+              </dd>
+
+              <dt className="text-foreground/50">Total tokens</dt>
+              <dd className="font-mono">
+                {economics.totalTokens.toLocaleString()}
+              </dd>
+
+              <dt className="text-foreground/50">Total latency</dt>
+              <dd className="font-mono">
+                {(economics.totalLatencyMs / 1000).toFixed(1)}s
+              </dd>
+
+              {economics.cheapestContestant && (
+                <>
+                  <dt className="text-foreground/50">Cheapest</dt>
+                  <dd className="font-mono">{economics.cheapestContestant}</dd>
+                </>
+              )}
+
+              {economics.fastestContestant && (
+                <>
+                  <dt className="text-foreground/50">Fastest</dt>
+                  <dd className="font-mono">{economics.fastestContestant}</dd>
+                </>
+              )}
+
+              {economics.bestValueContestant && (
+                <>
+                  <dt className="text-foreground/50">Best value</dt>
+                  <dd className="font-mono">{economics.bestValueContestant}</dd>
+                </>
+              )}
+            </dl>
+          </div>
+        </section>
+      )}
+
+      {/* Evaluate button (if not yet evaluated) */}
+      {allEvaluations.length === 0 && status === 'completed' && (
+        <section>
+          <EvaluateButton runId={id} />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/components/eval/ComparisonView.tsx
+++ b/components/eval/ComparisonView.tsx
@@ -1,0 +1,96 @@
+// Side-by-side contestant comparison display (M3.4).
+
+import type { RunComparison } from '@/lib/eval/types';
+
+type ComparisonViewProps = {
+  comparison: RunComparison;
+};
+
+export function ComparisonView({ comparison }: ComparisonViewProps) {
+  const { contestants, winner, criterionBreakdown } = comparison;
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-xs uppercase tracking-[0.3em] text-muted">
+        Comparison
+      </h3>
+
+      {/* Winner declaration */}
+      {winner && (
+        <div className="rounded border border-accent/30 bg-accent/5 p-3">
+          <p className="text-sm">
+            <span className="text-accent">{winner.label}</span>{' '}
+            wins by{' '}
+            <span className="font-mono text-accent">
+              {(winner.margin * 100).toFixed(1)}%
+            </span>{' '}
+            margin
+          </p>
+        </div>
+      )}
+
+      {/* Side-by-side overall scores */}
+      <div className="grid grid-cols-2 gap-4">
+        {contestants.map((sc) => (
+          <div
+            key={sc.contestantId}
+            className={`rounded border p-3 ${
+              winner?.contestantId === sc.contestantId
+                ? 'border-accent/30'
+                : 'border-foreground/10'
+            }`}
+          >
+            <p className="text-xs uppercase tracking-[0.2em] text-muted">
+              {sc.contestantLabel}
+            </p>
+            <p className="mt-1 font-mono text-lg text-accent">
+              {(sc.overallScore * 100).toFixed(1)}%
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Per-criterion breakdown */}
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-foreground/10 text-left text-xs uppercase tracking-[0.2em] text-muted">
+            <th className="py-1 pr-2">Criterion</th>
+            {contestants.map((sc) => (
+              <th key={sc.contestantId} className="py-1 pr-2 text-right">
+                {sc.contestantLabel}
+              </th>
+            ))}
+            <th className="py-1 text-right">Winner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {criterionBreakdown.map((cb) => (
+            <tr
+              key={cb.criterionName}
+              className="border-b border-foreground/5"
+            >
+              <td className="py-1.5 pr-2 text-foreground/70">
+                {cb.criterionName}
+              </td>
+              {cb.scores.map((s) => (
+                <td
+                  key={s.contestantLabel}
+                  className={`py-1.5 pr-2 text-right font-mono ${
+                    cb.winner === s.contestantLabel
+                      ? 'text-accent'
+                      : 'text-foreground/50'
+                  }`}
+                >
+                  {(s.score * 100).toFixed(0)}%
+                </td>
+              ))}
+              <td className="py-1.5 text-right text-foreground/50">
+                {cb.winner ?? '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/eval/CostBreakdown.tsx
+++ b/components/eval/CostBreakdown.tsx
@@ -1,0 +1,58 @@
+// Per-contestant cost, token, and latency breakdown (M3.4).
+
+import type { ContestantEconomics } from '@/lib/run/economics';
+
+type CostBreakdownProps = {
+  economics: ContestantEconomics;
+};
+
+/** Format microdollars as a dollar string. */
+function formatCost(micro: number): string {
+  return `$${(micro / 1_000_000).toFixed(4)}`;
+}
+
+/** Format milliseconds as seconds with one decimal. */
+function formatLatency(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function CostBreakdown({ economics }: CostBreakdownProps) {
+  return (
+    <div className="space-y-2">
+      <h4 className="text-xs uppercase tracking-[0.3em] text-muted">
+        Cost / Tokens
+      </h4>
+
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+        <dt className="text-foreground/50">Model</dt>
+        <dd className="font-mono">{economics.model}</dd>
+
+        <dt className="text-foreground/50">Input tokens</dt>
+        <dd className="font-mono">{economics.inputTokens.toLocaleString()}</dd>
+
+        <dt className="text-foreground/50">Output tokens</dt>
+        <dd className="font-mono">{economics.outputTokens.toLocaleString()}</dd>
+
+        <dt className="text-foreground/50">Cost</dt>
+        <dd className="font-mono text-accent">{formatCost(economics.costMicro)}</dd>
+
+        <dt className="text-foreground/50">Latency</dt>
+        <dd className="font-mono">{formatLatency(economics.latencyMs)}</dd>
+
+        {economics.scorePerDollar !== null && (
+          <>
+            <dt className="text-foreground/50">Score / dollar</dt>
+            <dd className="font-mono">{economics.scorePerDollar.toFixed(2)}</dd>
+          </>
+        )}
+
+        {economics.scorePerSecond !== null && (
+          <>
+            <dt className="text-foreground/50">Score / second</dt>
+            <dd className="font-mono">{economics.scorePerSecond.toFixed(4)}</dd>
+          </>
+        )}
+      </dl>
+    </div>
+  );
+}

--- a/components/eval/EvaluateButton.tsx
+++ b/components/eval/EvaluateButton.tsx
@@ -1,0 +1,83 @@
+// Button to trigger run evaluation via POST /api/runs/:id/evaluate (M3.4).
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { PitButton } from '@/components/ui/button';
+
+type EvaluateButtonProps = {
+  runId: string;
+};
+
+export function EvaluateButton({ runId }: EvaluateButtonProps) {
+  const router = useRouter();
+  const [rubricId, setRubricId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleEvaluate() {
+    if (!rubricId.trim()) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/runs/${runId}/evaluate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rubricId }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(
+          data?.error ?? `Evaluation failed (${res.status})`,
+        );
+      }
+
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 rounded border border-foreground/10 p-4">
+      <h3 className="text-xs uppercase tracking-[0.3em] text-muted">
+        Evaluate Run
+      </h3>
+
+      <div>
+        <label
+          htmlFor="rubric-id"
+          className="mb-1 block text-sm text-foreground/70"
+        >
+          Rubric ID
+        </label>
+        <input
+          id="rubric-id"
+          type="text"
+          value={rubricId}
+          onChange={(e) => setRubricId(e.target.value)}
+          placeholder="Enter rubric ID"
+          className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm text-foreground transition focus:border-accent focus:outline-none"
+        />
+      </div>
+
+      {error && (
+        <div className="rounded border border-red-400/50 bg-red-400/10 p-3 text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      <PitButton
+        type="button"
+        onClick={handleEvaluate}
+        disabled={loading || !rubricId.trim()}
+      >
+        {loading ? 'Evaluating...' : 'Evaluate'}
+      </PitButton>
+    </div>
+  );
+}

--- a/components/eval/FailureTagBadge.tsx
+++ b/components/eval/FailureTagBadge.tsx
@@ -1,0 +1,39 @@
+// Colored badge for failure tag categories (M3.4).
+
+import type { FailureCategory } from '@/lib/eval/types';
+
+type FailureTagBadgeProps = {
+  category: FailureCategory;
+  description?: string | null;
+};
+
+/**
+ * Maps each failure_category enum value to Tailwind color classes.
+ * Enum values: wrong_answer, partial_answer, refusal, off_topic,
+ * unsafe_output, hallucination, format_violation, context_misuse,
+ * instruction_violation.
+ */
+const categoryColors: Record<FailureCategory, string> = {
+  wrong_answer: 'border-red-400/50 bg-red-400/10 text-red-400',
+  partial_answer: 'border-orange-400/50 bg-orange-400/10 text-orange-400',
+  refusal: 'border-yellow-400/50 bg-yellow-400/10 text-yellow-400',
+  off_topic: 'border-yellow-400/50 bg-yellow-400/10 text-yellow-400',
+  unsafe_output: 'border-red-500/50 bg-red-500/10 text-red-500',
+  hallucination: 'border-red-400/50 bg-red-400/10 text-red-400',
+  format_violation: 'border-blue-400/50 bg-blue-400/10 text-blue-400',
+  context_misuse: 'border-purple-400/50 bg-purple-400/10 text-purple-400',
+  instruction_violation: 'border-orange-400/50 bg-orange-400/10 text-orange-400',
+};
+
+export function FailureTagBadge({ category, description }: FailureTagBadgeProps) {
+  const colors = categoryColors[category];
+
+  return (
+    <span
+      className={`inline-block rounded border px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] ${colors}`}
+      title={description ?? undefined}
+    >
+      {category.replace(/_/g, ' ')}
+    </span>
+  );
+}

--- a/components/eval/ScoreCard.tsx
+++ b/components/eval/ScoreCard.tsx
@@ -1,0 +1,54 @@
+// Per-contestant scorecard display with criterion scores (M3.4).
+
+import type { Scorecard } from '@/lib/eval/types';
+
+type ScoreCardProps = {
+  scorecard: Scorecard;
+};
+
+export function ScoreCard({ scorecard }: ScoreCardProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-baseline justify-between">
+        <h4 className="text-xs uppercase tracking-[0.3em] text-muted">
+          Scorecard
+        </h4>
+        <span className="font-mono text-sm text-accent">
+          {(scorecard.overallScore * 100).toFixed(1)}%
+        </span>
+      </div>
+
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-foreground/10 text-left text-xs uppercase tracking-[0.2em] text-muted">
+            <th className="py-1 pr-2">Criterion</th>
+            <th className="py-1 pr-2 text-right">Score</th>
+            <th className="py-1 pr-2 text-right">Weight</th>
+            <th className="py-1">Rationale</th>
+          </tr>
+        </thead>
+        <tbody>
+          {scorecard.criterionScores.map((cs) => (
+            <tr
+              key={cs.name}
+              className="border-b border-foreground/5"
+            >
+              <td className="py-1.5 pr-2 text-foreground/70">
+                {cs.name}
+              </td>
+              <td className="py-1.5 pr-2 text-right font-mono">
+                {(cs.normalizedScore * 100).toFixed(0)}%
+              </td>
+              <td className="py-1.5 pr-2 text-right font-mono text-foreground/50">
+                {cs.weight}
+              </td>
+              <td className="py-1.5 text-foreground/50">
+                {cs.rationale}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/eval/TraceViewer.tsx
+++ b/components/eval/TraceViewer.tsx
@@ -1,0 +1,60 @@
+// Collapsible trace viewer for request/response messages (M3.4).
+'use client';
+
+import type { TraceMessage } from '@/db/schema';
+
+type TraceViewerProps = {
+  requestMessages: TraceMessage[];
+  responseContent: string | null;
+};
+
+const roleLabelColors: Record<string, string> = {
+  system: 'text-purple-400',
+  user: 'text-blue-400',
+  assistant: 'text-green-400',
+};
+
+export function TraceViewer({
+  requestMessages,
+  responseContent,
+}: TraceViewerProps) {
+  return (
+    <div className="space-y-2">
+      <details className="group">
+        <summary className="cursor-pointer text-xs uppercase tracking-[0.3em] text-muted transition hover:text-foreground">
+          Request Messages ({requestMessages.length})
+        </summary>
+        <div className="mt-2 space-y-2">
+          {requestMessages.map((msg, idx) => (
+            <div
+              key={idx}
+              className="rounded border border-foreground/10 p-3"
+            >
+              <p
+                className={`mb-1 text-[10px] uppercase tracking-[0.2em] ${
+                  roleLabelColors[msg.role] ?? 'text-foreground/50'
+                }`}
+              >
+                {msg.role}
+              </p>
+              <pre className="whitespace-pre-wrap text-sm text-foreground/70">
+                {msg.content}
+              </pre>
+            </div>
+          ))}
+        </div>
+      </details>
+
+      <details className="group" open>
+        <summary className="cursor-pointer text-xs uppercase tracking-[0.3em] text-muted transition hover:text-foreground">
+          Response
+        </summary>
+        <div className="mt-2 rounded border border-foreground/10 p-3">
+          <pre className="whitespace-pre-wrap text-sm text-foreground/70">
+            {responseContent ?? '(no response)'}
+          </pre>
+        </div>
+      </details>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add server component run report page at `app/(eval)/runs/[id]/page.tsx` that displays task details, contestant traces, scorecards, failure tags, cost/token breakdown, side-by-side comparison, and economics summary
- Add 6 new components in `components/eval/`: ScoreCard, FailureTagBadge, CostBreakdown, ComparisonView, TraceViewer (client), EvaluateButton (client)
- Page calls `getRunWithTraces`, `getRunEconomics`, `getEvaluationsForRun`, `assembleRunReport`, and `getFailureTagsForRun` directly as a server component -- no API round-trip for rendering

## What changed

The run report page is the read-side UI for completed runs. It fetches all data server-side and renders:
1. Task details (name, prompt, constraints, acceptance criteria)
2. Per-contestant panels with trace viewer, scorecard, failure tags, and cost breakdown
3. Side-by-side comparison with winner declaration (if evaluated)
4. Economics summary (total cost, tokens, latency, cheapest/fastest/best-value)
5. Evaluate button (if run is completed but not yet evaluated)

## What was tested

- `pnpm typecheck` -- zero errors
- `pnpm lint` -- zero new warnings (46 pre-existing, all in unrelated files)
- `pnpm test:unit` -- 1659 tests pass, 0 failures

## Scope boundary

- No backend changes, no migrations, no API changes
- No new tests (E2E coverage planned for M3.5)
- UI is functional, not polished (per spec design decision 4)

Closes #127

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-rendered Run Report page for completed runs at app/(eval)/runs/[id] that shows task details, per-contestant traces and scores, side-by-side comparison, and full cost/token/latency economics. Fulfills Linear #127 and avoids client API round-trips by loading all data on the server.

- **New Features**
  - Task details and optional report summary.
  - Per-contestant panels: TraceViewer, ScoreCard, FailureTagBadge, CostBreakdown.
  - Side-by-side ComparisonView with winner and per-criterion breakdown.
  - Economics summary (totals and cheapest/fastest/best value) and an EvaluateButton when a completed run hasn’t been evaluated.

<sup>Written for commit b7ebb0edb572e6a05201cb918c6b1baf84362f5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive run report page displaying evaluation results, contestant scores, and detailed performance comparisons
  * Introduced side-by-side score comparisons with per-criterion breakdowns and winner highlighting
  * Added cost and performance analytics including token usage, latency, and efficiency metrics
  * New evaluation interface for scoring runs against custom rubrics
  * Added visual failure categorization tags and collapsible trace viewers for request/response inspection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->