### PR TITLE
fix: make Ask The Pit fail closed on knowledge doc failure

### DIFF
--- a/app/api/ask-the-pit/route.ts
+++ b/app/api/ask-the-pit/route.ts
@@ -45,20 +45,22 @@ let cachedSystemPrompt: string | null = null;
 function loadDocs(): string {
   if (cachedDocs !== null) return cachedDocs;
   const root = process.cwd();
-  cachedDocs = ASK_THE_PIT_DOCS.map((docPath) => {
+  const parts = ASK_THE_PIT_DOCS.map((docPath) => {
+    const fullPath = resolve(join(root, docPath));
+    // Prevent path traversal -- resolved path must stay within the project root.
+    const rel = relative(root, fullPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new Error(`Blocked path traversal: ${docPath}`);
+    }
     try {
-      const fullPath = resolve(join(root, docPath));
-      // Prevent path traversal — resolved path must stay within the project root.
-      const rel = relative(root, fullPath);
-      if (rel.startsWith('..') || isAbsolute(rel)) {
-        return `[Blocked: ${docPath}]`;
-      }
       const content = readFileSync(fullPath, 'utf-8');
       return stripSensitiveSections(content);
-    } catch {
-      return `[Could not load ${docPath}]`;
+    } catch (err) {
+      throw new Error(`Could not load knowledge doc: ${docPath}`, { cause: err });
     }
-  }).join('\n\n---\n\n');
+  });
+  const result = parts.join('\n\n---\n\n');
+  cachedDocs = result;
   return cachedDocs;
 }
 
@@ -81,11 +83,18 @@ async function rawPOST(req: Request) {
   const { message } = parsed.data;
 
   const requestId = getRequestId(req);
+  let docs: string;
+  try {
+    docs = loadDocs();
+  } catch (err) {
+    log.error('Ask The Pit knowledge docs failed to load', toError(err), { requestId });
+    return errorResponse(API_ERRORS.SERVICE_UNAVAILABLE, 503);
+  }
   if (!cachedSystemPrompt) {
     cachedSystemPrompt = buildAskThePitSystem({
       roleDescription: ASK_THE_PIT_ROLE,
       rules: ASK_THE_PIT_RULES,
-      documentation: loadDocs(),
+      documentation: docs,
     });
   }
   const systemPrompt = cachedSystemPrompt;

--- a/tests/integration/ask-the-pit-docs.test.ts
+++ b/tests/integration/ask-the-pit-docs.test.ts
@@ -122,7 +122,7 @@ describe('ask-the-pit document loading integration', () => {
     expect(systemContent).toContain('multi-agent AI debate arena');
   });
 
-  it('IT2: path traversal blocked', async () => {
+  it('IT2: path traversal returns 503', async () => {
     vi.resetModules();
 
     pitConfig.ASK_THE_PIT_DOCS = ['../../etc/passwd'];
@@ -131,11 +131,10 @@ describe('ask-the-pit document loading integration', () => {
     const { POST } = await import('@/app/api/ask-the-pit/route');
     const res = await POST(makeJsonReq({ message: 'hello' }));
 
-    expect(res.status).toBe(200);
-
-    const systemContent = getSystemContent();
-    expect(systemContent).toContain('[Blocked:');
-    expect(systemContent).not.toContain('should not appear');
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('Service unavailable.');
+    expect(streamTextMock).not.toHaveBeenCalled();
   });
 
   it('IT3: sensitive section stripping', async () => {
@@ -157,7 +156,7 @@ describe('ask-the-pit document loading integration', () => {
     expect(systemContent).toContain('Real-time streaming debates');
   });
 
-  it('IT4: missing doc handled gracefully', async () => {
+  it('IT4: missing doc returns 503', async () => {
     vi.resetModules();
 
     readFileSyncMock.mockImplementation(() => {
@@ -167,9 +166,9 @@ describe('ask-the-pit document loading integration', () => {
     const { POST } = await import('@/app/api/ask-the-pit/route');
     const res = await POST(makeJsonReq({ message: 'hello' }));
 
-    expect(res.status).toBe(200);
-
-    const systemContent = getSystemContent();
-    expect(systemContent).toContain('[Could not load');
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('Service unavailable.');
+    expect(streamTextMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `loadDocs()` now throws when any configured knowledge doc is missing or fails path traversal, instead of substituting placeholder strings
- `rawPOST()` catches the failure, logs it with request context, and returns 503
- The LLM is never called with degraded/placeholder content
- Integration tests IT2 and IT4 updated to assert 503 and verify the model is never invoked on doc load failure

Addresses the primary finding from the Codex adversarial review of Epic 2: silent degradation from grounded assistant to ungrounded chatbot when the knowledge base is unavailable.

## Test plan

- [x] Gate green (`pnpm run test:ci`)
- [ ] Manual: remove/rename `docs/public/ask-the-pit-knowledge.md` and confirm 503 response
- [ ] Manual: verify happy path still streams correctly with docs in place

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ask The Pit now fails closed if knowledge docs are missing or invalid. We return 503 and never invoke the model instead of sending placeholder content.

- **Bug Fixes**
  - `loadDocs()` throws on missing docs or blocked path traversal; no placeholders.
  - `rawPOST()` logs with request context and returns 503; system prompt builds only after successful doc load.
  - IT2/IT4 updated to expect 503 and verify the model is not called.

<sup>Written for commit 0e66ea8b03abd1add397b77bca1fde9f92ccdba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error handling for the Ask the Pit endpoint—now returns a proper service unavailable response when documentation cannot be loaded, rather than attempting to proceed with incomplete or placeholder data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->