### PR TITLE
chore(boot): layered boot contract with campaign overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,26 @@
 # Agent's Orders
 
 This file is the boot contract for agents working in this repo.
-Read this first. Use linked references only when the task needs them.
+It is a layered boot sequence [SD-331]:
 
-## True North
+- **Layer 0 (kernel)** and **Layer 1 (machinery manifest)** load every session.
+- **Layer 2 (campaign overlay)** is injected at session start from
+  `docs/internal/campaign/active.md`. Dormant by default.
+- **Layer 3 (reference modules)** is read on demand only.
+
+Orientation lives in this file; enforcement lives in hooks and scripts.
+If a rule matters, something with an exit code backs it.
+
+## Layer 0: Kernel
+
+### True North
 
 - **Primary objective:** get hired - proof over claims [SD-309]
 - **Override:** truth over hiring signal [SD-134]
 
 If proof and spin conflict, choose truth.
 
-## Boot Rules
+### Boot Rules
 
 These apply in every session unless the Operator explicitly overrides them.
 
@@ -18,8 +28,9 @@ These apply in every session unless the Operator explicitly overrides them.
 - Historical records are append-only; do not rewrite the chain [SD-266]
 - Estimates use agent-minutes, not human-speed guesses [SD-268]
 - Change is ready only when the gate is green
-- Open every address to the Operator with the YAML HUD below
-- Read back your understanding before acting [SD-315]
+- Open every address to the Operator with a one-line readback of the order as
+  understood [SD-315]. When a campaign is active, open with the campaign HUD
+  instead [SD-331]
 - Use `printf`, never `echo`, when piping literal values to the CLI
 - Python uses `uv` exclusively [SD-310]
 - New tasks go through `backlog add "title" --priority P [--epic E] [--tag T]`
@@ -35,21 +46,7 @@ These apply in every session unless the Operator explicitly overrides them.
 - No `git stash`, ever [SD-325]
 - End the session with no unpushed commits
 
-## YAML HUD
-
-Every address to the Operator opens with:
-
-```yaml
-watch_officer: <agent>
-weave_mode: <tight|loose>
-register: <formal|exploration|execution>
-tempo: <full-sail|sustainable-pace|tacking|stop-the-line|SEV-1>
-true_north: "hired = proof > claim"
-bearing: <current heading>
-last_known_position: <last completed task>
-```
-
-## Engineering Loop
+### Engineering Loop
 
 **Read -> Verify -> Write -> Execute -> Confirm**
 
@@ -58,7 +55,12 @@ last_known_position: <last completed task>
 - Spec or plan before implementation
 - Human review happens after execution, not during, unless the task is taste-bound
 
-## Work Tracking
+## Layer 1: Machinery Manifest
+
+Enforcement inventory. Gates and hooks are hard barriers; everything else in
+this layer is convention that agents must follow but nothing blocks.
+
+### Work Tracking
 
 Use the backlog CLI instead of editing YAML directly.
 
@@ -73,18 +75,18 @@ backlog close BL-001 -r "reason"
 
 Data lives in `docs/internal/backlog.yaml`.
 
-## GitHub Workflow
+### GitHub Workflow
 
 GitHub Issues and PRs are the external record of engineering discipline.
 
-### Issues
+#### Issues
 
 - External-facing work gets a GitHub issue
 - Issue bodies include: problem, acceptance criteria, scope boundary
 - Estimates use complexity and risk, never time
 - Labels: `feature`, `bug`, `refactor`, `chore`, `tech-debt`, `infra`, `portfolio`, `research`, `platform`, `community`, `blocked`, `needs-audit`
 
-### Branches
+#### Branches
 
 - Never commit directly to `main`
 - Branches use `feat/`, `fix/`, `refactor/`, `chore/`
