### PR TITLE
feat(ui): M3.5 - run list page with status badges

### DIFF
--- a/app/(eval)/runs/page.tsx
+++ b/app/(eval)/runs/page.tsx
@@ -1,0 +1,111 @@
+// Run list page (M3.5). Server component listing runs with status filter
+// and pagination. Closes #128.
+
+import Link from 'next/link';
+import { requireDb } from '@/db';
+import { listRuns } from '@/lib/run/runs';
+import { RunList } from '@/components/eval/RunList';
+import type { RunStatus } from '@/lib/run/types';
+
+export const metadata = {
+  title: 'Runs - The Pit',
+};
+
+const VALID_STATUSES: RunStatus[] = ['pending', 'running', 'completed', 'failed'];
+const DEFAULT_LIMIT = 20;
+
+function isValidStatus(value: string): value is RunStatus {
+  return (VALID_STATUSES as string[]).includes(value);
+}
+
+export default async function RunsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+
+  // Parse status filter.
+  const rawStatus = typeof params.status === 'string' ? params.status : undefined;
+  const status = rawStatus && isValidStatus(rawStatus) ? rawStatus : undefined;
+
+  // Parse pagination.
+  const rawOffset = typeof params.offset === 'string' ? parseInt(params.offset, 10) : 0;
+  const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+
+  const db = requireDb();
+  const runs = await listRuns(db, { status, limit: DEFAULT_LIMIT, offset });
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <h1 className="text-lg uppercase tracking-[0.3em] text-foreground">
+        Runs
+      </h1>
+
+      {/* Status filter tabs */}
+      <nav className="flex gap-2 border-b border-foreground/10 pb-2">
+        <StatusTab label="All" value={undefined} current={status} />
+        {VALID_STATUSES.map((s) => (
+          <StatusTab key={s} label={s} value={s} current={status} />
+        ))}
+      </nav>
+
+      <RunList runs={runs} />
+
+      {/* Pagination */}
+      <div className="flex items-center gap-4 text-sm">
+        {offset > 0 && (
+          <Link
+            href={buildHref(status, Math.max(0, offset - DEFAULT_LIMIT))}
+            className="text-accent transition hover:underline"
+          >
+            Previous
+          </Link>
+        )}
+        {runs.length === DEFAULT_LIMIT && (
+          <Link
+            href={buildHref(status, offset + DEFAULT_LIMIT)}
+            className="text-accent transition hover:underline"
+          >
+            Next
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Build href for pagination/filter links. */
+function buildHref(status: RunStatus | undefined, offset: number): string {
+  const parts: string[] = [];
+  if (status) parts.push(`status=${status}`);
+  if (offset > 0) parts.push(`offset=${offset}`);
+  return parts.length > 0 ? `/runs?${parts.join('&')}` : '/runs';
+}
+
+/** A single status filter tab rendered as a link. */
+function StatusTab({
+  label,
+  value,
+  current,
+}: {
+  label: string;
+  value: RunStatus | undefined;
+  current: RunStatus | undefined;
+}) {
+  const active = value === current;
+  const href = buildHref(value, 0);
+
+  return (
+    <Link
+      href={href}
+      className={`rounded px-3 py-1 text-xs uppercase tracking-[0.2em] transition ${
+        active
+          ? 'bg-foreground/10 text-foreground'
+          : 'text-foreground/50 hover:text-foreground'
+      }`}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/components/eval/RunList.tsx
+++ b/components/eval/RunList.tsx
@@ -1,0 +1,66 @@
+// Run list table component (M3.5). Server component.
+
+import Link from 'next/link';
+import type { Run } from '@/lib/run/types';
+import { StatusBadge } from './StatusBadge';
+
+type RunListProps = {
+  runs: Run[];
+};
+
+/** Format a Date or string timestamp for display. */
+function formatDate(value: Date | string): string {
+  const d = typeof value === 'string' ? new Date(value) : value;
+  return d.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+export function RunList({ runs }: RunListProps) {
+  if (runs.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-foreground/50">
+        No runs found.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-foreground/10 text-left text-xs uppercase tracking-[0.2em] text-muted">
+            <th className="pb-2 pr-4">Run ID</th>
+            <th className="pb-2 pr-4">Task ID</th>
+            <th className="pb-2 pr-4">Status</th>
+            <th className="pb-2">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr
+              key={run.id}
+              className="border-b border-foreground/5 transition hover:bg-foreground/[0.02]"
+            >
+              <td className="py-2 pr-4">
+                <Link
+                  href={`/runs/${run.id}`}
+                  className="font-mono text-accent transition hover:underline"
+                >
+                  {run.id}
+                </Link>
+              </td>
+              <td className="py-2 pr-4 font-mono text-foreground/50">
+                {run.taskId}
+              </td>
+              <td className="py-2 pr-4">
+                <StatusBadge status={run.status} />
+              </td>
+              <td className="py-2 font-mono text-foreground/50">
+                {formatDate(run.createdAt)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/eval/StatusBadge.tsx
+++ b/components/eval/StatusBadge.tsx
@@ -1,0 +1,26 @@
+// Colored badge for run status values (M3.5).
+
+import type { RunStatus } from '@/lib/run/types';
+
+type StatusBadgeProps = {
+  status: RunStatus;
+};
+
+const statusColors: Record<RunStatus, string> = {
+  pending: 'border-gray-400/50 bg-gray-400/10 text-gray-400',
+  running: 'border-blue-400/50 bg-blue-400/10 text-blue-400',
+  completed: 'border-green-400/50 bg-green-400/10 text-green-400',
+  failed: 'border-red-400/50 bg-red-400/10 text-red-400',
+};
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const colors = statusColors[status];
+
+  return (
+    <span
+      className={`inline-block rounded border px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] ${colors}`}
+    >
+      {status}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `app/(eval)/runs/page.tsx` -- async server component that lists runs with status filter tabs (All/Pending/Running/Completed/Failed) and offset pagination
- Add `components/eval/RunList.tsx` -- table component rendering Run ID (linked to report), Task ID, Status (via StatusBadge), and Created columns
- Add `components/eval/StatusBadge.tsx` -- colored badge component (pending=gray, running=blue, completed=green, failed=red) following FailureTagBadge styling pattern

No backend changes. No migrations. No API changes.

Closes #128

## What changed

The run list page (`/runs`) is the final piece of the M3.5 milestone. It fetches runs directly via `requireDb()` + `listRuns()` in a server component, matching the data-fetching pattern established in M3.4's report page. Status filter uses query params (`?status=completed`), and pagination uses `?offset=N` with a default limit of 20.

## What was tested

- `pnpm run typecheck` -- pass (zero errors)
- `pnpm run lint` -- pass (zero errors from new files; pre-existing warnings only)
- `pnpm run test:unit` -- 1659 tests pass, 0 failures

E2E test (Playwright) is deferred per task scope -- requires running dev server with database.

## Scope boundary

This PR contains only the three new UI files. No backend, schema, or API changes.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-rendered Runs page with filter tabs and offset pagination, plus colored status badges for quick scanning. Closes #128.

- **New Features**
  - New page at `/runs` listing Run ID (links to report), Task ID, Status, and Created.
  - Status tabs filter via `?status=pending|running|completed|failed`; “All” by default.
  - Pagination via `?offset` with 20 per page and Previous/Next links.
  - New `StatusBadge` component (pending=gray, running=blue, completed=green, failed=red).
  - Fetches runs in an async server component using `requireDb()` + `listRuns()`; no backend or API changes.

<sup>Written for commit 2d0f750aa4d893903e6144f8235e613a15af0d6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

