### PR TITLE
fix(route): extend timeout error classification with status codes

### DIFF
--- a/app/api/run-bout/route.ts
+++ b/app/api/run-bout/route.ts
@@ -49,13 +49,22 @@ async function rawPOST(req: Request) {
       // AI SDK abort/timeout errors surface as DOMException or Error with
       // name "AbortError", "TimeoutError", or "ResponseAborted" (Next.js).
       // Plain provider errors may contain "timeout", "timed out", or "DEADLINE".
+      // Provider HTTP errors may carry status 408 (Request Timeout) or 504
+      // (Gateway Timeout) without any timeout keyword in the message.
+      const status =
+        error != null && typeof (error as Record<string, unknown>).status === 'number'
+          ? (error as Record<string, unknown>).status
+          : undefined;
       if (
         name === 'AbortError' ||
         name === 'TimeoutError' ||
         name === 'ResponseAborted' ||
+        /timeout/i.test(name) ||
         message.includes('timeout') ||
         message.includes('timed out') ||
-        message.includes('DEADLINE')
+        message.includes('DEADLINE') ||
+        status === 408 ||
+        status === 504
       ) {
         return 'The bout timed out. Try a shorter length or fewer turns.';
       }

--- a/tests/api/run-bout-errors.test.ts
+++ b/tests/api/run-bout-errors.test.ts
@@ -575,6 +575,91 @@ describe('run-bout streaming error handling', () => {
   });
 
   // -------------------------------------------------------------------------
+  // 4g. onError: HTTP 408 status code (Request Timeout)
+  // -------------------------------------------------------------------------
+  it('returns timeout message for error with status 408', async () => {
+    let capturedOnError: ((error: unknown) => string) | undefined;
+
+    createUIMessageStreamMock.mockImplementation(
+      ({ onError }: { execute: (opts: unknown) => Promise<void>; onError?: (error: unknown) => string }) => {
+        capturedOnError = onError;
+        return 'mock-stream';
+      },
+    );
+    createUIMessageStreamResponseMock.mockReturnValue(
+      new Response('stream', { status: 200 }),
+    );
+
+    await POST(
+      makeRequest({ boutId: 'bout-408', presetId: 'darwin-special' }),
+    );
+
+    expect(capturedOnError).toBeDefined();
+    const err = Object.assign(new Error('Request Timeout'), { status: 408 });
+    const result = capturedOnError!(err);
+    expect(result).toBe(
+      'The bout timed out. Try a shorter length or fewer turns.',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4h. onError: HTTP 504 status code (Gateway Timeout)
+  // -------------------------------------------------------------------------
+  it('returns timeout message for error with status 504', async () => {
+    let capturedOnError: ((error: unknown) => string) | undefined;
+
+    createUIMessageStreamMock.mockImplementation(
+      ({ onError }: { execute: (opts: unknown) => Promise<void>; onError?: (error: unknown) => string }) => {
+        capturedOnError = onError;
+        return 'mock-stream';
+      },
+    );
+    createUIMessageStreamResponseMock.mockReturnValue(
+      new Response('stream', { status: 200 }),
+    );
+
+    await POST(
+      makeRequest({ boutId: 'bout-504', presetId: 'darwin-special' }),
+    );
+
+    expect(capturedOnError).toBeDefined();
+    const err = Object.assign(new Error('Gateway Timeout'), { status: 504 });
+    const result = capturedOnError!(err);
+    expect(result).toBe(
+      'The bout timed out. Try a shorter length or fewer turns.',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4i. onError: StreamTimeoutError (case-insensitive name match)
+  // -------------------------------------------------------------------------
+  it('returns timeout message for StreamTimeoutError name', async () => {
+    let capturedOnError: ((error: unknown) => string) | undefined;
+
+    createUIMessageStreamMock.mockImplementation(
+      ({ onError }: { execute: (opts: unknown) => Promise<void>; onError?: (error: unknown) => string }) => {
+        capturedOnError = onError;
+        return 'mock-stream';
+      },
+    );
+    createUIMessageStreamResponseMock.mockReturnValue(
+      new Response('stream', { status: 200 }),
+    );
+
+    await POST(
+      makeRequest({ boutId: 'bout-stream-timeout', presetId: 'darwin-special' }),
+    );
+
+    expect(capturedOnError).toBeDefined();
+    const err = new Error('Stream exceeded maximum duration');
+    err.name = 'StreamTimeoutError';
+    const result = capturedOnError!(err);
+    expect(result).toBe(
+      'The bout timed out. Try a shorter length or fewer turns.',
+    );
+  });
+
+  // -------------------------------------------------------------------------
   // 5. onError: 429 rate limit → descriptive message
   // -------------------------------------------------------------------------
   it('returns rate limit message for 429 errors', async () => {


### PR DESCRIPTION
## Summary

- Extended onError handler to catch HTTP 408/504 status codes as timeout errors
- Added case-insensitive name matching for timeout variants (e.g. StreamTimeoutError)
- 3 new test cases covering status code and variant name classification

## Why

Darkcat finding C5: two models flagged that string-matching on error.message is brittle. Provider-specific errors may surface as HTTP status codes (408 Request Timeout, 504 Gateway Timeout) or variant error names that the previous exact matches missed.

## Test plan

- [x] Gate green (1516 tests)
- [x] New tests: status 408, status 504, StreamTimeoutError name
- [x] Existing timeout tests unchanged and passing

Resolves darkcat finding C5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend timeout detection in the `onError` handler to include HTTP 408/504 and case-insensitive timeout names, ensuring users get the correct timeout message.

- **Bug Fixes**
  - Treat `error.status` 408 and 504 as timeouts.
  - Case-insensitive match for timeout names (e.g., `StreamTimeoutError`).
  - Added 3 tests for 408, 504, and timeout-name variants.

<sup>Written for commit 48bf66ee88f8020d62cf866639a32b1d64793a44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