@@ -97,7 +99,7 @@ Example:
 git worktree add -b feat/42-arena-builder ../thepit-42-arena-builder main
 ```
 
-### PRs
+#### PRs
 
 - 1 PR = 1 concern
 - Squash merge to keep history clean
@@ -106,20 +108,20 @@ git worktree add -b feat/42-arena-builder ../thepit-42-arena-builder main
 - Add screenshots or GIFs for UI changes
 - Review attestation belongs in the PR body or comments
 
-### Sequence
+#### Sequence
 
 ```text
 issue -> worktree -> develop -> gate -> PR -> review -> squash merge -> post-merge verify -> close issue -> remove worktree
 ```
 
-## Deployment
+### Deployment
 
 - Git-triggered deployments are **disabled** on Vercel (burns server budget)
 - Deploy manually with `vercel --prod` from the CLI
 - Set env vars with `printf 'value' | vercel env add NAME production --force`
 - Never use `echo` for piping env values (use `printf`)
 
-## Gate
+### Gate
 
 The gate is survival, not optimisation.
 
@@ -129,7 +131,7 @@ pnpm run test:ci
 
 If the gate fails, the change is not ready.
 
-## Pitcommit
+### Pitcommit
 
 Invocation:
 
@@ -171,7 +173,7 @@ Key behavior:
 - `.gauntlet/` is ephemeral and gitignored
 - `--no-verify` is emergency-only
 
-## Conventions
+### Conventions
 
 - TypeScript, Next.js 16, Tailwind, Drizzle ORM, Neon Postgres
 - Tests live under `tests/`
@@ -179,7 +181,7 @@ Key behavior:
 - YAML is the default structured-data format [SD-258]
 - Use 2-space indentation
 
-## Filesystem Map
+### Filesystem Map
 
 Read depth 1 every session. Read deeper only when relevant.
 
@@ -201,6 +203,7 @@ Read depth 1 every session. Read deeper only when relevant.
 |- docs/                specs, decisions, internal docs
 |  |- decisions/        session-scoped decision files
 |  |- internal/         operational references and logs
+|  |  |- campaign/      campaign overlay: active.md + archive/
 |- .github/workflows/   CI
 ```
 
@@ -211,7 +214,32 @@ BFS rule [SD-195]:
 - Depth 3+: deliberate research only
 - Read `docs/internal/session-decisions-index.yaml`, not the full chain, for orientation
 
-## Recent Orientation
+## Layer 2: Campaign Overlay
+
+A campaign is a deliberately adopted operating frame (register, roles,
+vocabulary, HUD) scoped to a sustained push, then distilled and retired.
+The naval frame (2026-02-24 to 2026-03-10) was the first instance.
+
+- `docs/internal/campaign/active.md` is the only file this layer loads.
+  A SessionStart hook injects it (`.claude/settings.local.json`; `.claude/`
+  is dark and stays untracked, so the hook is per-machine config). Agents
+  without the hook read `active.md` at boot.
+- Dormant state: plain register, no HUD beyond the one-line readback.
+- Active state: the frame defines register, roles, vocabulary, and the HUD
+  spec. HUD fields derive from real state where possible; do not invent them.
+- Lifecycle: adopt -> industrialize -> distill -> retire. Retirement criteria
+  are fixed at adoption. See `docs/internal/campaign/README.md`.
+- Precedence: the Operator's fluency protocol governs whether AI acts; this
+  contract governs how agents work; the campaign governs voice. A campaign
+  register never overrides enforcement or the fluency protocol [SD-331].
+- Archived campaigns live in `docs/internal/campaign/archive/` with their
+  frame, distillation, and retro. The archive is append-only [SD-266].
+
+## Layer 3: Reference Modules
+
+Not part of the first-pass boot load. Read only when needed.
+
+### Recent Orientation
 
 Standing:
 
@@ -219,7 +247,6 @@ Standing:
 - SD-266 immutable chain
 - SD-268 agentic estimation
 - SD-278 pilot over
-- SD-286 slopodar boot
 - SD-297 forward-ref decision collisions
 - SD-309 hired = proof > claim
 - SD-310 `uv` only
@@ -229,19 +256,21 @@ Standing:
 - SD-325 no stash
 - SD-326 discipline beats swarm
 - SD-328 tech-debt exposure through layered review
+- SD-329 slopodar superseded by product failure taxonomy (supersedes SD-286 boot read)
+- SD-330 run pipeline abandoned; core product refocus
+- SD-331 layered boot with campaign overlay
 
 Use `docs/internal/session-decisions-index.yaml` for current summaries.
 
-## Reference Modules
-
-These are not part of the first-pass boot load. Read them only when needed.
+### Modules
 
 - `docs/internal/session-decisions-index.yaml` - current standing orders and recent decisions
