### PR TITLE
fix: record M1-M3 pipeline abandonment decision (SD-330), update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This repository consolidates three development phases via subtree merge, preserv
 
 **Phase 3 - Validation** (Mar 2026): Cross-model adversarial review, slop failure modes taxonomy (49 entries), container-based agent isolation, and a 12-chapter systems engineering bootcamp.
 
-**Current direction:** Evaluation-first platform. Structured runs with rubric scoring, failure taxonomy, cost accounting, and dual-layer governance (in-product and on-product). MVP target: run two agent configurations against a task, score them, tag failures, report cost, explain why one won.
+**Current direction:** Multi-agent debate arena with real-time streaming, agent identity (DNA hashing, on-chain attestation), credit economy, and community features. Platform infrastructure: AI gateway for multi-provider BYOK, tournament brackets, live spectator chat. The dual-layer governance thesis (in-product and on-product) continues as the engineering methodology, not a product feature.
 
 The agentic infrastructure (adversarial review pipeline, anti-pattern detection, session governance) lives in `docs/internal/` and supporting tooling. The interesting finding: sycophantic drift - agents performing honesty while being dishonest about their confidence - is harder to catch than hallucination, because it passes every surface-level check.
 

--- a/docs/internal/session-decisions-index.yaml
+++ b/docs/internal/session-decisions-index.yaml
@@ -7,8 +7,8 @@
 # Recent SDs shown here - read full file for deeper history.
 
 generated: "2026-03-16T09:00:00.000Z"
-total_decisions: 328
-range: "SD-001 to SD-329"
+total_decisions: 329
+range: "SD-001 to SD-330"
 note: "Chain carries forward from tspit (pilot study). noopit is thepit-v2 - diverged at SD-278."
 
 # Standing orders that carry forward (always active)
@@ -128,3 +128,7 @@ recent:
     label: "slopodar-to-failure-taxonomy"
     summary: "The slopodar (49-entry anti-pattern taxonomy) is superseded operationally by the failure_category enum in the product schema (wrong_answer, partial_answer, refusal, off_topic, unsafe_output, hallucination, format_violation, context_misuse, instruction_violation). The slopodar is not deleted - it is historical data and the chain is immutable (SD-266). It was the Operator's organic contact with failure classification that the field is now establishing in more collectively agreeable terms. The product's failure taxonomy is the distillation. Supersedes SD-286 (slopodar mandatory boot read). Agents no longer need to load slopodar.yaml on boot."
     status: "STANDING"
+  - id: SD-330
+    label: "run-pipeline-abandoned"
+    summary: "M1-M3 run/evaluation/cost pipeline abandoned. Orders miscommunicated, plans departed from sensible reality. The Pit returns to development of the core product: multi-agent debate arena. Roadmap refocused on platform hardening, Ask The Pit, AI Gateway, tournaments, spectator chat. Closed issues #102, #104, #106, #109, #18. Archived old roadmap to docs/deep-archive/2026-04-01-run-pipeline-abandoned/. New roadmap: docs/roadmap.md."
+    status: "PERMANENT"


### PR DESCRIPTION
## Summary

- Added SD-330 to session-decisions-index.yaml recording the M1-M3 run pipeline abandonment
- Updated README.md "Current direction" from stale evaluation-first language to actual current direction (debate arena, AI gateway, tournaments, spectator chat)

## Why

3-model adversarial review (Codex, Claude, Gemini) flagged a source-of-truth conflict: the README and spec describe an evaluation-first MVP (structured runs, rubric scoring, failure taxonomy, cost accounting), but the new roadmap focuses on platform infrastructure for the debate arena. The M1-M3 pipeline was abandoned without a formal decision record, violating SD-266 (immutable chain).

## Test plan

- [x] Gate green (1513 tests)
- [x] No code changes, docs only
- [x] Existing SD entries unmodified (append-only per SD-266)

Resolves darkcat finding C2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record the M1–M3 run/evaluation/cost pipeline abandonment as SD-330 and update the README “Current direction” to the debate arena focus (AI gateway, tournaments, spectator chat). Aligns docs with the new roadmap and preserves the append-only decision chain per SD-266; no code changes.

<sup>Written for commit 7b45cb9c85cf2a41e6d3881ada8d84d3f856a6ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

