### PR TITLE
fix: break all env.ts import chains from client components

### DIFF
--- a/components/arena-builder.tsx
+++ b/components/arena-builder.tsx
@@ -7,7 +7,7 @@ import { AgentIcon } from '@/components/agent-icon';
 import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/cn';
 import { useCopy } from '@/lib/copy-client';
-import { FREE_MODEL_ID } from '@/lib/ai';
+import { DEFAULT_FREE_MODEL as FREE_MODEL_ID } from '@/lib/models';
 import { useByokModelPicker } from '@/lib/use-byok-model-picker';
 import { DEFAULT_AGENT_COLOR } from '@/lib/presets';
 import {

--- a/components/preset-card.tsx
+++ b/components/preset-card.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, type FormEvent } from 'react';
 import { useFormStatus } from 'react-dom';
 import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs';
 
-import { FREE_MODEL_ID } from '@/lib/ai';
+import { DEFAULT_FREE_MODEL as FREE_MODEL_ID } from '@/lib/models';
 import { trackEvent } from '@/lib/analytics';
 import { useCopy } from '@/lib/copy-client';
 import {
@@ -12,7 +12,7 @@ import {
   estimateBoutCostGbp,
   formatCredits,
   toMicroCredits,
-} from '@/lib/credits';
+} from '@/lib/credits-client';
 import {
   labelForModel,
   useByokModelPicker,

--- a/lib/credits-client.ts
+++ b/lib/credits-client.ts
@@ -1,0 +1,84 @@
+// Client-safe credit utilities for display purposes.
+//
+// This module provides the same estimation and formatting functions as
+// lib/credits.ts but without importing lib/env.ts. It reads process.env
+// directly for values that Next.js inlines at build time, with sensible
+// defaults matching the env.ts schema defaults.
+//
+// Why: lib/credits.ts imports lib/env.ts which runs Zod validation at
+// module load time and throws in the browser where server env vars are
+// undefined. Client components must use this module instead.
+
+import { MODEL_IDS } from '@/lib/models';
+
+// --- Defaults (must match env.ts schema defaults) ---
+
+const CREDIT_VALUE_GBP = Number(process.env.CREDIT_VALUE_GBP ?? '0.01');
+const MICRO_PER_CREDIT = 100;
+const MICRO_VALUE_GBP = CREDIT_VALUE_GBP / MICRO_PER_CREDIT;
+const TOKEN_CHARS_PER = Number(process.env.CREDIT_TOKEN_CHARS_PER ?? '4');
+const OUTPUT_TOKENS_PER_TURN = Number(
+  process.env.CREDIT_OUTPUT_TOKENS_PER_TURN ?? '120',
+);
+const INPUT_FACTOR = Number(process.env.CREDIT_INPUT_FACTOR ?? '5.5');
+const CREDIT_PLATFORM_MARGIN = Number(
+  process.env.CREDIT_PLATFORM_MARGIN ?? '0.10',
+);
+const BYOK_FEE_GBP_PER_1K_TOKENS = Number(
+  process.env.BYOK_FEE_GBP_PER_1K_TOKENS ?? '0.0002',
+);
+const BYOK_MIN_GBP = Number(process.env.BYOK_MIN_GBP ?? '0.001');
+
+export const CREDITS_ENABLED = process.env.CREDITS_ENABLED === 'true';
+
+// --- Model pricing (hardcoded defaults, no env.ts) ---
+
+const MODEL_PRICES_GBP: Record<string, { in: number; out: number }> = {
+  [MODEL_IDS.HAIKU]: { in: 1, out: 5 },
+  [MODEL_IDS.SONNET_45]: { in: 3, out: 15 },
+  [MODEL_IDS.SONNET_46]: { in: 3, out: 15 },
+};
+
+const getModelPricing = (modelId: string) =>
+  MODEL_PRICES_GBP[modelId] ?? MODEL_PRICES_GBP[MODEL_IDS.HAIKU]!;
+
+// --- Pure functions (same logic as lib/credits.ts) ---
+
+export const toMicroCredits = (gbpAmount: number) =>
+  Math.ceil(gbpAmount / MICRO_VALUE_GBP);
+
+export const formatCredits = (micro: number) =>
+  (micro / MICRO_PER_CREDIT).toFixed(2);
+
+const estimateBoutTokens = (
+  turns: number,
+  outputTokensPerTurn = OUTPUT_TOKENS_PER_TURN,
+) => {
+  const outputTokens = Math.max(1, Math.ceil(turns * outputTokensPerTurn));
+  const inputTokens = Math.max(1, Math.ceil(outputTokens * INPUT_FACTOR));
+  return { inputTokens, outputTokens };
+};
+
+export const estimateBoutCostGbp = (
+  turns: number,
+  modelId: string,
+  outputTokensPerTurn = OUTPUT_TOKENS_PER_TURN,
+) => {
+  if (modelId === 'byok') {
+    const { inputTokens, outputTokens } = estimateBoutTokens(
+      turns,
+      outputTokensPerTurn,
+    );
+    const totalTokens = inputTokens + outputTokens;
+    const cost = (totalTokens / 1000) * BYOK_FEE_GBP_PER_1K_TOKENS;
+    return Math.max(cost, BYOK_MIN_GBP);
+  }
+  const pricing = getModelPricing(modelId);
+  const { inputTokens, outputTokens } = estimateBoutTokens(
+    turns,
+    outputTokensPerTurn,
+  );
+  const raw =
+    (inputTokens * pricing.in + outputTokens * pricing.out) / 1_000_000;
+  return raw * (1 + CREDIT_PLATFORM_MARGIN);
+};


### PR DESCRIPTION
## Summary

- `components/arena-builder.tsx`: replaced `FREE_MODEL_ID` import from `lib/ai` with `DEFAULT_FREE_MODEL` from `lib/models`
- `components/preset-card.tsx`: same `FREE_MODEL_ID` fix, plus replaced credit functions from `lib/credits` with new `lib/credits-client.ts`
- Created `lib/credits-client.ts`: client-safe credit estimation/formatting (same math, no env.ts dependency)

## Why

`lib/ai.ts` and `lib/credits.ts` both import `lib/env.ts`, which runs Zod validation at module load and throws in production when server-only vars (DATABASE_URL, ANTHROPIC_API_KEY, CLERK_SECRET_KEY) are undefined in the browser. Two 'use client' components imported these modules, pulling the validation into client chunks.

## Test plan

- [x] Gate green (typecheck, lint, all tests pass)
- [x] Full sweep confirms no remaining client-side imports of env-tainted modules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `lib/env.ts` from client bundles to stop browser crashes from Zod env validation. Swapped risky imports in `arena-builder` and `preset-card`, and added `lib/credits-client.ts` for client-safe credit math.

- **Bug Fixes**
  - Replaced `FREE_MODEL_ID` from `lib/ai` with `DEFAULT_FREE_MODEL` from `lib/models` in `components/arena-builder.tsx` and `components/preset-card.tsx`.
  - Moved credit helpers in `components/preset-card.tsx` to new `lib/credits-client.ts` (same math, no `lib/env.ts`; reads `process.env` at build time with sane defaults and model pricing).

<sup>Written for commit 64c68c1ba8d992cacb0c7a9751e1b81aff5ea688. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure to consolidate credit calculation utilities and model configuration imports into dedicated modules, improving code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->