-- `docs/internal/session-decisions.md` - full historical chain and provenance
-- `docs/internal/lexicon.md` - full vocabulary
-- `docs/internal/layer-model.md` - full operational model
-- `docs/internal/slopodar.yaml` - anti-pattern taxonomy
-- `scripts/darkcat.md` and `docs/internal/weaver/` - adversarial review materials
+- `docs/deep-archive/2026-03-27-roadmap-sweep/docs/internal/session-decisions.md` - full historical chain and provenance
+- `docs/deep-archive/2026-03-27-roadmap-sweep/docs/internal/lexicon.md` - full vocabulary (v0.27, distilled)
+- `docs/deep-archive/2026-03-27-roadmap-sweep/docs/internal/layer-model.md` - full operational model (L0-L12)
+- `docs/internal/slopodar.yaml` - anti-pattern taxonomy (historical; see SD-329)
+- `docs/internal/weaver/` - adversarial review materials
+- `docs/internal/campaign/archive/` - retired campaign frames and retros
 - `.claude/agents/*.md` - role-specific instructions
 
 ## What This File Is Not

--- a/docs/internal/backlog.yaml
+++ b/docs/internal/backlog.yaml
@@ -49,7 +49,8 @@
   epic: null
   created: '2026-03-09T09:53:25.454394+00:00'
   closed: '2026-03-12T14:00:00+00:00'
-  reason: 'Signal killed SD-321. Adversarial test completed SD-320: shorthand >= signal with 14% smaller size.'
+  reason: 'Signal killed SD-321. Adversarial test completed SD-320: shorthand >= signal
+    with 14% smaller size.'
 - id: BL-007
   title: 'Blog publish scheduler: script to flip draft=false on posts by date. Hugo
     renders future-dated draft=false pages only with buildFuture=true. Need either
@@ -175,5 +176,28 @@
   - code-health
   epic: null
   created: '2026-03-16T09:30:00.000000+00:00'
+  closed: null
+  reason: null
+- id: BL-016
+  title: 'Restructure boot contract into layered kernel + campaign overlay (SD-331,
+    #152)'
+  status: closed
+  priority: high
+  tags:
+  - infra
+  epic: null
+  created: '2026-07-04T09:02:01.767374+01:00'
+  closed: '2026-07-04T09:02:15.033154+01:00'
+  reason: 'Done in chore/152-boot-campaign-overlay: AGENTS.md layered, campaign overlay
+    + naval archive landed, hook wired. SD-331.'
+- id: BL-017
+  title: Fix pre-existing auth-bypass gate failures (SEC-AUTH-003/005 expect 401,
+    get 404)
+  status: open
+  priority: high
+  tags:
+  - bug
+  epic: null
+  created: '2026-07-04T09:04:42.299805+01:00'
   closed: null
   reason: null

--- a/docs/internal/campaign/README.md
+++ b/docs/internal/campaign/README.md
@@ -1,0 +1,62 @@
+# Campaign Lifecycle
+
+A campaign is a deliberately adopted operating frame: a register, a cast of
+roles, a vocabulary, and a HUD, scoped to one sustained push. The frame exists
+to keep the Operator (L12, the only model-independent verification layer)
+engaged and calibrated through long verification-heavy work. Identity framing
+is load-bearing for system reliability, not cosmetic (Affective Dynamics
+Hypothesis, layer-model L12). It is also a maintenance liability, so it has a
+lifecycle with a mandatory exit.
+
+The lifecycle is scaffold-then-distill:
+
+## 1. Adopt
+
+Write `active.md` with four mandatory sections. A campaign without all four
+is not adopted.
+
+- **Frame** - register, roles, vocabulary, HUD spec. HUD fields must derive
+  from real state (keel state, git, rehab status) wherever possible.
+- **Objective** - what the campaign is for, in one sentence, tied to True North.
+- **Retirement criteria** - dates or conditions, fixed at adoption, when the
+  founding enthusiasm is honest. The tent comes with a strike date sewn in.
+- **Distillation checklist** - which terms and mechanisms are candidates for
+  permanent machinery when the campaign ends.
+
+Log an SD recording the adoption and the retirement criteria.
+
+## 2. Industrialize
+
+Run the campaign. Ceremony that demands durable records (logs, decisions,
+attestations) is the point; ceremony that only decorates is slop
+(maturity-theatre). If a ritual stops being read, cut it mid-campaign.
+
+## 3. Distill
+
+At retirement, triangulate the vocabulary: which terms map to established
+frameworks (adopt the established name), which are genuinely novel (keep and
+define), which die with the frame. Promote surviving machinery to Layer 1.
+Precedent: lexicon v0.26, where ~60% mapped to Lean/SRE/CRM/Bainbridge and
+the novel remainder clustered on context engineering.
+
+## 4. Retire
+
+- Move `active.md` to `archive/<yyyy-mm-name>/frame.md`
+- Write `distillation.md` and `retro.md` alongside it
+- Restore the dormant stub in `active.md`
+- Log an SD recording retirement and what was promoted
+
+The archive is append-only [SD-266].
+
+## Precedence
+
+The Operator's fluency protocol governs whether AI acts. The boot contract
+governs how agents work. The campaign governs voice. A campaign register never
+overrides enforcement or the fluency protocol, and adopting a campaign is not
+a BLUE exception [SD-331].
+
+## Triggers
+
+Revive a frame on measured engagement decay (thinning logs, dropping flow
+scores in rehab.db, skipped verification), not nostalgia. If plain register
+sustains verification quality, the fiction stays archived.

