### PR TITLE
fix: improve Ask The Pit client error messaging

### DIFF
--- a/components/ask-the-pit.tsx
+++ b/components/ask-the-pit.tsx
@@ -2,6 +2,23 @@
 
 import { useCallback, useRef, useState } from 'react';
 
+/** Map an HTTP error status to a user-facing message. */
+export function getErrorMessage(
+  status: number,
+  _body?: { error?: string },
+): string {
+  switch (status) {
+    case 429:
+      return 'Too many questions. Try again in a moment.';
+    case 404:
+      return 'Ask The Pit is currently unavailable.';
+    case 503:
+      return 'The Pit could not generate a response. Try again.';
+    default:
+      return 'Something went wrong. Try again.';
+  }
+}
+
 type Message = {
   id: number;
   role: 'user' | 'assistant';
@@ -46,10 +63,16 @@ export function AskThePit({ enabled }: { enabled: boolean }) {
         });
 
         if (!res.ok) {
-          const text = await res.text();
+          let body: { error?: string } | undefined;
+          try {
+            body = await res.json();
+          } catch {
+            // Response was not JSON; fall through with undefined body.
+          }
+          const msg = getErrorMessage(res.status, body);
           setMessages((prev) => [
             ...prev,
-            { id: nextMessageId++, role: 'assistant', content: `Error: ${text}` },
+            { id: nextMessageId++, role: 'assistant', content: msg },
           ]);
           setStreaming(false);
           return;
@@ -92,7 +115,7 @@ export function AskThePit({ enabled }: { enabled: boolean }) {
       } catch {
         setMessages((prev) => [
           ...prev,
-          { id: nextMessageId++, role: 'assistant', content: 'Failed to connect.' },
+          { id: nextMessageId++, role: 'assistant', content: 'Could not reach The Pit. Check your connection.' },
         ]);
       } finally {
         setStreaming(false);

--- a/tests/unit/ask-the-pit-errors.test.ts
+++ b/tests/unit/ask-the-pit-errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { getErrorMessage } from '@/components/ask-the-pit';
+
+describe('getErrorMessage', () => {
+  it('returns rate limit message for 429', () => {
+    expect(getErrorMessage(429)).toBe(
+      'Too many questions. Try again in a moment.',
+    );
+  });
+
+  it('returns unavailable message for 404', () => {
+    expect(getErrorMessage(404)).toBe(
+      'Ask The Pit is currently unavailable.',
+    );
+  });
+
+  it('returns service error message for 503', () => {
+    expect(getErrorMessage(503)).toBe(
+      'The Pit could not generate a response. Try again.',
+    );
+  });
+
+  it('returns generic message for other status codes', () => {
+    expect(getErrorMessage(500)).toBe('Something went wrong. Try again.');
+    expect(getErrorMessage(401)).toBe('Something went wrong. Try again.');
+    expect(getErrorMessage(400)).toBe('Something went wrong. Try again.');
+  });
+
+  it('ignores body content and maps by status only', () => {
+    expect(getErrorMessage(429, { error: 'Rate limit exceeded' })).toBe(
+      'Too many questions. Try again in a moment.',
+    );
+    expect(getErrorMessage(404, { error: 'Ask The Pit is not enabled.' })).toBe(
+      'Ask The Pit is currently unavailable.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extracted `getErrorMessage(status, body?)` pure function for status-to-message mapping
- 429: "Too many questions. Try again in a moment."
- 404: "Ask The Pit is currently unavailable."
- 503: "The Pit could not generate a response. Try again."
- Generic: "Something went wrong. Try again."
- Catch block: "Could not reach The Pit. Check your connection."
- 5 unit tests for all branches

## What changed

Only error branches in `handleSubmit`. Happy path (streaming) untouched.

## Test plan

- [x] 5 new unit tests for error message mapping
- [x] Gate green (1521 tests)

Resolves darkcat finding (Ask The Pit error messaging). Epic 2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Ask The Pit client error messages with clear, status-based text and a better network error. Only error handling changed; streaming path is unchanged.

- Bug Fixes
  - Map HTTP errors to friendly messages via `getErrorMessage`: 429 "Too many questions. Try again in a moment.", 404 "Ask The Pit is currently unavailable.", 503 "The Pit could not generate a response. Try again.", others "Something went wrong. Try again."
  - On network failure, show "Could not reach The Pit. Check your connection."

- Refactors
  - Extracted `getErrorMessage(status, body?)` as a pure, exported function.
  - Added 5 unit tests covering all branches.

<sup>Written for commit 5648e69c715a8e5e239e83c05affc48e34cc2e62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

