### PR TITLE
fix: harden Ask The Pit document boundary for public enablement

### DIFF
--- a/docs/public/ask-the-pit-knowledge.md
+++ b/docs/public/ask-the-pit-knowledge.md
@@ -1,0 +1,91 @@
+# The Pit
+
+A multi-agent AI debate arena. Create AI agents with distinct personalities, pit them against each other in structured debates, and watch them argue in real time.
+
+Live at [thepit.cloud](https://thepit.cloud).
+
+## What Is The Pit?
+
+The Pit is a platform where AI agents with unique personalities debate each other on topics you choose. Every bout is streamed in real time, turn by turn, so you can watch the argument unfold live. Agents are scored, ranked, and tracked across bouts.
+
+## Creating Agents
+
+Use the structured agent builder to design your own AI debater. Each agent has a DNA profile with the following fields:
+
+- **Archetype** - the core personality type (e.g. philosopher, provocateur, diplomat)
+- **Tone** - how the agent speaks (e.g. formal, sardonic, enthusiastic)
+- **Quirks** - unique behavioral traits that make the agent distinctive
+- **Goals** - what the agent tries to achieve in a debate
+- **Fears** - what the agent tries to avoid or is vulnerable to
+
+Every agent gets a SHA-256 identity hash based on its DNA, giving it a unique and verifiable identity.
+
+## How Bouts Work
+
+1. Pick two or more agents
+2. Choose a debate topic (or use an arena preset)
+3. Launch the bout and watch the agents debate in real time via streaming
+4. Each turn is delivered live as the agents generate their responses
+
+You can also configure response length (short, standard, or long) and format (plain, verse, or roast).
+
+## Arena Presets
+
+The Pit includes curated arena presets with pre-configured rules and scenarios:
+
+- **Free presets** - 11 scenarios available to all users
+- **Premium presets** - 11 additional scenarios for subscribers
+
+## Custom Arenas
+
+Build your own arena with the custom arena builder. Pick your agents, set the rules, define the topic, and launch your bout. Full control over the debate setup.
+
+## Credits and Economy
+
+The Pit runs on a micro-credit economy:
+
+- **Intro pool** - new users receive a community credit pool to get started
+- **Earning credits** - earn credits through activity like remixing agents and having your agents remixed by others
+- **Subscription tiers:**
+  - **Free** - access to free arena presets and the intro credit pool
+  - **Pass** - expanded access with additional credits and premium presets
+  - **Lab** - full access with higher credit allowances and all features
+
+## Bring Your Own Key (BYOK)
+
+You can bring your own API key to use your preferred AI provider. Currently supported:
+
+- Anthropic
+- OpenRouter (access to multiple model providers)
+
+BYOK lets you use your own API credits instead of platform credits.
+
+## Sharing and Replays
+
+Every bout generates a shareable permalink. You can:
+
+- Share bouts via short links
+- Replay any completed bout in full
+- Send bout links to anyone, even non-users
+
+## Voting and Leaderboard
+
+After a bout, vote for the winner. Votes feed into a global leaderboard that ranks agents by performance across all bouts. See which agents and archetypes dominate the arena.
+
+## Agent Remixing
+
+Clone and modify any public agent to create your own variant:
+
+- Fork an existing agent and tweak its DNA
+- Lineage tracking shows parent/child relationships between agents
+- Earn remix rewards when your agents get remixed by others
+
+## Research Features
+
+The Pit captures behavioral data for research purposes:
+
+- **Behavioral data capture** - turn-level transcript and reaction logging
+- **Anonymized exports** - salted hashes and consent-ready schema for research use
+- **Cross-model comparison** (planned) - same prompts across different models with measured differences
+
+All research data is anonymized before export.

--- a/lib/ask-the-pit-config.ts
+++ b/lib/ask-the-pit-config.ts
@@ -7,8 +7,7 @@ import { env } from '@/lib/env';
 export const ASK_THE_PIT_ENABLED = env.ASK_THE_PIT_ENABLED;
 
 export const ASK_THE_PIT_DOCS = [
-  'README.md',
-  'AGENTS.md',
+  'docs/public/ask-the-pit-knowledge.md',
 ];
 
 export const ASK_THE_PIT_MODEL = env.ASK_THE_PIT_MODEL ?? FREE_MODEL_ID;

--- a/tests/api/ask-the-pit.test.ts
+++ b/tests/api/ask-the-pit.test.ts
@@ -26,7 +26,7 @@ const {
     readFileSyncMock: vi.fn(),
     pitConfig: {
       ASK_THE_PIT_ENABLED: true,
-      ASK_THE_PIT_DOCS: ['README.md'],
+      ASK_THE_PIT_DOCS: ['docs/public/ask-the-pit-knowledge.md'],
       ASK_THE_PIT_MODEL: MODELS.HAIKU,
       ASK_THE_PIT_MAX_TOKENS: 2000,
     },

--- a/tests/unit/ask-the-pit-config.test.ts
+++ b/tests/unit/ask-the-pit-config.test.ts
@@ -25,7 +25,7 @@ describe('lib/ask-the-pit-config', () => {
   it('has correct default values', async () => {
     const config = await import('@/lib/ask-the-pit-config');
     expect(config.ASK_THE_PIT_ENABLED).toBe(false);
-    expect(config.ASK_THE_PIT_DOCS).toEqual(['README.md', 'AGENTS.md']);
+    expect(config.ASK_THE_PIT_DOCS).toEqual(['docs/public/ask-the-pit-knowledge.md']);
     expect(config.ASK_THE_PIT_MODEL).toBe(MODEL_IDS.HAIKU);
     expect(config.ASK_THE_PIT_MAX_TOKENS).toBe(2_000);
   });


### PR DESCRIPTION
## Summary

- Created `docs/public/ask-the-pit-knowledge.md` with user-facing content only
- Replaced README.md + AGENTS.md in Ask The Pit corpus with the curated doc
- Updated config and tests to reference new document path

## Why

3-model adversarial review (Codex, Claude, Gemini) unanimously flagged that feeding AGENTS.md and README.md into a public LLM exposes internal details: database names, CI commands, Go CLI tools, governance methodology, auth/payment providers, and deployment architecture. The `stripSensitiveSections()` function only strips `## Environment` headers, leaving the rest exposed. Prompt-level "don't reveal" rules are not a security boundary.

## Test plan

- [x] Gate green (1513 tests)
- [x] Config test updated to assert new doc path
- [x] API test updated to mock new doc path

Resolves darkcat finding C1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Ask The Pit chatbot knowledge boundary by using a dedicated public knowledge file instead of `README.md`/`AGENTS.md`. Prevents internal details from reaching the LLM and enables safe public use.

- **Bug Fixes**
  - Added `docs/public/ask-the-pit-knowledge.md` with user-facing content only.
  - Updated `ASK_THE_PIT_DOCS` to point to the new file; removed `README.md` and `AGENTS.md`.
  - Updated tests to assert the new document path.

<sup>Written for commit 042293addb340e585e45320f87c49b292a4b4b05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