--- a/docs/internal/campaign/active.md
+++ b/docs/internal/campaign/active.md
@@ -1,0 +1,6 @@
+# Campaign Overlay
+
+No active campaign. Plain register.
+
+Open addresses to the Operator with a one-line readback, no HUD.
+To adopt a campaign, see `docs/internal/campaign/README.md`.

--- a/docs/internal/campaign/archive/2026-02-naval/distillation.md
+++ b/docs/internal/campaign/archive/2026-02-naval/distillation.md
@@ -1,0 +1,34 @@
+# Distillation: Naval Frame
+
+Performed 2026-03-10 (lexicon v0.26, commits 540dc57, 607607f, 668c23b) via
+independent cross-triangulation: Architect (naval -> Linux) and Analyst
+(naval -> SWE).
+
+## Findings
+
+- **~60% mapped to established frameworks** and took the established names:
+  readback (aviation CRM), verification pipeline (Reason's Swiss Cheese
+  model), stop-the-line (Andon cord), standing policy (ADRs), cognitive
+  deskilling (Bainbridge 1983), quality gate (poka-yoke), working set
+  (Denning).
+- **~18% was genuinely novel**, clustered on context engineering for LLM
+  agents, a domain that did not exist before agentic workflows: dumb zone,
+  compaction loss, weave, cold/hot context pressure, sycophantic
+  amplification loop, spinning to infinity.
+- **6 terms retired** with the frame; 9 novel terms kept.
+
+## Machinery promoted to permanent (Layer 1)
+
+- Append-only decision chain [SD-266]
+- Readback before acting [SD-315]
+- Pitcommit tree-hash attestation and the gauntlet gate
+- Darkcat multi-model adversarial review, ROI-bounded [SD-318]
+- Slopodar taxonomy (later itself distilled into the product failure taxonomy,
+  SD-329)
+
+## The one-line verdict
+
+The contribution was not a new governance framework; it was a vocabulary for
+a new operational domain built on top of established frameworks. The frame
+survived translation into plain vocabulary with its enforcement machinery
+intact, which is the falsifiable evidence it was governance and not costume.

