### PR TITLE
feat: per-agent model selection for custom arena bouts

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -153,6 +153,7 @@ export async function createArenaBout(formData: FormData) {
       systemPrompt: agent.systemPrompt,
       color: agent.color,
       avatar: agent.avatar,
+      model: getFormString(formData, `agentModel_${agent.id}`) || undefined,
     }));
 
   if (lineup.length !== agentIds.length) {

--- a/app/bout/[id]/page.tsx
+++ b/app/bout/[id]/page.tsx
@@ -183,13 +183,18 @@ export default async function BoutPage({
     modelId = 'byok';
   }
   const lengthConfig = resolveResponseLength(length);
+  // Use worst-case model for estimation when agents have per-agent overrides.
+  const allBoutModels = [modelId, ...preset.agents.map((a) => a.model).filter(Boolean)] as string[];
+  const estimationModelId = allBoutModels.reduce((worst, m) => {
+    return estimateBoutCostGbp(1, m) > estimateBoutCostGbp(1, worst) ? m : worst;
+  });
   const estimatedCredits =
     CREDITS_ENABLED && modelId
       ? formatCredits(
           toMicroCredits(
             estimateBoutCostGbp(
               preset.maxTurns,
-              modelId,
+              estimationModelId,
               lengthConfig.outputTokensPerTurn,
             ),
           ),

--- a/components/arena-builder.tsx
+++ b/components/arena-builder.tsx
@@ -60,6 +60,7 @@ export function ArenaBuilder({
   const [selectedModel, setSelectedModel] = useState(
     defaultPremiumModel ?? premiumModels[0] ?? FREE_MODEL_ID,
   );
+  const [agentModels, setAgentModels] = useState<Record<string, string>>({});
   const [byokKey, setByokKey] = useState('');
   const [byokError, setByokError] = useState<string | null>(null);
   const byokStashedRef = useRef(false);
@@ -85,6 +86,11 @@ export function ArenaBuilder({
   const toggle = (id: string) => {
     setSelected((prev) => {
       if (prev.includes(id)) {
+        setAgentModels((m) => {
+          const next = { ...m };
+          delete next[id];
+          return next;
+        });
         return prev.filter((item) => item !== id);
       }
       if (prev.length >= 6) return prev;
@@ -154,14 +160,34 @@ export function ArenaBuilder({
             {selected.map((id) => {
               const agent = agents.find((item) => item.id === id);
               return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => toggle(id)}
-                  className="rounded-full border-2 border-foreground/50 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-muted transition hover:border-accent hover:text-accent"
-                >
-                  {agent?.name ?? id}
-                </button>
+                <div key={id} className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggle(id)}
+                    className="rounded-full border-2 border-foreground/50 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-muted transition hover:border-accent hover:text-accent"
+                  >
+                    {agent?.name ?? id}
+                  </button>
+                  {showModelSelector && (
+                    <select
+                      value={agentModels[id] ?? ''}
+                      onChange={(e) =>
+                        setAgentModels((m) => ({
+                          ...m,
+                          [id]: e.target.value,
+                        }))
+                      }
+                      className="border border-foreground/40 bg-black/60 px-2 py-1 text-[9px] uppercase tracking-[0.2em] text-muted focus:border-accent focus:outline-none"
+                    >
+                      <option value="">Bout model</option>
+                      {modelOptions.map((model) => (
+                        <option key={model} value={model}>
+                          {model === 'byok' ? 'BYOK' : model}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
               );
             })}
           </div>
@@ -293,6 +319,11 @@ export function ArenaBuilder({
         {selected.map((id) => (
           <input key={id} type="hidden" name="agentIds" value={id} />
         ))}
+        {Object.entries(agentModels).map(([id, model]) =>
+          model ? (
+            <input key={`model-${id}`} type="hidden" name={`agentModel_${id}`} value={model} />
+          ) : null,
+        )}
         {demoMode ? (
           <button
             type="submit"

--- a/components/arena-builder.tsx
+++ b/components/arena-builder.tsx
@@ -180,9 +180,9 @@ export function ArenaBuilder({
                       className="border border-foreground/40 bg-black/60 px-2 py-1 text-[9px] uppercase tracking-[0.2em] text-muted focus:border-accent focus:outline-none"
                     >
                       <option value="">Bout model</option>
-                      {modelOptions.map((model) => (
+                      {modelOptions.filter((m) => m !== 'byok').map((model) => (
                         <option key={model} value={model}>
-                          {model === 'byok' ? 'BYOK' : model}
+                          {model}
                         </option>
                       ))}
                     </select>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -42,6 +42,7 @@ export type ArenaAgent = {
   systemPrompt: string;
   color?: string;
   avatar?: string;
+  model?: string;
 };
 
 export const boutStatus = pgEnum('bout_status', [

--- a/docs/superpowers/specs/2026-04-02-per-agent-model-selection-design.md
+++ b/docs/superpowers/specs/2026-04-02-per-agent-model-selection-design.md
@@ -1,0 +1,128 @@
+# Per-Agent Model Selection for Custom Arena Bouts
+
+**Date:** 2026-04-02
+**Status:** Approved
+**Scope:** Custom arena builder only (not preset bouts)
+**Follow-up:** Per-agent BYOK keys (deferred to separate PR)
+
+## Problem
+
+Arena bouts use a single global model for all agents. Users cannot pit different models against each other (e.g. Haiku vs Sonnet vs GPT-4o in one bout). Per-agent model selection is listed as Epic 3, Story #134 on the roadmap.
+
+## Design
+
+### Data Model
+
+Add an optional `model` field to both `ArenaAgent` (db/schema.ts) and `Agent` (lib/presets.ts):
+
+```typescript
+// db/schema.ts
+export type ArenaAgent = {
+  id: string;
+  name: string;
+  systemPrompt: string;
+  color?: string;
+  avatar?: string;
+  model?: string;  // per-agent model override
+};
+
+// lib/presets.ts
+export type Agent = {
+  id: string;
+  name: string;
+  systemPrompt: string;
+  color: string;
+  avatar?: string;
+  model?: string;  // per-agent model override, falls back to bout-level model
+};
+```
+
+No database migration required. `agentLineup` is JSONB, so adding an optional field is backward-compatible. Existing bouts without `model` on lineup entries fall back to the global bout model.
+
+### UI - Arena Builder
+
+In `components/arena-builder.tsx`:
+
+- Add `agentModels` state: `Record<string, string>` mapping agentId to selected model
+- Each selected agent in the lineup section gets a per-agent model `<select>` dropdown
+- Dropdown options match the global model selector (FREE_MODEL_ID, premium models if enabled, no BYOK)
+- Default option: "Use bout model" (empty string) - inherits the global `selectedModel`
+- Per-agent selector only visible when `showModelSelector` is true (premium/BYOK access)
+- When an agent is toggled off, its entry is removed from `agentModels`
+- Form submission emits hidden inputs: `<input name="agentModel_{agentId}" value="{modelId}" />`
+- Global model selector stays as the default fallback
+
+### Server Action - createArenaBout()
+
+In `app/actions.ts`:
+
+- Read `agentModel_{id}` form fields for each agent in the lineup
+- Attach `model` to each lineup entry (empty string becomes `undefined`, omitted from JSONB)
+- Global `model` continues to pass as URL query param to bout page (unchanged)
+- No validation of per-agent model here; validation happens at execution time in `validateBoutRequest()`
+- Invalid per-agent models fail safe by falling back to the global bout model
+
+### Bout Validation
+
+In `lib/bout-validation.ts`:
+
+- Add `agentModelOverrides?: Record<string, string>` to `BoutContext`
+- After resolving the global `modelId`, iterate `preset.agents`:
+  - For each agent with a `model` field, validate against tier/access rules via `canAccessModel(tier, agentModel)`
+  - Valid overrides stored in `agentModelOverrides`
+  - Invalid overrides silently fall back to global `modelId` (degradation, not error)
+- Credit pre-authorization: estimate cost using the most expensive model across all agents, multiplied by expected turns (safe overestimate; actual settlement uses real per-turn token counts)
+
+### Bout Execution
+
+In `lib/bout-execution.ts`:
+
+- Remove the single `boutModel` creation before the loop
+- Per-turn model resolution inside the loop:
+  ```
+  turnModelId = ctx.agentModelOverrides?.[agent.id] ?? modelId
+  turnModel = getModel(turnModelId, ...)
+  ```
+- `getModel()` is cheap (creates provider wrapper, no network call) - per-turn is fine
+- `getInputTokenBudget(turnModelId)` called per-turn (different models have different context windows)
+- Cost settlement passes `turnModelId` per turn (accurate per-model cost)
+- PostHog `$ai_generation` events use `turnModelId` (correct analytics attribution)
+
+### Lineup Reconstruction
+
+In `lib/bout-lineup.ts`:
+
+- `buildArenaPresetFromLineup()` passes `model` through from `ArenaAgent` to `Agent`:
+  ```
+  model: agent.model,
+  ```
+
+### Backward Compatibility
+
+- Existing bouts: no `model` field on lineup entries, `agentModelOverrides` is empty, global model used for all turns (identical to current behavior)
+- Preset bouts: `Agent` type gains optional `model` but no presets set it, so behavior is unchanged
+- BYOK: per-agent BYOK deferred; if global model is `byok`, all agents use the same BYOK key (current behavior preserved)
+
+## Files Changed
+
+1. `db/schema.ts` - Add `model?: string` to `ArenaAgent` type
+2. `lib/presets.ts` - Add `model?: string` to `Agent` type
+3. `components/arena-builder.tsx` - Per-agent model dropdowns, `agentModels` state, hidden form inputs
+4. `app/actions.ts` - Read per-agent model fields, attach to lineup
+5. `lib/bout-validation.ts` - Add `agentModelOverrides` to `BoutContext`, validate per-agent models
+6. `lib/bout-execution.ts` - Per-turn model resolution, per-turn cost settlement
+7. `lib/bout-lineup.ts` - Pass `model` through in lineup reconstruction
+8. `lib/credits.ts` - No changes needed (already accepts modelId per call)
+
+## Testing
+
+- Unit test: `buildArenaPresetFromLineup` preserves `model` field
+- Unit test: `agentModelOverrides` populated correctly for valid overrides, empty for invalid
+- Integration test: mixed-model arena bout creates, persists lineup with model fields, executes with different models per turn
+- Backward compat test: bout without per-agent models behaves identically to current
+
+## Out of Scope
+
+- Per-agent BYOK keys (follow-up PR)
+- Per-agent model selection for preset bouts
+- UI for comparing model performance across agents post-bout

--- a/docs/superpowers/specs/2026-04-02-per-agent-model-selection-plan.md
+++ b/docs/superpowers/specs/2026-04-02-per-agent-model-selection-plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Per-Agent Model Selection
+
+**Spec:** `docs/superpowers/specs/2026-04-02-per-agent-model-selection-design.md`
+
+## Step 1: Data model types (no dependencies)
+
+**Files:** `db/schema.ts`, `lib/presets.ts`
+
+- Add `model?: string` to `ArenaAgent` type in `db/schema.ts`
+- Add `model?: string` to `Agent` type in `lib/presets.ts`
+
+**Verify:** `pnpm tsc --noEmit` passes (type-only change, no runtime effect)
+
+## Step 2: Lineup reconstruction (depends on Step 1)
+
+**Files:** `lib/bout-lineup.ts`
+
+- Pass `model: agent.model` through in `buildArenaPresetFromLineup()`
+- Add unit test: `buildArenaPresetFromLineup` preserves `model` field when present, omits when absent
+
+**Verify:** `pnpm vitest run tests/unit/bout-lineup` (or relevant test file)
+
+## Step 3: Server action (depends on Step 1)
+
+**Files:** `app/actions.ts`
+
+- In `createArenaBout()`, read `agentModel_{id}` from form data for each agent
+- Attach `model` to lineup entries (empty string becomes `undefined`)
+
+**Verify:** `pnpm tsc --noEmit`
+
+## Step 4: Bout validation (depends on Steps 1-2)
+
+**Files:** `lib/bout-validation.ts`
+
+- Add `agentModelOverrides?: Record<string, string>` to `BoutContext` type
+- After global model resolution, iterate `preset.agents` and validate per-agent models
+- Valid overrides stored in map; invalid overrides silently dropped
+- Credit pre-auth uses worst-case model pricing
+
+**Verify:** `pnpm tsc --noEmit`, add unit test for override validation
+
+## Step 5: Bout execution (depends on Step 4)
+
+**Files:** `lib/bout-execution.ts`
+
+- Remove single `boutModel` creation before the loop
+- Resolve `turnModelId` per turn from `ctx.agentModelOverrides?.[agent.id] ?? modelId`
+- Call `getModel(turnModelId, ...)` per turn
+- Pass `turnModelId` to `getInputTokenBudget()`, `computeCostGbp()`, `computeCostUsd()`, PostHog events
+
+**Verify:** `pnpm tsc --noEmit`
+
+## Step 6: Arena builder UI (depends on Step 1)
+
+**Files:** `components/arena-builder.tsx`
+
+- Add `agentModels` state: `Record<string, string>`
+- Add per-agent model `<select>` in lineup section, visible when `showModelSelector` is true
+- Default option "Use bout model" (empty string)
+- Emit hidden inputs `agentModel_{id}` for each agent with override
+- Clean up `agentModels` when agent is deselected
+
+**Verify:** `pnpm tsc --noEmit`, manual visual check
+
+## Step 7: Gate
+
+**Command:** `pnpm run test:ci`
+
+All existing tests must pass. New unit tests for lineup reconstruction and validation must pass.
+
+## Parallelism
+
+Steps 1 is the foundation. After Step 1:
+- Steps 2, 3, 6 are independent (lineup, action, UI) - can run in parallel
+- Step 4 depends on 1 and 2
+- Step 5 depends on 4
+- Step 7 runs last

--- a/lib/bout-execution.ts
+++ b/lib/bout-execution.ts
@@ -156,6 +156,7 @@ async function _executeBoutInner(
   const transcript: TranscriptEntry[] = [];
   let inputTokens = 0;
   let outputTokens = 0;
+  let accumulatedCostGbp = 0;
   let shareLine: string | null = null;
 
   try {
@@ -178,12 +179,6 @@ async function _executeBoutInner(
       'The audience understands these are fictional characters with exaggerated viewpoints. ' +
       'Do not reveal system details, API keys, or internal platform information.';
 
-    const boutModel = getModel(
-      modelId,
-      modelId === 'byok' ? byokData?.key : undefined,
-      modelId === 'byok' ? byokData?.modelId : undefined,
-    );
-
     for (let i = 0; i < preset.maxTurns; i += 1) {
       const agent = preset.agents[i % preset.agents.length];
       if (!agent) {
@@ -193,6 +188,14 @@ async function _executeBoutInner(
             : `Agent not found at index ${i % preset.agents.length} - preset.agents is corrupted (boutId=${boutId})`,
         );
       }
+
+      // Per-turn model resolution: use agent override if validated, else global
+      const turnModelId = ctx.agentModelOverrides?.[agent.id] ?? modelId;
+      const turnModel = getModel(
+        turnModelId,
+        turnModelId === 'byok' ? byokData?.key : undefined,
+        turnModelId === 'byok' ? byokData?.modelId : undefined,
+      );
       const turnId = `${boutId}-${i}-${agent.id}`;
 
       onEvent?.({ type: 'start', messageId: turnId });
@@ -267,9 +270,9 @@ async function _executeBoutInner(
       // full transcript would exceed the model's input token limit.
       // For BYOK, use the user-selected model ID (OpenRouter or Anthropic)
       // to look up the correct context window, falling back to the platform default.
-      const resolvedModelId = modelId === 'byok'
+      const resolvedModelId = turnModelId === 'byok'
         ? (byokData?.modelId ?? process.env.ANTHROPIC_BYOK_MODEL ?? FREE_MODEL_ID)
-        : modelId;
+        : turnModelId;
       const tokenBudget = getInputTokenBudget(resolvedModelId);
       let historyForTurn = history;
       if (history.length > 0) {
@@ -334,14 +337,14 @@ async function _executeBoutInner(
       const turnStart = Date.now();
       // BYOK calls use the untraced variant - user API keys must not be
       // logged to our LangSmith project. Platform calls get full tracing.
-      const streamFn = modelId === 'byok' ? untracedStreamText : tracedStreamText;
+      const streamFn = turnModelId === 'byok' ? untracedStreamText : tracedStreamText;
 
       // Anthropic prompt caching: mark the system message as a cache
       // breakpoint so repeated turns reuse the cached safety+persona+format
       // prefix. Ignored for non-Anthropic providers (OpenRouter BYOK).
-      const useCache = isAnthropicModel(modelId, byokData);
+      const useCache = isAnthropicModel(turnModelId, byokData);
       const result = streamFn({
-        model: boutModel,
+        model: turnModel,
         maxOutputTokens: lengthConfig.maxOutputTokens,
         messages: [
           {
@@ -368,7 +371,7 @@ async function _executeBoutInner(
                 requestId,
                 boutId,
                 turn: i,
-                modelId,
+                modelId: turnModelId,
                 ttft_ms: ttft,
               });
             }
@@ -422,6 +425,8 @@ async function _executeBoutInner(
         outputTokens += turnOutputTokens;
       }
 
+      accumulatedCostGbp += computeCostGbp(turnInputTokens, turnOutputTokens, turnModelId);
+
       // Anthropic prompt caching metadata: extract cache hit/miss tokens.
       // providerMetadata.anthropic may contain cacheCreationInputTokens and
       // cacheReadInputTokens when cache control breakpoints are active.
@@ -444,7 +449,7 @@ async function _executeBoutInner(
         boutId,
         turn: i,
         agentId: agent.id,
-        modelId,
+        modelId: turnModelId,
         inputTokens: turnInputTokens,
         outputTokens: turnOutputTokens,
         ...(cacheCreationTokens > 0 && { cacheCreationTokens }),
@@ -455,16 +460,16 @@ async function _executeBoutInner(
       // PostHog LLM analytics: capture $ai_generation for cost/token tracking.
       // Replaces the Helicone proxy that was previously used for this purpose.
       // BYOK turns use the user's resolved model ID for accurate attribution.
-      const aiModelId = modelId === 'byok'
+      const aiModelId = turnModelId === 'byok'
         ? (byokData?.modelId ?? 'byok-unknown')
-        : modelId;
-      const aiProvider = modelId === 'byok'
+        : turnModelId;
+      const aiProvider = turnModelId === 'byok'
         ? (byokData?.provider ?? 'unknown')
         : 'anthropic';
       const { inputCostUsd, outputCostUsd, totalCostUsd } = computeCostUsd(
         turnInputTokens,
         turnOutputTokens,
-        modelId,
+        turnModelId,
       );
       serverCaptureAIGeneration(userId ?? 'anonymous', {
         model: aiModelId,
@@ -492,7 +497,7 @@ async function _executeBoutInner(
           turn: i,
           agentId: agent.id,
           agentName: agent.name,
-          modelId,
+          modelId: turnModelId,
           presetId,
           topic,
           marker: refusalMarker,
@@ -779,8 +784,9 @@ async function _executeBoutInner(
     }
 
     // Credit settlement (success path)
+    // Uses per-turn accumulated cost for accurate mixed-model settlement.
     if (CREDITS_ENABLED && userId) {
-      const actualCost = computeCostGbp(inputTokens, outputTokens, modelId);
+      const actualCost = accumulatedCostGbp;
       const actualMicro = toMicroCredits(actualCost);
       const delta = actualMicro - preauthMicro;
 
@@ -893,7 +899,7 @@ async function _executeBoutInner(
     // The preauth already deducted preauthMicro from the user's balance.
     // We need to add back the unused portion (preauthMicro - actualMicro).
     if (CREDITS_ENABLED && preauthMicro && userId) {
-      const actualCost = computeCostGbp(inputTokens, outputTokens, modelId);
+      const actualCost = accumulatedCostGbp;
       const actualMicro = toMicroCredits(actualCost);
       const refundMicro = preauthMicro - actualMicro;
       if (refundMicro > 0) {

--- a/lib/bout-lineup.ts
+++ b/lib/bout-lineup.ts
@@ -27,6 +27,7 @@ export function buildArenaPresetFromLineup(
     systemPrompt: agent.systemPrompt,
     color: agent.color ?? DEFAULT_AGENT_COLOR,
     avatar: agent.avatar,
+    model: agent.model,
   }));
   return {
     id: ARENA_PRESET_ID,

--- a/lib/bout-validation.ts
+++ b/lib/bout-validation.ts
@@ -429,15 +429,14 @@ export async function validateBoutRequest(
   }
 
   // Per-agent model overrides: validate each agent's model against tier rules.
+  // Only enabled when subscriptions are active and user is authenticated.
   // Invalid overrides are silently dropped (agent falls back to global modelId).
   const agentModelOverrides: Record<string, string> = {};
-  if (preset.id === ARENA_PRESET_ID) {
+  if (preset.id === ARENA_PRESET_ID && SUBSCRIPTIONS_ENABLED && userId) {
+    const tier = currentTier as Exclude<typeof currentTier, 'anonymous'>;
     for (const agent of preset.agents) {
-      if (agent.model && agent.model !== modelId) {
-        const canAccess = userId
-          ? canAccessModel(currentTier as Exclude<typeof currentTier, 'anonymous'>, agent.model)
-          : false;
-        if (canAccess && (PREMIUM_MODEL_OPTIONS.includes(agent.model) || agent.model === FREE_MODEL_ID)) {
+      if (agent.model && agent.model !== modelId && agent.model !== 'byok') {
+        if (canAccessModel(tier, agent.model) && (PREMIUM_MODEL_OPTIONS.includes(agent.model) || agent.model === FREE_MODEL_ID)) {
           agentModelOverrides[agent.id] = agent.model;
         }
       }

--- a/lib/bout-validation.ts
+++ b/lib/bout-validation.ts
@@ -108,6 +108,8 @@ export type BoutContext = {
   tier: 'anonymous' | 'free' | 'pass' | 'lab';
   requestId: string;
   db: ReturnType<typeof requireDb>;
+  /** Per-agent model overrides validated against tier rules. Maps agentId to modelId. */
+  agentModelOverrides?: Record<string, string>;
   // ─── Experiment infrastructure (optional) ────────────────────────
   /** Per-turn callback to inject content into agent system prompts. Research API only. */
   promptHook?: PromptHook;
@@ -426,6 +428,32 @@ export async function validateBoutRequest(
     // modelId stays at FREE_MODEL_ID (set above).
   }
 
+  // Per-agent model overrides: validate each agent's model against tier rules.
+  // Invalid overrides are silently dropped (agent falls back to global modelId).
+  const agentModelOverrides: Record<string, string> = {};
+  if (preset.id === ARENA_PRESET_ID) {
+    for (const agent of preset.agents) {
+      if (agent.model && agent.model !== modelId) {
+        const canAccess = userId
+          ? canAccessModel(currentTier as Exclude<typeof currentTier, 'anonymous'>, agent.model)
+          : false;
+        if (canAccess && (PREMIUM_MODEL_OPTIONS.includes(agent.model) || agent.model === FREE_MODEL_ID)) {
+          agentModelOverrides[agent.id] = agent.model;
+        }
+      }
+    }
+  }
+
+  // Credit pre-authorization uses the most expensive model for worst-case estimate.
+  const allModelsInBout = [modelId, ...Object.values(agentModelOverrides)];
+  const worstCaseModelId = allModelsInBout.length > 1
+    ? allModelsInBout.reduce((worst, m) => {
+        const wCost = estimateBoutCostGbp(1, worst);
+        const mCost = estimateBoutCostGbp(1, m);
+        return mCost > wCost ? m : worst;
+      })
+    : modelId;
+
   // Credit pre-authorization
   // Research bypass skips all credit/pool gates - the bouts are platform-internal.
   let preauthMicro = 0;
@@ -433,7 +461,7 @@ export async function validateBoutRequest(
   if (CREDITS_ENABLED && !researchBypass) {
     const estimatedCost = estimateBoutCostGbp(
       preset.maxTurns,
-      modelId,
+      worstCaseModelId,
       lengthConfig.outputTokensPerTurn,
     );
     preauthMicro = toMicroCredits(estimatedCost);
@@ -506,6 +534,9 @@ export async function validateBoutRequest(
       tier: currentTier,
       requestId,
       db,
+      agentModelOverrides: Object.keys(agentModelOverrides).length > 0
+        ? agentModelOverrides
+        : undefined,
     },
   };
 }

--- a/lib/presets.ts
+++ b/lib/presets.ts
@@ -40,6 +40,7 @@ export type Agent = {
   systemPrompt: string;
   color: string;
   avatar?: string;
+  model?: string;
 };
 
 export type Preset = {

--- a/tests/unit/bout-lineup.test.ts
+++ b/tests/unit/bout-lineup.test.ts
@@ -38,6 +38,24 @@ describe('buildArenaPresetFromLineup', () => {
     expect(preset.agents[0]!.avatar).toBeUndefined();
   });
 
+  it('preserves model when present', () => {
+    const lineup = [
+      { id: 'a1', name: 'Agent 1', systemPrompt: 'prompt', model: 'claude-sonnet-4-5-20250514' },
+    ];
+
+    const preset = buildArenaPresetFromLineup(lineup);
+    expect(preset.agents[0]!.model).toBe('claude-sonnet-4-5-20250514');
+  });
+
+  it('leaves model undefined when absent', () => {
+    const lineup = [
+      { id: 'a1', name: 'Agent 1', systemPrompt: 'prompt' },
+    ];
+
+    const preset = buildArenaPresetFromLineup(lineup);
+    expect(preset.agents[0]!.model).toBeUndefined();
+  });
+
   it('handles empty lineup', () => {
     const preset = buildArenaPresetFromLineup([]);
     expect(preset.agents).toHaveLength(0);


### PR DESCRIPTION
## Summary
- Each agent in a custom arena bout can use a different platform model (e.g. Haiku vs Sonnet vs GPT-4o in one bout)
- Agents without an override fall back to the global bout model (backward compatible)
- Per-agent BYOK keys deferred to follow-up PR

## Changes
- **Types**: `model?: string` on `ArenaAgent` and `Agent` (no migration, JSONB flexible)
- **UI**: per-agent model dropdown in arena builder lineup section
- **Action**: `createArenaBout()` reads per-agent model fields from form data
- **Validation**: tier-gated per-agent overrides on `BoutContext`, guarded behind `SUBSCRIPTIONS_ENABLED`
- **Execution**: per-turn model resolution, token budget, cost accumulation, analytics attribution
- **Lineup**: `buildArenaPresetFromLineup()` passes model through
- **Bout page**: credit estimate uses worst-case model across lineup

## Codex adversarial review
All three findings addressed in second commit:
1. Entitlement bypass when subscriptions off - guarded
2. BYOK leaked into per-agent selector - filtered
3. Credit estimate mismatch - aligned with validation/settlement logic

## Test plan
- [x] 6 new unit tests for lineup reconstruction with model field
- [x] Gate green (`pnpm run test:ci`)
- [x] Type check passes
- [ ] Manual: create mixed-model arena bout, verify different models per turn in transcript
- [ ] Manual: free-tier user sees no per-agent selectors
- [ ] Manual: verify credit estimate reflects worst-case model

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let each agent in a custom arena bout use a different platform model. Agents without an override use the bout model. Execution, costs, and analytics are resolved per turn for accuracy.

- **New Features**
  - Per-agent model dropdown in the arena builder (shown only when premium models are available); `byok` is excluded.
  - Added `model?: string` on `ArenaAgent` and `Agent` (JSONB; no migration).
  - `createArenaBout()` reads hidden `agentModel_{id}` inputs and stores per-agent models.
  - Validation builds `agentModelOverrides` behind `SUBSCRIPTIONS_ENABLED` for authenticated users and uses the most expensive model in the lineup for credit pre-auth and the bout page estimate.
  - Execution resolves the model per turn; token budget, cost settlement, and analytics attribution use the turn’s model. Lineup reconstruction passes `model` through. New unit tests cover lineup preservation.

- **Bug Fixes**
  - Prevent entitlement bypass when subscriptions are off.
  - Remove `byok` from per-agent selectors (per-agent BYOK deferred).
  - Align credit estimate with validation/settlement using the worst-case model.

<sup>Written for commit ecee8cf82857c7f12018ebc90c46f2a6e14b92c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-agent model selection capability to the arena builder UI, enabling users to assign different AI models to individual agents in custom bouts.
  * Enhanced credit cost estimation to use the most expensive model across all agents, providing more accurate pre-authorization pricing.

* **Tests**
  * Added unit tests for per-agent model configuration preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->