### PR TITLE
chore: mark Ask The Pit as shipped on roadmap page

### DIFF
--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -63,7 +63,7 @@ const LANES: Lane[] = [
       { label: 'Vercel AI Gateway (BYOK)', status: 'planned', detail: 'BYOK users choose any LLM via Vercel AI Gateway' },
       { label: 'Multi-model routing', status: 'planned', detail: 'Route different agents to different models' },
       { label: 'Tournament brackets', status: 'planned', detail: 'Elimination-style multi-round events' },
-      { label: 'Ask The Pit', status: 'planned', detail: 'AI-powered FAQ chat using project documentation' },
+      { label: 'Ask The Pit', status: 'done', detail: 'AI-powered FAQ chat using curated platform documentation' },
       { label: 'Spectator chat', status: 'planned', detail: 'Live commentary during streaming bouts' },
     ],
   },


### PR DESCRIPTION
## Summary

- Updated roadmap page: Ask The Pit status from 'planned' to 'done'
- Detail updated to reflect curated documentation (not raw README/AGENTS.md)

## Context

Epic 2 delivery complete:
- PR #137: Document boundary hardening (C1)
- PR #142: Integration tests (doc loading, path traversal, stripping)
- PR #143: E2E Playwright tests
- PR #144: Error messaging improvements

Production enablement requires setting ASK_THE_PIT_ENABLED=true in Vercel env vars.

## Test plan

- [x] Roadmap page renders correctly with updated status

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks “Ask The Pit” as shipped on the roadmap and updates its detail to reflect curated platform documentation.

- **Migration**
  - To enable in production, set `ASK_THE_PIT_ENABLED=true` in Vercel env vars.

<sup>Written for commit c16d7392505af2824d302dca4b3cf0c1bef36400. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