--- a/docs/internal/campaign/archive/2026-02-naval/frame.md
+++ b/docs/internal/campaign/archive/2026-02-naval/frame.md
@@ -1,0 +1,57 @@
+# Campaign: Naval Frame
+
+Retroactively archived 2026-07-04 [SD-331]. This campaign predates the
+campaign overlay structure; the record below is reconstructed from the chain,
+the lexicon, and the narrative layer. Canonical artifacts are linked, not
+copied [SD-266].
+
+## Span
+
+- **Adopted:** 2026-02-24 [SD-120], catalysed by watching Master and Commander
+  with the Captain's father. "Naval engineering metaphor recognised as
+  self-organising scaffold."
+- **Retired:** 2026-03-10, commit 668c23b ("Captain -> Operator"): "The naval
+  metaphor was scaffolding. The principles are substrate-neutral."
+
+## Objective
+
+Govern one accountable human directing semi-autonomous, non-deterministic
+agents through a month of verification-heavy solo development, before the
+field had vocabulary for that relationship.
+
+## Frame
+
+- **Roles:** Captain (Operator, L12), Weaver (review orchestration), Keel
+  (durable state), Watchdog (blindspot taxonomy), AnotherPair (voice audit),
+  Quartermaster, Analyst, and crew.
+- **Register:** formal / exploration / execution; weave tight or loose;
+  tempo full-sail, sustainable-pace, tacking, stop-the-line, SEV-1.
+- **Named protocols:** Dead Reckoning (context-death recovery), Fair Wind
+  (sequential merge ceremony), Parallax (two-lens triangulation), Darkcat
+  Alley (3-model adversarial review), the Gauntlet (verification pipeline).
+
+## HUD spec (as used)
+
+```yaml
+watch_officer: <agent>
+weave_mode: <tight|loose>
+register: <formal|exploration|execution>
+tempo: <full-sail|sustainable-pace|tacking|stop-the-line|SEV-1>
+true_north: "hired = proof > claim"
+bearing: <current heading>
+last_known_position: <last completed task>
+```
+
+## Retirement criteria (reconstructed)
+
+None were fixed at adoption; the frame was retired by judgment when the
+distillation showed the principles were substrate-neutral. Fixing retirement
+criteria at adoption is a lesson this archive encodes for successors.
+
+## Canonical artifacts
+
+- `docs/deep-archive/2026-03-27-roadmap-sweep/docs/internal/lexicon.md` (vocabulary, v0.27)
+- `docs/deep-archive/2026-03-27-roadmap-sweep/docs/internal/layer-model.md` (L0-L12)
+- `docs/internal/narrative-layer.yaml`, `docs/internal/play-by-play.yaml` (narrative record)
+- `docs/internal/beyond-captain.yaml`, `docs/internal/sextant.yaml` (Operator calibration)
+- `docs/internal/session-decisions-index.yaml` (the chain)

--- a/docs/internal/campaign/archive/2026-02-naval/retro.md
+++ b/docs/internal/campaign/archive/2026-02-naval/retro.md
@@ -1,0 +1,59 @@
+# Retro: Why the Naval Frame Worked
+
+Written 2026-07-04 from a full excavation of thepit and its ancestor repos
+(noopit, midgets) [SD-331]. Four findings.
+
+## 1. It imported a pre-debugged governance institution
+
+The Age of Sail navy is a mature institution engineered for exactly the
+agentic problem shape: one accountable commander governing semi-autonomous,
+imperfectly reliable subordinates under high-latency communication, where a
+misunderstood order is catastrophic and the institution must survive the
+commander's absence (context death). Plain SWE vocabulary assumes
+deterministic tools or human peers; agents are neither. The fiction was a
+compressed cultural transmission of command doctrine, and roleplay was the
+decompression codec. Evidence: the v0.26 triangulation found ~60% of the
+vocabulary mapped to established frameworks (CRM, Swiss Cheese, Andon,
+Bainbridge) that had never been formally studied here. The story already
+encoded them.
+
+## 2. The genre forced the artifacts that matter
+
+Naval fiction is a record-keeping genre: logs, standing orders, musters,
+commendations. Playing it seriously produced the append-only chain, the keel
+state, the attestation gate, and the catch-logs, which are exactly what
+survives compaction. Roughly 40% of the system was hard enforcement and 60%
+narrative, and the narrative is what generated the enforcement. Named
+protocols are compression: a three-word ritual name reloads a whole procedure
+into any fresh context window.
+
+## 3. The fun was load-bearing
+
+L12 is the only model-independent verification layer and it is a fatiguing,
+motivation-dependent human. The frame converted a month of tedious
+adversarial review into a game with stakes, roles, and a running story, and
+kept the Operator present through it (330 logged decisions, a 49-entry slop
+taxonomy, SD-326's throughput evidence). The frame also gave a permission
+structure in both directions: authority without self-consciousness ("that's
+an order") and a vocabulary for calling bullshit ("lullaby territory",
+Category One) that plain register makes awkward because plain register is
+the voice slop is written in.
+
+## 4. It was retired, which is the proof
+
+On 2026-03-10 (668c23b) the frame was struck deliberately, distilled into
+substrate-neutral principles, with machinery and catch-logs intact. A cargo
+cult cannot strike its own tent. Adoption and abandonment were both logged
+with reasons (SD-120's contemporaneous self-critique: "I am about as real a
+captain as somebody in a Master and Commander style-tuned sailing
+simulator"), which is governance of the governance.
+
+## Lessons encoded in the campaign lifecycle
+
+- Fix retirement criteria at adoption (the navy had none; it got lucky in
+  its Operator).
+- HUD fields must derive from real state; an unread HUD performed by agents
+  is maturity-theatre in your own uniform.
+- Revive frames on measured engagement decay, not nostalgia. The method
+  (scaffold-then-distill) is the transferable asset; the navy was its first
+  tenant.

--- a/docs/internal/dev-cost-ledger.yaml
+++ b/docs/internal/dev-cost-ledger.yaml
@@ -11,3 +11,10 @@ entries:
     model_calls_estimate: 60
     failures_caught: 7
     notes: "Spec writing (3 phases), roadmap, reviewer briefing, README rewrite, OpenHands evaluation, 2 rounds adversarial review (7 findings resolved), on-product governance spec"
+  - date: "2026-07-04"
+    pr: null
+    milestone: "SD-331 campaign-overlay boot"
+    agent_minutes: 45
+    model_calls_estimate: 12
+    failures_caught: 0
+    notes: "Governance excavation (3 parallel readers over thepit + noopit + midgets), AGENTS.md layered restructure, campaign lifecycle + naval archive, SessionStart hook, chain/event/backlog bookkeeping. Issue #152."

--- a/docs/internal/events.yaml
+++ b/docs/internal/events.yaml
@@ -137,3 +137,12 @@ events:
     ref: docs/specs/on-product-governance.md
     summary: "Adversarial review tiered by risk surface. Gate-only for schema/CRUD (6 milestones), single-model for API/UI (7 milestones), full 3-model triangulation for engine milestones (M1.4, M2.2). Evidence: git history shows 0% finding rate on schema PRs, 40%+ on integration code (c8ce063 rate limiter bypass, 2805384 double-refund race + SQL injection, a7e5514 serialization bugs). Tiered spend is itself a demonstration of token cost economics (skill 7) applied to the development process - calibrating verification cost against defect probability rather than applying uniform overhead."
     backrefs: [docs/specs/on-product-governance.md, SD-329]
+
+  - date: "2026-07-04"
+    time: "09:15"
+    type: decision
+    agent: Weaver
+    commit: null
+    ref: SD-331
+    summary: "SD-331: layered boot with campaign overlay. Full excavation of thepit + ancestor repos (noopit governance evolution, midgets research validation) reconstructed the naval frame arc: adopted 2026-02-24 (SD-120), industrialized through named protocols and the attestation machinery, distilled and retired 2026-03-10 (668c23b). Findings: enforcement that works lives in hooks/scripts; agent-performed prose decays into maturity-theatre (the always-on YAML HUD was the live example); identity framing is load-bearing for L12 engagement but campaign-scoped. AGENTS.md restructured into L0-L3 layers, campaign lifecycle codified (adopt with fixed retirement criteria, industrialize, distill, retire), naval frame retroactively archived as first campaign, SessionStart hook injects the overlay."
+    backrefs: [AGENTS.md, docs/internal/campaign/README.md, docs/internal/campaign/archive/2026-02-naval/, .claude/settings.json, SD-120, SD-266, SD-315, SD-331]

--- a/docs/internal/session-decisions-index.yaml
+++ b/docs/internal/session-decisions-index.yaml
@@ -6,9 +6,9 @@
 # The full log is for provenance and archaeology.
 # Recent SDs shown here - read full file for deeper history.
 
-generated: "2026-03-16T09:00:00.000Z"
-total_decisions: 329
-range: "SD-001 to SD-330"
+generated: "2026-07-04T09:00:00.000Z"
+total_decisions: 330
+range: "SD-001 to SD-331"
 note: "Chain carries forward from tspit (pilot study). noopit is thepit-v2 - diverged at SD-278."
 
 # Standing orders that carry forward (always active)
@@ -132,3 +132,7 @@ recent:
     label: "run-pipeline-abandoned"
     summary: "M1-M3 run/evaluation/cost pipeline abandoned. Orders miscommunicated, plans departed from sensible reality. The Pit returns to development of the core product: multi-agent debate arena. Roadmap refocused on platform hardening, Ask The Pit, AI Gateway, tournaments, spectator chat. Closed issues #102, #104, #106, #109, #18. Archived old roadmap to docs/deep-archive/2026-04-01-run-pipeline-abandoned/. New roadmap: docs/roadmap.md."
     status: "PERMANENT"
+  - id: SD-331
+    label: "campaign-overlay-boot"
+    summary: "Boot contract restructured into a layered boot sequence: L0 kernel (identity, boot rules, engineering loop), L1 machinery manifest (enforcement inventory), L2 campaign overlay (docs/internal/campaign/active.md, SessionStart-injected, dormant by default), L3 reference modules (on demand). Orientation lives in the prompt; enforcement lives in hooks and scripts. The YAML HUD is campaign-gated: plain register opens with a one-line readback; a full HUD exists only under an active campaign and derives from real state. Scaffold-then-distill codified as the campaign lifecycle: adopt (retirement criteria fixed at adoption), industrialize, distill, retire. Naval frame (2026-02-24 SD-120 to 2026-03-10 668c23b) retroactively archived as the first campaign with frame, distillation, and retro. Campaign register is subordinate to the Operator's fluency protocol and never overrides enforcement. Origin: full excavation of thepit + noopit + midgets governance history, GitHub issue #152."
+    status: "ACTIVE"


### PR DESCRIPTION
Closes #152.

## What changed

- AGENTS.md restructured into an explicit layered boot sequence: Layer 0 kernel (identity, boot rules, engineering loop), Layer 1 machinery manifest (enforcement inventory), Layer 2 campaign overlay, Layer 3 reference modules. Every existing rule is preserved; stale reference paths (lexicon, layer model, full SD chain) now point at their deep-archive locations.
- New `docs/internal/campaign/`: a dormant `active.md` stub loaded at session start, and a lifecycle README codifying scaffold-then-distill: adopt (retirement criteria fixed at adoption), industrialize, distill, retire.
- The naval frame (2026-02-24, SD-120, through 2026-03-10, commit 668c23b) is retroactively archived as the first campaign, with its frame, its distillation record (~60% of vocabulary mapped to established frameworks, the novel remainder clustered on context engineering), and a retro on why it worked.
- The YAML HUD becomes campaign-gated. Plain register opens with a one-line readback; a full HUD exists only under an active campaign and must derive from real state. Rationale: prose rituals performed by agents decay into unread boilerplate, while hooks and gates keep working.
- Bookkeeping: SD-331 appended to the index, event logged, backlog item BL-016 opened and closed, dev-cost ledger entry added.

## Why

A full excavation of this repo and its ancestors (noopit, midgets) showed the governance layer's enforcement lives in hooks and scripts, while agent-performed ceremony decays unless it is scoped and retired. This encodes that finding into the boot contract itself: identity framing becomes a deliberate, archivable campaign rather than a permanent fixture.

## What was tested

Docs/yaml-only change; no code paths touched. Lint, typecheck, and 1540 unit tests pass. `pnpm run test:ci` is red on main itself: two pre-existing auth-bypass integration failures (SEC-AUTH-003, SEC-AUTH-005 receive 404 where 401 is expected), reproduced on pristine main with env parity and filed as #153. Gate attestation recorded as fail rather than bypassed silently.

## Follow-up limits

- #153 (pre-existing gate red) is deliberately out of scope.
- The SessionStart hook that injects `active.md` is per-machine `.claude/` config (untracked by design); agents without it are instructed to read `active.md` at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructures the boot contract into explicit layers with a campaign overlay, and gates the YAML HUD behind an active campaign (closes #152). This is docs-only, preserves rules, archives the naval frame, and codifies the campaign lifecycle (SD-331).

- **Refactors**
  - Layered `AGENTS.md` into L0 kernel, L1 machinery, L2 campaign, L3 references; HUD moved under the campaign overlay.
  - Added `docs/internal/campaign/active.md` (dormant stub) and lifecycle `README.md` (adopt → industrialize → distill → retire).
  - Archived the 2026-02 naval campaign with `frame.md`, `distillation.md`, and `retro.md`.
  - Updated stale references to deep-archive paths; logged SD-331 and updated `backlog.yaml`, `events.yaml`, and `dev-cost-ledger.yaml`.

- **Migration**
  - No code paths changed.
  - Default open is a one-line readback; enable a HUD by adopting a campaign via `docs/internal/campaign/active.md`.
  - Optional SessionStart hook that loads `active.md` lives in per-machine `.claude/` config.
  - CI shows two pre-existing auth-bypass failures on `main`; tracked in #153.

<sup>Written for commit f37d113dd6526ac63d88c0db20ec11dc021d8f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rickhallett/thepit/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the project’s startup and workflow guidance with a more structured layout and updated operator-facing instructions.
  * Added new campaign-related documentation covering lifecycle, active-state behavior, and archived reference material.
  * Expanded internal tracking notes and session records to reflect the latest boot and campaign changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->